### PR TITLE
setup moveit2 dependencies to allow package pulling. Moved from rover…

### DIFF
--- a/nixfiles/ci/jobsets/misc.nix
+++ b/nixfiles/ci/jobsets/misc.nix
@@ -19,6 +19,9 @@ lib.novaForAllSystems (nova: {
     # Autonomous
     librealsense2-gui
 
+    # Arm
+    moveit-ros
+
     # Temporary
     ## Gazebo and ros2-control
     gazebo-ros-pkgs

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -47,6 +47,13 @@ let
         url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
         hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
       })
+
+      # patch for lib64 moving issue
+      # https://github.com/lopsided98/nix-ros-overlay/commit/dabd41fd0d43b92ce134386900f9af5d61546e8d
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/dabd41fd0d43b92ce134386900f9af5d61546e8d.patch";
+        hash = "sha256-LDbOm7Wn2sqlhxy52GsP6ARaeiKnam63d9eh3u+FgmE=";
+      })
     ];
   });
 

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -93,6 +93,60 @@ self: super:
       grid-map-cv = rosSuper.grid-map-cv.overrideAttrs ({ CXXFLAGS ? "", ... }: {
         CXXFLAGS = "${CXXFLAGS} -Wno-error=stringop-overflow";
       });
+
+      # osqp-vendor CMakeLists patched to not try to pull from osqp during build
+      osqp-vendor = (rosSelf.lib.patchExternalProjectGit rosSuper.osqp-vendor {
+        url = "https://github.com/osqp/osqp.git";
+        originalRev = "";
+        rev = "v0.6.2";
+        fetchgitArgs.hash = "sha256-RYk3zuZrJXPcF27eMhdoZAio4DZ+I+nFaUEg1g/aLNk=";
+      }).overrideAttrs ({ preFixup ? "", nativeBuildInputs ? "", ... }: {
+        
+        nativeBuildInputs = nativeBuildInputs ++ [ self.breakpointHook ];
+
+        preFixup = preFixup + ''
+          mv "$out/lib64/cmake/"* "$out/lib/cmake"
+          rmdir "$out/lib64/cmake"
+          
+        '';
+
+      });
+
+      geometric-shapes = rosSuper.geometric-shapes.overrideAttrs ({ postPatch ? "", ... }: {
+        version = "2.2.1-1";
+        src = self.fetchzip {
+          name = "geometric-shapes";
+          url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/jazzy/geometric_shapes/2.2.1-1.tar.gz";
+          hash = "sha256-o2Eck5v0SgZlsbOmbpf5qikEjkjDqv/wJ2kTdTiq2RQ=";
+        };
+        postPatch = postPatch + ''
+        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
+        '';
+      });
+
+      moveit-core = rosSuper.moveit-core.overrideAttrs ({postPatch ? "", nativeBuildInputs ? "", ...}: {
+        version = "2.10.0-1";
+        src = self.fetchzip {
+          name = "moveit-core";
+          url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.10.0-1.tar.gz";
+          sha256 = "sha256-WwWn+S+POgbqVVFiTNS9YCPW4HwH0UtkvCrAYRmEuIE=";
+        };
+        postPatch = postPatch + ''
+        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
+        '';
+      });
+
+      moveit-ros-occupancy-map-monitor = rosSuper.moveit-ros-occupancy-map-monitor.overrideAttrs ({ postPatch ? "", ... }: {
+        version = "2.10.0-r1";
+        src = self.fetchzip {
+          name = "ros-jazzy-moveit-ros-occupancy-map-monitor";
+          url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.10.0-1.tar.gz";
+          hash = "sha256-WHbMOwEkQoPOrHQOeH/0GJyEa7g/ez3LJsJTZw6jUUw=";
+        };
+        postPatch = postPatch + ''
+        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
+        '';
+      });
     } // (
       let
         fixRtabmapDependent = pkg: pkg.overrideAttrs ({ buildInputs ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -101,7 +101,7 @@ self: super:
         rev = "v0.6.2";
         fetchgitArgs.hash = "sha256-RYk3zuZrJXPcF27eMhdoZAio4DZ+I+nFaUEg1g/aLNk=";
       }).overrideAttrs ({ preFixup ? "", nativeBuildInputs ? "", ... }: {
-        
+
         nativeBuildInputs = nativeBuildInputs ++ [ self.breakpointHook ];
 
         preFixup = preFixup + ''
@@ -112,39 +112,37 @@ self: super:
 
       });
 
