### PR TITLE
Argument validation corrected and Arm URDF given fixed_frame

### DIFF
--- a/src/ros/rover/nova_bringup/launch/urdf.launch.py
+++ b/src/ros/rover/nova_bringup/launch/urdf.launch.py
@@ -25,7 +25,8 @@ from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 
 def launch_setup(context, *args, **kwargs):
-    if LaunchConfiguration('rover').perform(context):
+    if LaunchConfiguration('rover').perform(context) == "True":
+        fixed_frame = 'base_link'
         robot_description = ParameterValue(
             Command(
                 [
@@ -39,11 +40,13 @@ def launch_setup(context, *args, **kwargs):
             value_type=str
         )
     else:
+        fixed_frame = 'arm_link'
         robot_description = ParameterValue(
             Command(
                 [
                     'xacro ', 
                     LaunchConfiguration('arm_urdf_path'),
+                    ' depth_camera:=false'
                 ]
             ),
             value_type=str
@@ -71,7 +74,7 @@ def launch_setup(context, *args, **kwargs):
         namespace='',
         executable='rviz2',
         name='rviz2',
-        arguments=['-d', [PathJoinSubstitution([FindPackageShare('nova_bringup'), 'rviz', 'default.rviz'])]]
+        arguments=['-d', [PathJoinSubstitution([FindPackageShare('nova_bringup'), 'rviz', 'default.rviz'])], '-f', fixed_frame]
     )
 
     return [


### PR DESCRIPTION
## PR Rules
1. Test the changes on the rover (if applicable) 
2. Merge (or rebase) the 'testing' branch into this branch before PR merge
3. Create a **Draft** PR if you're still working on the change
4. Delete this branch after PR merge

## PR Checklist
- [ - ] Assigned reviewer
- [ - ] Merged/rebased testing into this branch
- [ ] Moved task on notion to reveiw

Remove an option if irrelevant to your changes

## PR Details

### Summary of the PR

Argument validation for urdf.launch.py is fixed. Made rviz assign an appropriate fixed_frame when loading only arm URDF 

<hr/>

### Reason for change

When loading URDF given arguments to load just the arm and turn off Rover it still loaded the Rover. Just loading the arm was also missing an appropriate fixed_frame that would have to be manually fixed in rviz (tedious). I wanted to be able to view *only* the arm if I wanted to, which seems to be the intended functionality.

<hr/>

### Please explain anything that can be helpful to the reviewers since they didn't write the code themselves.

CLI arguments are evaluated as strings, not boolean
Arm's fixed_frame was set to arm_link for it can have appropriate transforms and positions etc. etc.

<hr/>

### Testing details (if applicable)

Run urdf.launch.py with rover turned off. It should just load the arm.
Running with the rover turned on (Default behaviour) should still load everything as before.

<hr/>