-      geometric-shapes = rosSuper.geometric-shapes.overrideAttrs ({ postPatch ? "", ... }: {
-        version = "2.2.1-1";
-        src = self.fetchzip {
-          name = "geometric-shapes";
-          url = "https://github.com/ros2-gbp/geometric_shapes-release/archive/release/jazzy/geometric_shapes/2.2.1-1.tar.gz";
-          hash = "sha256-o2Eck5v0SgZlsbOmbpf5qikEjkjDqv/wJ2kTdTiq2RQ=";
-        };
-        postPatch = postPatch + ''
-        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
-        '';
+      geometric-shapes = rosSuper.geometric-shapes.overrideAttrs ({ patches ? [ ], ... }: {
+        patches = patches ++ [
+          # https://github.com/moveit/geometric_shapes/pull/241
+          (self.fetchpatch {
+            url = "https://github.com/moveit/geometric_shapes/commit/78898826b16b7547c69c63ce28b9bddcd167a09e.patch";
+            includes = [ "CMakeLists.txt" ];
+            revert = true;
+            hash = "sha256-elLSrqVnyTyG5P+iPXIx0RccC7TmdPVAZtbhpJcYUO0=";
+          })
+        ];
       });
 
-      moveit-core = rosSuper.moveit-core.overrideAttrs ({postPatch ? "", nativeBuildInputs ? "", ...}: {
-        version = "2.10.0-1";
+      moveit-core = rosSuper.moveit-core.overrideAttrs ({ postPatch ? "", ... }: {
         src = self.fetchzip {
           name = "moveit-core";
           url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_core/2.10.0-1.tar.gz";
           sha256 = "sha256-WwWn+S+POgbqVVFiTNS9YCPW4HwH0UtkvCrAYRmEuIE=";
         };
         postPatch = postPatch + ''
-        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
+          substituteInPlace CMakeLists.txt --replace 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap 1.9.7...1.10.0 REQUIRED)'
         '';
       });
 
       moveit-ros-occupancy-map-monitor = rosSuper.moveit-ros-occupancy-map-monitor.overrideAttrs ({ postPatch ? "", ... }: {
-        version = "2.10.0-r1";
         src = self.fetchzip {
           name = "ros-jazzy-moveit-ros-occupancy-map-monitor";
           url = "https://github.com/ros2-gbp/moveit2-release/archive/release/jazzy/moveit_ros_occupancy_map_monitor/2.10.0-1.tar.gz";
           hash = "sha256-WHbMOwEkQoPOrHQOeH/0GJyEa7g/ez3LJsJTZw6jUUw=";
         };
         postPatch = postPatch + ''
-        sed -i 's|find_package(octomap 1.9.7...<1.10.0 REQUIRED)|find_package(octomap 1.9.7...1.10.0 REQUIRED)|' CMakeLists.txt
+          substituteInPlace CMakeLists.txt --replace 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap 1.9.7...1.10.0 REQUIRED)'
         '';
       });
     } // (


### PR DESCRIPTION
… repo to mono repo

Made some adjustments to maintenance.nix to allow moveit2 to be pulled into workspace without any build issues.

## List of Changes

### osqp-vendor

Circumvents pulling through the vendor CMakeList (Because buildPhase has no internet) and instead directly patches the externalproject_add functionality included in the CMakeList to (I think) pull during fetchPhase.
Also have it fix some issues with moving lib64 files around.

### octomap configuration version mismatch

Adjusted the acceptable range of octomap configuration ranges to include 1.10 (The version nix pulls) for
- geometric-shapes
- moveit-core
- moveit-ros-occupancy-map-monitor

### general nix default.nix change

A patch is used to prevent nix fixupPhase from moving lib64 files into lib. This is usually done to streamline stores since nix tries to separate out 32bit and 64bit versions of files into separate stores so there isn't a point in having both types of binaries in separate folders. However this causes annoying issues with CMakes that expect both folders to exist and this seems to be the least tedious solution.

## Testing-procedure

Would require additional tests to make sure it actually provides accurate functionality as intended by a standard MoveIt2 simulation.
The fixes above can be verified by trying to run a nix-shell with any nix-ros-overlay pkgs that use the above listed dependencies (Or directly pull those dependencies) using

```
nix-shell -p 'with import ./. { }; pkgs.ros.nova-workspace.override{
extraPackages = {
inherit(pkgs.ros) moveit-ros;
};
}'
```

Replace moveit-ros with anything else that depends on the above listed dependencies. 

You can also verify that it has added moveit-ros to the workspace (This is moveit2 btw, verified by checking where the overlay is pulling moveit2 from) by running `ros2 pkgs list` after running the above command.

The change made to our workspace general default.nix might/might not cause issues.
It shouldn't, might just cause some store bloat in the future since it's skipping the streamlining function of combining lib64 and lib but this caused a lot of issues.

https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/move-lib64.sh

On the bright side, future libraries that run into this issue will not have this issue anymore.

![Finally X 23092024091830.jpg](https://github.com/user-attachments/assets/abb50463-f774-457d-a717-1e4b139b60b9)

