### PR TITLE
Migrate auto_bringup to Gazebo Harmonic superficially

### DIFF
--- a/nixfiles/ci/jobsets/misc.nix
+++ b/nixfiles/ci/jobsets/misc.nix
@@ -28,5 +28,22 @@ lib.novaForAllSystems (nova: {
     pluginlib
     ## Nav2
     nav2-bringup
-    navigation2;
+    navigation2
+
+    ament-cmake-core 
+    ament-cmake-export-definitions 
+    ament-cmake-export-dependencies 
+    ament-cmake-export-include-directories 
+    ament-cmake-export-interfaces 
+    ament-cmake-export-libraries 
+    ament-cmake-export-link-flags 
+    ament-cmake-export-targets 
+    ament-cmake-gen-version-h 
+    ament-cmake-libraries 
+    ament-cmake-python 
+    ament-cmake-target-dependencies 
+    ament-cmake-test 
+    ament-cmake-version 
+    cmake
+    ;
 })

--- a/nixfiles/ci/jobsets/misc.nix
+++ b/nixfiles/ci/jobsets/misc.nix
@@ -23,6 +23,7 @@ lib.novaForAllSystems (nova: {
     # Temporary
     ## Gazebo and ros2-control
     ros-gz
+    gz-ros2-control
     ros2-control
     ros2-controllers
     pluginlib

--- a/nixfiles/ci/jobsets/misc.nix
+++ b/nixfiles/ci/jobsets/misc.nix
@@ -22,10 +22,9 @@ lib.novaForAllSystems (nova: {
 
     # Temporary
     ## Gazebo and ros2-control
-    #gazebo-ros-pkgs
+    ros-gz
     ros2-control
     ros2-controllers
-    #gazebo-ros2-control
     pluginlib
     ## Nav2
     nav2-bringup

--- a/nixfiles/ci/jobsets/misc.nix
+++ b/nixfiles/ci/jobsets/misc.nix
@@ -22,10 +22,10 @@ lib.novaForAllSystems (nova: {
 
     # Temporary
     ## Gazebo and ros2-control
-    gazebo-ros-pkgs
+    #gazebo-ros-pkgs
     ros2-control
     ros2-controllers
-    gazebo-ros2-control
+    #gazebo-ros2-control
     pluginlib
     ## Nav2
     nav2-bringup

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -29,32 +29,38 @@ let
   # nix-ros-overlay = ../nix-ros-overlay;
   nix-ros-overlay = pkgs.lib.maybeEnv "NRO_PATH" (maybeApplyPatches {
     src = pkgs.fetchFromGitHub {
-      owner = "muellerbernd";
+      owner = "lopsided98";
       repo = "nix-ros-overlay";
       inherit (revisions.nix-ros-overlay) rev hash;
     };
     patches = [
-      # # fix: gz vendor
-      # # https://github.com/lopsided98/nix-ros-overlay/pull/472
+      # Patch and fix gz-*-vendor packages for Jazzy and Rolling
+      # https://github.com/lopsided98/nix-ros-overlay/pull/422
       # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/aa846d382c40809f812b2f1c7d8b92d901a75da5.patch";
       #   hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
       # })
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
-      #   hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
-      # })
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
-      #   hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
-      # })
+      # fix: gz vendor
+      # https://github.com/lopsided98/nix-ros-overlay/pull/472
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
+        hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
+      })
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
+        hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
+      })
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
+        hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
+      })
 
-      # # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
-      # # https://github.com/lopsided98/nix-ros-overlay/pull/454
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
-      #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      # })
+      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
+      # https://github.com/lopsided98/nix-ros-overlay/pull/454
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
+        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
+      })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -34,13 +34,34 @@ let
       inherit (revisions.nix-ros-overlay) rev hash;
     };
     patches = [
-      # Fix: gz vendor
+      # Patch and fix gz-*-vendor packages for Jazzy and Rolling
+      # https://github.com/lopsided98/nix-ros-overlay/pull/422
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/aa846d382c40809f812b2f1c7d8b92d901a75da5.patch";
+        hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
+      })
+
+      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
+      # https://github.com/lopsided98/nix-ros-overlay/pull/454
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
+        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
+      })
+
+      # fix: gz vendor
       # https://github.com/lopsided98/nix-ros-overlay/pull/472
-      # (pkgs.fetchpatch {
-      #   url = "https://patch-diff.githubusercontent.com/raw/lopsided98/nix-ros-overlay/pull/472.patch";
-      #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      # })
-      ./overlay/ros/patches/nix-ros-workspace.patch
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
+        excludes = [ "examples/ros2-gz-example.nix" ];
+        hash = "sha256-nJD6ltAIpp+yOyegn1PdUA4oK6JB4m+6PpCdsPB2/oU=";
+      })
+
+      # Some more Gazebo improvements
+      # https://github.com/muellerbernd/nix-ros-overlay/pull/2
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/compare/6d04148eac0727be34e5333f6e12cfc7e86673c3...eca9687ce15335bbb2d4b7b14fbf74ce0e957f43.patch";
+        hash = "sha256-c6DD2U6Lo2dcs0APxEHg9l0bz1Ioa5aX5FoATajXYAc=";
+      })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -36,9 +36,23 @@ let
     patches = [
       # Patch and fix gz-*-vendor packages for Jazzy and Rolling
       # https://github.com/lopsided98/nix-ros-overlay/pull/422
+      # (pkgs.fetchpatch {
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/aa846d382c40809f812b2f1c7d8b92d901a75da5.patch";
+      #   hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
+      # })
+      # fix: gz vendor
+      # https://github.com/lopsided98/nix-ros-overlay/pull/472
       (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/aa846d382c40809f812b2f1c7d8b92d901a75da5.patch";
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
         hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
+      })
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
+        hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
+      })
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
+        hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
       })
 
       # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -34,27 +34,7 @@ let
       inherit (revisions.nix-ros-overlay) rev hash;
     };
     patches = [
-      # # fix: gz vendor
-      # # https://github.com/lopsided98/nix-ros-overlay/pull/472
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
-      #   hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
-      # })
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
-      #   hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
-      # })
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
-      #   hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
-      # })
 
-      # # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
-      # # https://github.com/lopsided98/nix-ros-overlay/pull/454
-      # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
-      #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      # })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -41,13 +41,6 @@ let
       #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
       # })
       ./overlay/ros/patches/nix-ros-workspace.patch
-
-      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
-      # https://github.com/lopsided98/nix-ros-overlay/pull/454
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
-        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -29,38 +29,32 @@ let
   # nix-ros-overlay = ../nix-ros-overlay;
   nix-ros-overlay = pkgs.lib.maybeEnv "NRO_PATH" (maybeApplyPatches {
     src = pkgs.fetchFromGitHub {
-      owner = "lopsided98";
+      owner = "muellerbernd";
       repo = "nix-ros-overlay";
       inherit (revisions.nix-ros-overlay) rev hash;
     };
     patches = [
-      # Patch and fix gz-*-vendor packages for Jazzy and Rolling
-      # https://github.com/lopsided98/nix-ros-overlay/pull/422
+      # # fix: gz vendor
+      # # https://github.com/lopsided98/nix-ros-overlay/pull/472
       # (pkgs.fetchpatch {
-      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/aa846d382c40809f812b2f1c7d8b92d901a75da5.patch";
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
       #   hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
       # })
-      # fix: gz vendor
-      # https://github.com/lopsided98/nix-ros-overlay/pull/472
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/e79e9b9f1ebafde9f8f342b1a20c97947e859889.patch";
-        hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
-      })
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
-        hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
-      })
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
-        hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
-      })
+      # (pkgs.fetchpatch {
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/fc4c0ebbe4b1d53aa2dbdca331bd74280645f961.patch";
+      #   hash = "sha256-XLpInAKRg/O5K7pzpzMv99qKjXoXOmdLwDqH1tVMx1c=";
+      # })
+      # (pkgs.fetchpatch {
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/6d04148eac0727be34e5333f6e12cfc7e86673c3.patch";
+      #   hash = "sha256-OKa16KSiZi21PXa8KzxmQQFqzC5SoiGVtXGY7Czzy0Y=";
+      # })
 
-      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
-      # https://github.com/lopsided98/nix-ros-overlay/pull/454
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
-        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      })
+      # # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
+      # # https://github.com/lopsided98/nix-ros-overlay/pull/454
+      # (pkgs.fetchpatch {
+      #   url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
+      #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
+      # })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -29,12 +29,25 @@ let
   # nix-ros-overlay = ../nix-ros-overlay;
   nix-ros-overlay = pkgs.lib.maybeEnv "NRO_PATH" (maybeApplyPatches {
     src = pkgs.fetchFromGitHub {
-      owner = "muellerbernd";
+      owner = "lopsided98";
       repo = "nix-ros-overlay";
       inherit (revisions.nix-ros-overlay) rev hash;
     };
     patches = [
+      # Fix: gz vendor
+      # https://github.com/lopsided98/nix-ros-overlay/pull/472
+      # (pkgs.fetchpatch {
+      #   url = "https://patch-diff.githubusercontent.com/raw/lopsided98/nix-ros-overlay/pull/472.patch";
+      #   hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
+      # })
+      ./overlay/ros/patches/nix-ros-workspace.patch
 
+      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
+      # https://github.com/lopsided98/nix-ros-overlay/pull/454
+      (pkgs.fetchpatch {
+        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
+        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
+      })
     ];
   });
 

--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -41,13 +41,6 @@ let
         hash = "sha256-GdUjgcOgW2+8qceMPGO5EvOMwUc/iMNYYdQqfkCc1UA=";
       })
 
-      # python3Packages.rosinstall-generator: Add distutils to nativeBuildInputs
-      # https://github.com/lopsided98/nix-ros-overlay/pull/454
-      (pkgs.fetchpatch {
-        url = "https://github.com/lopsided98/nix-ros-overlay/commit/b620de3c64484c410fbee3924d3ce251a9e61150.patch";
-        hash = "sha256-B4GQS4afAQdnTEWQ1bxkugjrFtGYDG2ZfQmATSymBsI=";
-      })
-
       # fix: gz vendor
       # https://github.com/lopsided98/nix-ros-overlay/pull/472
       (pkgs.fetchpatch {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -318,15 +318,15 @@ self: super:
         });
 
         depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-          patches = patches ++ [
-            # Fix signature issue from #943
-            # https://github.com/ros-perception/image_pipeline/pull/1018
-            (self.fetchpatch {
-              url = "https://github.com/ros-perception/image_pipeline/commit/a7c0b09c5e37fcaf7e3153e6d353687a793ee3f9.patch";
-              stripLen = 1;
-              hash = "sha256-wXUSSfRBzCTxrilCvSJFhpq384+7hvL7vxnIyLaW5zs=";
-            })
-          ];
+#          patches = patches ++ [
+#            # Fix signature issue from #943
+#            # https://github.com/ros-perception/image_pipeline/pull/1018
+#            (self.fetchpatch {
+#              url = "https://github.com/ros-perception/image_pipeline/commit/a7c0b09c5e37fcaf7e3153e6d353687a793ee3f9.patch";
+#              stripLen = 1;
+#              hash = "sha256-wXUSSfRBzCTxrilCvSJFhpq384+7hvL7vxnIyLaW5zs=";
+#            })
+#          ];
         });
 
         rosapi = rosSuper.rosapi.overrideAttrs ({ patches ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -304,7 +304,7 @@ self: super:
         gazebo-ros-pkgs = rosSelf.callPackage (self.nix-ros-overlay + "/distros/iron/gazebo-ros-pkgs") { };
 
         image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-#          patches = patches ++ [
+          patches = patches ++ [
 #            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
 #            # https://github.com/ros-perception/image_pipeline/pull/930
 #            (self.fetchpatch {
@@ -313,7 +313,8 @@ self: super:
 #              stripLen = 1;
 #              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
 #            })
-#          ];
+            ./patches/image_proc.patch
+          ];
         });
 
         depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -305,28 +305,8 @@ self: super:
 
         image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
           patches = patches ++ [
-#            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
-#            # https://github.com/ros-perception/image_pipeline/pull/930
-#            (self.fetchpatch {
-#              url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
-#              revert = true;
-#              stripLen = 1;
-#              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
-#            })
             ./patches/image_proc.patch
           ];
-        });
-
-        depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-#          patches = patches ++ [
-#            # Fix signature issue from #943
-#            # https://github.com/ros-perception/image_pipeline/pull/1018
-#            (self.fetchpatch {
-#              url = "https://github.com/ros-perception/image_pipeline/commit/a7c0b09c5e37fcaf7e3153e6d353687a793ee3f9.patch";
-#              stripLen = 1;
-#              hash = "sha256-wXUSSfRBzCTxrilCvSJFhpq384+7hvL7vxnIyLaW5zs=";
-#            })
-#          ];
         });
 
         rosapi = rosSuper.rosapi.overrideAttrs ({ patches ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -304,16 +304,16 @@ self: super:
         gazebo-ros-pkgs = rosSelf.callPackage (self.nix-ros-overlay + "/distros/iron/gazebo-ros-pkgs") { };
 
         image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-          patches = patches ++ [
-            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
-            # https://github.com/ros-perception/image_pipeline/pull/930
-            (self.fetchpatch {
-              url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
-              revert = true;
-              stripLen = 1;
-              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
-            })
-          ];
+#          patches = patches ++ [
+#            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
+#            # https://github.com/ros-perception/image_pipeline/pull/930
+#            (self.fetchpatch {
+#              url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
+#              revert = true;
+#              stripLen = 1;
+#              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
+#            })
+#          ];
         });
 
         depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -302,6 +302,9 @@ self: super:
           sourceRoot = src.name + "/gazebo_ros2_control";
         };
         gazebo-ros-pkgs = rosSelf.callPackage (self.nix-ros-overlay + "/distros/iron/gazebo-ros-pkgs") { };
+        
+        # Adding gz-vendor packages
+        gz-ros2-control-demos = rosSelf.callPackage (self.nix-ros-overlay + "/distros/jazzy/gz-ros2-control-demos") { };
 
         image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
           patches = patches ++ [

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -303,18 +303,18 @@ self: super:
         };
         gazebo-ros-pkgs = rosSelf.callPackage (self.nix-ros-overlay + "/distros/iron/gazebo-ros-pkgs") { };
 
-        # image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-        #   patches = patches ++ [
-        #     # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
-        #     # https://github.com/ros-perception/image_pipeline/pull/930
-        #     (self.fetchpatch {
-        #       url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
-        #       revert = true;
-        #       stripLen = 1;
-        #       hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
-        #     })
-        #   ];
-        # });
+        image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
+          patches = patches ++ [
+            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
+            # https://github.com/ros-perception/image_pipeline/pull/930
+            (self.fetchpatch {
+              url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
+              revert = true;
+              stripLen = 1;
+              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
+            })
+          ];
+        });
 
         depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {
           patches = patches ++ [

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -302,22 +302,19 @@ self: super:
           sourceRoot = src.name + "/gazebo_ros2_control";
         };
         gazebo-ros-pkgs = rosSelf.callPackage (self.nix-ros-overlay + "/distros/iron/gazebo-ros-pkgs") { };
-        
-        # Adding gz-vendor packages
-        gz-ros2-control-demos = rosSelf.callPackage (self.nix-ros-overlay + "/distros/jazzy/gz-ros2-control-demos") { };
 
-        image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
-          patches = patches ++ [
-            # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
-            # https://github.com/ros-perception/image_pipeline/pull/930
-            (self.fetchpatch {
-              url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
-              revert = true;
-              stripLen = 1;
-              hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
-            })
-          ];
-        });
+        # image-proc = rosSuper.image-proc.overrideAttrs ({ patches ? [ ], ... }: {
+        #   patches = patches ++ [
+        #     # Revert "Add TrackMarkerNode to image_proc" (requires OpenCV <= 4.6.0)
+        #     # https://github.com/ros-perception/image_pipeline/pull/930
+        #     (self.fetchpatch {
+        #       url = "https://github.com/ros-perception/image_pipeline/commit/f8c88a2970e7fcc16fd2457f5e5873df6b3e2769.patch";
+        #       revert = true;
+        #       stripLen = 1;
+        #       hash = "sha256-z0hfjFWRx0vBwa5aWIiJ4plICwaCAe1rGAacVPKmgC0=";
+        #     })
+        #   ];
+        # });
 
         depth-image-proc = rosSuper.depth-image-proc.overrideAttrs ({ patches ? [ ], ... }: {
           patches = patches ++ [

--- a/nixfiles/overlay/ros/patches/image_proc.patch
+++ b/nixfiles/overlay/ros/patches/image_proc.patch
@@ -1,0 +1,15 @@
+diff --git a/src/track_marker.cpp b/src/track_marker.cpp
+index e103de0..6f2ce40 100644
+--- a/src/track_marker.cpp
++++ b/src/track_marker.cpp
+@@ -64,8 +64,8 @@ TrackMarkerNode::TrackMarkerNode(const rclcpp::NodeOptions & options)
+   // Default dictionary is cv::aruco::DICT_6X6_250
+   int dict_id = this->declare_parameter("dictionary", 10);
+ 
+-  detector_params_ = cv::aruco::DetectorParameters::create();
+-  dictionary_ = cv::aruco::getPredefinedDictionary(dict_id);
++  detector_params_ = cv::makePtr<cv::aruco::DetectorParameters>(cv::aruco::DetectorParameters());
++  dictionary_ = cv::makePtr<cv::aruco::Dictionary>(cv::aruco::getPredefinedDictionary(dict_id));
+ 
+   // Setup lazy subscriber using publisher connection callback
+   rclcpp::PublisherOptions pub_options;

--- a/nixfiles/overlay/ros/patches/nix-ros-workspace.patch
+++ b/nixfiles/overlay/ros/patches/nix-ros-workspace.patch
@@ -1,0 +1,492 @@
+From aa846d382c40809f812b2f1c7d8b92d901a75da5 Mon Sep 17 00:00:00 2001
+From: Michal Sojka <michal.sojka@cvut.cz>
+Date: Sat, 6 Jul 2024 22:48:54 +0200
+Subject: [PATCH 1/3] Patch and fix gz-*-vendor packages for Jazzy and Rolling
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes build failures in gz-*-vendor packages for Jazzy and
+Rolling. Some of these packages are required for building rviz2.
+
+Since most of the gz-* packages share the same structure, we introduce
+patchGzAmentVendorGit function to make patching easier. In addition to
+patching ament_vendor() calls, it adds a check to CMakeLists.txt to
+detect upstream updates of the vendored package version. This should
+help keeping our overrides in sync with upstream.
+
+Currently, the overrides for Jazzy and Rolling are the same.
+
+Co-authored-by: Błażej Sowa <bsowa123@gmail.com>
+---
+ distros/jazzy/overrides.nix   | 107 ++++++++++++++++++++++++++++++++++
+ distros/rolling/overrides.nix | 107 ++++++++++++++++++++++++++++++++++
+ lib/default.nix               |  33 +++++++++++
+ 3 files changed, 247 insertions(+)
+
+diff --git a/distros/jazzy/overrides.nix b/distros/jazzy/overrides.nix
+index 11a74b784e..d05a60a0af 100644
+--- a/distros/jazzy/overrides.nix
++++ b/distros/jazzy/overrides.nix
+@@ -31,6 +31,108 @@ in {
+     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
+   };
+ 
++  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
++    version = "3.5.3";
++    hash = "sha256-fnN3Fmp7F5W0JixJUEp2v/OnXzmRidS5ujmSYxIRWto=";
++  };
++
++  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
++    version = "5.6.0";
++    hash = "sha256-vM+/V2F+Nr/LReqcMAmAbgAyaph/vMZVb0BO0MAUp6I=";
++  }).overrideAttrs ({
++    nativeBuildInputs ? [], ...
++  }: {
++    # https://github.com/gazebo-release/gz_common_vendor/pull/2
++    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
++  });
++
++  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
++    url = "https://github.com/dartsim/dart.git";
++    rev = "v6.13.2";
++    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
++  };
++
++  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
++    version = "9.1.0";
++    hash = "sha256-txeIzj2vmvL5NDu6O07c7LwcCWE26OFEzvyc9TBrJAw=";
++  };
++
++  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
++    version = "8.3.0";
++    hash = "sha256-V0zaL6qrd510hMECCr3/mMkyqf4yu2aaKLRZ6Rw0s/4=";
++  }).overrideAttrs ({
++    postInstall ? "", ...
++  }: {
++    # "RPATH of binary libGrid3D.so contains a forbidden reference to
++    # /build/" (see https://github.com/gazebosim/gz-gui/issues/627).
++    postInstall = postInstall + ''
++      ${self.patchelf}/bin/patchelf --remove-rpath $out/opt/gz_gui_vendor/lib64/gz-gui-8/plugins/libGrid3D.so
++    '';
++  });
++
++  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
++    version = "7.1.0";
++    hash = "sha256-En3V8i/Ie8+KnSHGlm9Bap7REdLhYBaVHVbOM+/Pzno=";
++  };
++
++  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
++    version = "7.5.0";
++    hash = "sha256-TEadejtPCR3FAUbyAAME28tmqaxypPTJDYidjZ3FPIY=";
++  };
++
++  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
++    version = "10.3.0";
++    hash = "sha256-PQT8EpTxafldnKG3hDSXw2P22gLRg2EfMllrzaTaDEw=";
++  };
++
++  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
++    url = "https://github.com/OGRECave/ogre-next.git";
++    rev = "v2.3.3";
++    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
++  }).overrideAttrs({ ... }: {
++    dontFixCmake = true;
++  });
++
++  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
++    version = "7.3.0";
++    hash = "sha256-PTalEQc9C/QsYMO+XK7aOzZUzC01jxiW6bjdItB5hlM=";
++  };
++
++  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
++    version = "2.0.3";
++    hash = "sha256-9t6vcnBbfRWu6ptmqYAhmWKDoKAaK631JD9u1C0G0mY=";
++  };
++
++  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
++    version = "8.2.0";
++    hash = "sha256-eaWkZKHu566Rub7YSO2lnKdj8YQbhl86v+JR4zrgtjs=";
++  };
++
++  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
++    version = "8.2.0";
++    hash = "sha256-j/8kS+Bvaim2gtsZcp+/u8CAE+N24/5qZhciFR0Q8+M=";
++  };
++
++  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
++    version = "8.6.0";
++    hash = "sha256-zSiPHEh3h2J8hGL342tde5U9FLaGnWs72WD9BqyPf6E=";
++  };
++
++  gz-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
++    version = "2.0.1";
++    hash = "sha256-sV/T53oVk1fgjwqn/SRTaPTukt+vAlGGxGvTN8+G6Mo=";
++  };
++
++  gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
++    version = "13.4.0";
++    hash = "sha256-2Akd3vKr07IdgoJppvUV1nZlHE4RdQfI2R18ihHTDHk=";
++  };
++
++  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
++    version = "2.2.0";
++    hash = "sha256-dNoDOZtk/zseHuOM5mOPHkXKU7wqxxKrFnh7e09bjRA=";
++  };
++
+   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
+     patches ? [], ...
+   }: {
+@@ -87,6 +189,11 @@ in {
+     sha256 = "sha256-TyFt3d78GidhDGD17KgjAaZl/qvAcGJP8lmu4EOxpYg=";
+   };
+ 
++  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
++    version = "14.5.0";
++    hash = "sha256-nGBLnQP0TTKDVbYGyx23Fcs79UCJveajsll2LvyLJwQ=";
++  };
++
+   urdfdom = rosSuper.urdfdom.overrideAttrs ({
+     patches ? [], ...
+   }: {
+diff --git a/distros/rolling/overrides.nix b/distros/rolling/overrides.nix
+index fedb61ab11..4030fe7533 100644
+--- a/distros/rolling/overrides.nix
++++ b/distros/rolling/overrides.nix
+@@ -31,6 +31,108 @@ in {
+     fetchgitArgs.hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
+   };
+ 
++  gz-cmake-vendor = lib.patchGzAmentVendorGit rosSuper.gz-cmake-vendor {
++    version = "3.5.3";
++    hash = "sha256-fnN3Fmp7F5W0JixJUEp2v/OnXzmRidS5ujmSYxIRWto=";
++  };
++
++  gz-common-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-common-vendor {
++    version = "5.6.0";
++    hash = "sha256-vM+/V2F+Nr/LReqcMAmAbgAyaph/vMZVb0BO0MAUp6I=";
++  }).overrideAttrs ({
++    nativeBuildInputs ? [], ...
++  }: {
++    # https://github.com/gazebo-release/gz_common_vendor/pull/2
++    nativeBuildInputs = nativeBuildInputs ++ [ self.pkg-config ];
++  });
++
++  gz-dartsim-vendor = lib.patchAmentVendorGit rosSuper.gz-dartsim-vendor {
++    url = "https://github.com/dartsim/dart.git";
++    rev = "v6.13.2";
++    fetchgitArgs.hash = "sha256-AfKPqUiW6BsM98TIzTY2ZcFP1WvURs8/dGOzanIiB9g=";
++  };
++
++  gz-fuel-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-fuel-tools-vendor {
++    version = "9.1.0";
++    hash = "sha256-txeIzj2vmvL5NDu6O07c7LwcCWE26OFEzvyc9TBrJAw=";
++  };
++
++  gz-gui-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-gui-vendor {
++    version = "8.3.0";
++    hash = "sha256-V0zaL6qrd510hMECCr3/mMkyqf4yu2aaKLRZ6Rw0s/4=";
++  }).overrideAttrs ({
++    postInstall ? "", ...
++  }: {
++    # "RPATH of binary libGrid3D.so contains a forbidden reference to
++    # /build/" (see https://github.com/gazebosim/gz-gui/issues/627).
++    postInstall = postInstall + ''
++      ${self.patchelf}/bin/patchelf --remove-rpath $out/opt/gz_gui_vendor/lib64/gz-gui-8/plugins/libGrid3D.so
++    '';
++  });
++
++  gz-launch-vendor = lib.patchGzAmentVendorGit rosSuper.gz-launch-vendor {
++    version = "7.1.0";
++    hash = "sha256-En3V8i/Ie8+KnSHGlm9Bap7REdLhYBaVHVbOM+/Pzno=";
++  };
++
++  gz-math-vendor = lib.patchGzAmentVendorGit rosSuper.gz-math-vendor {
++    version = "7.5.0";
++    hash = "sha256-TEadejtPCR3FAUbyAAME28tmqaxypPTJDYidjZ3FPIY=";
++  };
++
++  gz-msgs-vendor = lib.patchGzAmentVendorGit rosSuper.gz-msgs-vendor {
++    version = "10.3.0";
++    hash = "sha256-PQT8EpTxafldnKG3hDSXw2P22gLRg2EfMllrzaTaDEw=";
++  };
++
++  gz-ogre-next-vendor = (lib.patchAmentVendorGit rosSuper.gz-ogre-next-vendor {
++    url = "https://github.com/OGRECave/ogre-next.git";
++    rev = "v2.3.3";
++    fetchgitArgs.hash = "sha256-elSj35LwsLzj1ssDPsk9NW/KSXfiOGYmw9hQSAWdpFM=";
++  }).overrideAttrs({ ... }: {
++    dontFixCmake = true;
++  });
++
++  gz-physics-vendor = lib.patchGzAmentVendorGit rosSuper.gz-physics-vendor {
++    version = "7.3.0";
++    hash = "sha256-PTalEQc9C/QsYMO+XK7aOzZUzC01jxiW6bjdItB5hlM=";
++  };
++
++  gz-plugin-vendor = lib.patchGzAmentVendorGit rosSuper.gz-plugin-vendor {
++    version = "2.0.3";
++    hash = "sha256-9t6vcnBbfRWu6ptmqYAhmWKDoKAaK631JD9u1C0G0mY=";
++  };
++
++  gz-rendering-vendor = lib.patchGzAmentVendorGit rosSuper.gz-rendering-vendor {
++    version = "8.2.0";
++    hash = "sha256-eaWkZKHu566Rub7YSO2lnKdj8YQbhl86v+JR4zrgtjs=";
++  };
++
++  gz-sensors-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sensors-vendor {
++    version = "8.2.0";
++    hash = "sha256-j/8kS+Bvaim2gtsZcp+/u8CAE+N24/5qZhciFR0Q8+M=";
++  };
++
++  gz-sim-vendor = lib.patchGzAmentVendorGit rosSuper.gz-sim-vendor {
++    version = "8.6.0";
++    hash = "sha256-zSiPHEh3h2J8hGL342tde5U9FLaGnWs72WD9BqyPf6E=";
++  };
++
++  gz-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
++    version = "2.0.1";
++    hash = "sha256-sV/T53oVk1fgjwqn/SRTaPTukt+vAlGGxGvTN8+G6Mo=";
++  };
++
++  gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
++    version = "13.4.0";
++    hash = "sha256-2Akd3vKr07IdgoJppvUV1nZlHE4RdQfI2R18ihHTDHk=";
++  };
++
++  gz-utils-vendor = lib.patchGzAmentVendorGit rosSuper.gz-utils-vendor {
++    version = "2.2.0";
++    hash = "sha256-dNoDOZtk/zseHuOM5mOPHkXKU7wqxxKrFnh7e09bjRA=";
++  };
++
+   iceoryx-hoofs = rosSuper.iceoryx-hoofs.overrideAttrs ({
+     patches ? [], ...
+   }: {
+@@ -82,6 +184,11 @@ in {
+     '';
+   };
+ 
++  sdformat-vendor = lib.patchGzAmentVendorGit rosSuper.sdformat-vendor {
++    version = "14.5.0";
++    hash = "sha256-nGBLnQP0TTKDVbYGyx23Fcs79UCJveajsll2LvyLJwQ=";
++  };
++
+   urdfdom = rosSuper.urdfdom.overrideAttrs ({
+     patches ? [], ...
+   }: {
+diff --git a/lib/default.nix b/lib/default.nix
+index 29dc50635e..877857aa20 100644
+--- a/lib/default.nix
++++ b/lib/default.nix
+@@ -106,6 +106,39 @@
+     '' + postPatch;
+   });
+ 
++  # patchAmentVendorGit specialized for gz-*-vendor packages. In
++  # addition to patching ament_vendor() calls, it adds a check to
++  # CMakeLists.txt to detect upstream updates of the vendored package
++  # version.
++  patchGzAmentVendorGit = pkg: {
++    version,
++    hash,
++    tarSourceArgs ? {}
++  }: let
++    stem = lib.strings.removeSuffix "-vendor"
++      (lib.strings.removePrefix "ros-${pkg.rosDistro}-" pkg.pname); # e.g. gz-cmake
++    majorNum = lib.versions.major version;
++    patchedPkg = lib.patchAmentVendorGit pkg {
++      url = "https://github.com/gazebosim/${stem}.git";
++      originalUrl = "https://github.com/gazebosim/\${GITHUB_NAME}.git";
++      rev = "${stem}${majorNum}_${version}"; # e.g. "gz-cmake3_3.5.3"
++      fetchgitArgs.hash = hash;
++      inherit tarSourceArgs;
++    };
++  in
++    patchedPkg.overrideAttrs ({
++      pname, postPatch ? "", ...
++    }: {
++      dontFixCmake = true;      # don't replace $out/opt with $out/var/empty
++      postPatch = postPatch + ''
++        cat >> CMakeLists.txt <<'EOF'
++        if(NOT ''${LIB_VER} VERSION_EQUAL "${version}")
++          message(FATAL_ERROR "Mismatch in ${pname} version (Nix: ${version}, upstream: ''${LIB_VER}). Fix this in overrides.nix.")
++        endif()
++        EOF
++      '';
++    });
++
+   patchBoostPython = pkg: pkg.overrideAttrs ({
+     postPatch ? "", ...
+   }: {
+
+From fc4c0ebbe4b1d53aa2dbdca331bd74280645f961 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bernd=20M=C3=BCller?= <github@muellerbernd.de>
+Date: Thu, 19 Sep 2024 23:17:44 +0200
+Subject: [PATCH 2/3] [add] example-ros2-gz shell
+
+---
+ examples/ros2-gz-example.nix | 42 ++++++++++++++++++++++++++++++++++++
+ flake.nix                    |  1 +
+ 2 files changed, 43 insertions(+)
+ create mode 100644 examples/ros2-gz-example.nix
+
+diff --git a/examples/ros2-gz-example.nix b/examples/ros2-gz-example.nix
+new file mode 100644
+index 0000000000..82ef92d237
+--- /dev/null
++++ b/examples/ros2-gz-example.nix
+@@ -0,0 +1,42 @@
++# gz needs insecure packages, namely freeimage-unstable-2021-11-01
++# to run this dev shell use:
++# NIXPKGS_ALLOW_INSECURE=1 nix develop --impure .\#example-ros2-gz
++
++{pkgs ? import ../. {}}:
++with pkgs;
++with rosPackages.jazzy;
++  mkShell {
++    nativeBuildInputs = [
++      (buildEnv {
++        paths = [
++          colcon
++          ros-core
++          ament-cmake-core
++          python-cmake-module
++          # ros-gz
++
++          gz-cmake-vendor
++          gz-common-vendor
++          gz-dartsim-vendor
++          gz-fuel-tools-vendor
++          gz-gui-vendor
++          gz-launch-vendor
++          gz-math-vendor
++          gz-msgs-vendor
++          gz-ogre-next-vendor
++          gz-physics-vendor
++          gz-plugin-vendor
++          gz-rendering-vendor
++          gz-sensors-vendor
++          gz-sim-vendor
++          gz-tools-vendor
++          gz-transport-vendor
++          gz-utils-vendor
++        ];
++      })
++    ];
++    GZ_CONFIG_PATH = "${gz-tools-vendor}/opt/gz_tools_vendor/share/gz:${gz-gui-vendor}/opt/gz_gui_vendor/share/gz\:${gz-cmake-vendor}/opt/gz_cmake_vendor/share/gz\:${gz-fuel-tools-vendor}/opt/gz_fuel_tools_vendor/share/gz\:${gz-launch-vendor}/opt/gz_launch_vendor/share/gz\:${gz-math-vendor}/opt/gz_math_vendor/share/gz\:${gz-msgs-vendor}/opt/gz_msgs_vendor/share/gz\:${gz-physics-vendor}/opt/gz_physics_vendor/share/gz\:${gz-plugin-vendor}/opt/gz_plugin_vendor/share/gz\:${gz-rendering-vendor}/opt/gz_rendering_vendor/share/gz\:${gz-sensors-vendor}/opt/gz_sensors_vendor/share/gz\:${gz-sim-vendor}/opt/gz_sim_vendor/share/gz\:${gz-transport-vendor}/opt/gz_transport_vendor/share/gz\:${gz-utils-vendor}/opt/gz_utils_vendor/share/gz";
++    shellHook = ''
++      unset QT_QPA_PLATFORM
++    '';
++  }
+diff --git a/flake.nix b/flake.nix
+index bde6e0e277..31ac34f068 100644
+--- a/flake.nix
++++ b/flake.nix
+@@ -20,6 +20,7 @@
+       devShells = {
+         example-turtlebot3-gazebo = import ./examples/turtlebot3-gazebo.nix { inherit pkgs; };
+         example-ros2-basic = import ./examples/ros2-basic.nix { inherit pkgs; };
++        example-ros2-gz = import ./examples/ros2-gz-example.nix { inherit pkgs; };
+       };
+     }) // {
+       overlays.default = import ./overlay.nix;
+
+From 6d04148eac0727be34e5333f6e12cfc7e86673c3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bernd=20M=C3=BCller?= <github@muellerbernd.de>
+Date: Fri, 20 Sep 2024 00:13:03 +0200
+Subject: [PATCH 3/3] [fix] gz setup and apply suggestions from wentasah
+
+---
+ distros/jazzy/overrides.nix   | 16 ++++++++++++++--
+ distros/rolling/overrides.nix | 16 ++++++++++++++--
+ examples/ros2-gz-example.nix  |  1 -
+ lib/default.nix               |  6 ++++++
+ 4 files changed, 34 insertions(+), 5 deletions(-)
+
+diff --git a/distros/jazzy/overrides.nix b/distros/jazzy/overrides.nix
+index d05a60a0af..18e88f6a3d 100644
+--- a/distros/jazzy/overrides.nix
++++ b/distros/jazzy/overrides.nix
+@@ -118,10 +118,22 @@ in {
+     hash = "sha256-zSiPHEh3h2J8hGL342tde5U9FLaGnWs72WD9BqyPf6E=";
+   };
+ 
+-  gz-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
++  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
+     version = "2.0.1";
+     hash = "sha256-sV/T53oVk1fgjwqn/SRTaPTukt+vAlGGxGvTN8+G6Mo=";
+-  };
++  }).overrideAttrs({
++    nativeBuildInputs ? [], propagatedNativeBuildInputs ? [], qtWrapperArgs ? [], postFixup ? "", ...
++  }: {
++    nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
++    propagatedNativeBuildInputs = propagatedNativeBuildInputs ++ [self.qt5.qtquickcontrols2 self.qt5.qtgraphicaleffects self.pkg-config];
++    qtWrapperArgs = qtWrapperArgs ++ [
++      # Use X11 by default
++      "--set-default QT_QPA_PLATFORM xcb"
++    ];
++    postFixup = postFixup + ''
++      wrapQtApp "$out/opt/gz_tools_vendor/bin/gz"
++    '';
++  });
+ 
+   gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
+     version = "13.4.0";
+diff --git a/distros/rolling/overrides.nix b/distros/rolling/overrides.nix
+index 4030fe7533..143f476af0 100644
+--- a/distros/rolling/overrides.nix
++++ b/distros/rolling/overrides.nix
+@@ -118,10 +118,22 @@ in {
+     hash = "sha256-zSiPHEh3h2J8hGL342tde5U9FLaGnWs72WD9BqyPf6E=";
+   };
+ 
+-  gz-tools-vendor = lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
++  gz-tools-vendor = (lib.patchGzAmentVendorGit rosSuper.gz-tools-vendor {
+     version = "2.0.1";
+     hash = "sha256-sV/T53oVk1fgjwqn/SRTaPTukt+vAlGGxGvTN8+G6Mo=";
+-  };
++  }).overrideAttrs({
++    nativeBuildInputs ? [], propagatedNativeBuildInputs ? [], qtWrapperArgs ? [], postFixup ? "", ...
++  }: {
++    nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
++    propagatedNativeBuildInputs = propagatedNativeBuildInputs ++ [self.qt5.qtquickcontrols2 self.qt5.qtgraphicaleffects self.pkg-config];
++    qtWrapperArgs = qtWrapperArgs ++ [
++      # Use X11 by default
++      "--set-default QT_QPA_PLATFORM xcb"
++    ];
++    postFixup = postFixup + ''
++      wrapQtApp "$out/opt/gz_tools_vendor/bin/gz"
++    '';
++  });
+ 
+   gz-transport-vendor = lib.patchGzAmentVendorGit rosSuper.gz-transport-vendor {
+     version = "13.4.0";
+diff --git a/examples/ros2-gz-example.nix b/examples/ros2-gz-example.nix
+index 82ef92d237..22288addb3 100644
+--- a/examples/ros2-gz-example.nix
++++ b/examples/ros2-gz-example.nix
+@@ -35,7 +35,6 @@ with rosPackages.jazzy;
+         ];
+       })
+     ];
+-    GZ_CONFIG_PATH = "${gz-tools-vendor}/opt/gz_tools_vendor/share/gz:${gz-gui-vendor}/opt/gz_gui_vendor/share/gz\:${gz-cmake-vendor}/opt/gz_cmake_vendor/share/gz\:${gz-fuel-tools-vendor}/opt/gz_fuel_tools_vendor/share/gz\:${gz-launch-vendor}/opt/gz_launch_vendor/share/gz\:${gz-math-vendor}/opt/gz_math_vendor/share/gz\:${gz-msgs-vendor}/opt/gz_msgs_vendor/share/gz\:${gz-physics-vendor}/opt/gz_physics_vendor/share/gz\:${gz-plugin-vendor}/opt/gz_plugin_vendor/share/gz\:${gz-rendering-vendor}/opt/gz_rendering_vendor/share/gz\:${gz-sensors-vendor}/opt/gz_sensors_vendor/share/gz\:${gz-sim-vendor}/opt/gz_sim_vendor/share/gz\:${gz-transport-vendor}/opt/gz_transport_vendor/share/gz\:${gz-utils-vendor}/opt/gz_utils_vendor/share/gz";
+     shellHook = ''
+       unset QT_QPA_PLATFORM
+     '';
+diff --git a/lib/default.nix b/lib/default.nix
+index 877857aa20..863119136c 100644
+--- a/lib/default.nix
++++ b/lib/default.nix
+@@ -137,6 +137,12 @@
+         endif()
+         EOF
+       '';
++      preBuild = ''
++        find . -name "*build.make" -print -exec sed -i "s#var/empty#opt#g" {} \;
++      '';
++      setupHook = self.writeText "${pname}-setup-hook.sh" ''
++        addToSearchPath GZ_CONFIG_PATH "@out@/opt/${lib.replaceStrings ["-"] ["_"] stem}_vendor/share/gz"
++      '';
+     });
+ 
+   patchBoostPython = pkg: pkg.overrideAttrs ({

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -2,9 +2,9 @@
 , buildROSWorkspace
 , buildEnv
 , rviz2
-, gazebo
-, gz-launch-vendor
-, gz-ros2-control-demos
+#, gazebo
+#, gz-launch-vendor
+#, gz-ros2-control-demos
 , ros-gz
 , rqt
 , rqt-common-plugins
@@ -35,7 +35,7 @@
 # , nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
 # , nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
 , nova-teleop-drive-joy ? throw "nova-teleop-drive-joy is needed, but not available!"
-, nova-gazebo ? throw "nova-gazebo is needed, but not available!"
+#, nova-gazebo ? throw "nova-gazebo is needed, but not available!"
 , nova-python-control ? throw "python-control is needed, but not available!"
 , nova-excavation-construction ? throw "excavation-construction is needed, but not available!"
 , nova-utils ? throw "nova-utils is needed, but not available!"
@@ -103,9 +103,9 @@ in
   prebuiltPackages = (lib.optionalAttrs graphical {
     inherit
       rviz2
-      gazebo
-      gz-launch-vendor
-      gz-ros2-control-demos
+      #gazebo
+      #gz-launch-vendor
+      #gz-ros2-control-demos
       ros-gz
       gps-umd
       rqt rqt-common-plugins;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -3,9 +3,7 @@
 , buildEnv
 , rviz2
 , gazebo
-, gz-launch-vendor
 , gz-ros2-control-demos
-, ros-gz
 , rqt
 , rqt-common-plugins
 , gdb
@@ -31,9 +29,9 @@
 , nova-auto-bringup ? throw "auto-bringup is needed, but not available!"
 , nova-rover-description ? throw "rover-description is needed, but not available!"
 , nova-blcmd-hardware ? throw "nova-blcmd-hardware is needed, but not available!"
-# , nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
-# , nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
-# , nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
+, nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
+, nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
+, nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
 , nova-teleop-drive-joy ? throw "nova-teleop-drive-joy is needed, but not available!"
 , nova-gazebo ? throw "nova-gazebo is needed, but not available!"
 , nova-python-control ? throw "python-control is needed, but not available!"
@@ -56,9 +54,9 @@
       nova-science
       nova-cameras2
       nova-blcmd-hardware
-      # nova-pivot-drive-controller
-      # nova-strafe-controller
-      # nova-diff-drive-controller
+      nova-pivot-drive-controller
+      nova-strafe-controller
+      nova-diff-drive-controller
       nova-teleop-drive-joy
       nova-gui
       nova-drive
@@ -104,9 +102,7 @@ in
     inherit
       rviz2
       gazebo
-      gz-launch-vendor
       gz-ros2-control-demos
-      ros-gz
       gps-umd
       rqt rqt-common-plugins;
   }) // extraPackages;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -3,6 +3,7 @@
 , buildEnv
 , rviz2
 , ros-gz
+, gz-ros2-control
 , rqt
 , rqt-common-plugins
 , gdb
@@ -101,6 +102,7 @@ in
     inherit
       rviz2
       ros-gz
+      gz-ros2-control
       gps-umd
       rqt rqt-common-plugins;
   }) // extraPackages;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -3,6 +3,7 @@
 , buildEnv
 , rviz2
 , gazebo
+, gz-ros2-control-demos
 , rqt
 , rqt-common-plugins
 , gdb
@@ -101,6 +102,7 @@ in
     inherit
       rviz2
       gazebo
+      gz-ros2-control-demos
       gps-umd
       rqt rqt-common-plugins;
   }) // extraPackages;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -3,7 +3,9 @@
 , buildEnv
 , rviz2
 , gazebo
+, gz-launch-vendor
 , gz-ros2-control-demos
+, ros-gz
 , rqt
 , rqt-common-plugins
 , gdb
@@ -102,7 +104,9 @@ in
     inherit
       rviz2
       gazebo
+      gz-launch-vendor
       gz-ros2-control-demos
+      ros-gz
       gps-umd
       rqt rqt-common-plugins;
   }) // extraPackages;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -31,9 +31,9 @@
 , nova-auto-bringup ? throw "auto-bringup is needed, but not available!"
 , nova-rover-description ? throw "rover-description is needed, but not available!"
 , nova-blcmd-hardware ? throw "nova-blcmd-hardware is needed, but not available!"
-, nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
-, nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
-, nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
+# , nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
+# , nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
+# , nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
 , nova-teleop-drive-joy ? throw "nova-teleop-drive-joy is needed, but not available!"
 , nova-gazebo ? throw "nova-gazebo is needed, but not available!"
 , nova-python-control ? throw "python-control is needed, but not available!"
@@ -56,9 +56,9 @@
       nova-science
       nova-cameras2
       nova-blcmd-hardware
-      nova-pivot-drive-controller
-      nova-strafe-controller
-      nova-diff-drive-controller
+      # nova-pivot-drive-controller
+      # nova-strafe-controller
+      # nova-diff-drive-controller
       nova-teleop-drive-joy
       nova-gui
       nova-drive

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -76,7 +76,7 @@
       nova-bringup
       nova-auto-bringup
       nova-rover-description
-      nova-gazebo
+      # nova-gazebo
       nova-python-control
       nova-excavation-construction
       nova-utils;

--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -2,9 +2,6 @@
 , buildROSWorkspace
 , buildEnv
 , rviz2
-#, gazebo
-#, gz-launch-vendor
-#, gz-ros2-control-demos
 , ros-gz
 , rqt
 , rqt-common-plugins
@@ -31,11 +28,11 @@
 , nova-auto-bringup ? throw "auto-bringup is needed, but not available!"
 , nova-rover-description ? throw "rover-description is needed, but not available!"
 , nova-blcmd-hardware ? throw "nova-blcmd-hardware is needed, but not available!"
-# , nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
-# , nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
-# , nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
+, nova-pivot-drive-controller ? throw "nova-pivot-drive-controller is needed, but not available!"
+, nova-strafe-controller ? throw "nova-strafe-controller is needed, but not available!"
+, nova-diff-drive-controller ? throw "nova-diff-drive-controller is needed, but not available!"
 , nova-teleop-drive-joy ? throw "nova-teleop-drive-joy is needed, but not available!"
-#, nova-gazebo ? throw "nova-gazebo is needed, but not available!"
+, nova-gazebo ? throw "nova-gazebo is needed, but not available!"
 , nova-python-control ? throw "python-control is needed, but not available!"
 , nova-excavation-construction ? throw "excavation-construction is needed, but not available!"
 , nova-utils ? throw "nova-utils is needed, but not available!"
@@ -56,9 +53,9 @@
       nova-science
       nova-cameras2
       nova-blcmd-hardware
-      # nova-pivot-drive-controller
-      # nova-strafe-controller
-      # nova-diff-drive-controller
+      nova-pivot-drive-controller
+      nova-strafe-controller
+      nova-diff-drive-controller
       nova-teleop-drive-joy
       nova-gui
       nova-drive
@@ -76,7 +73,7 @@
       nova-bringup
       nova-auto-bringup
       nova-rover-description
-      # nova-gazebo
+      nova-gazebo
       nova-python-control
       nova-excavation-construction
       nova-utils;
@@ -103,9 +100,6 @@ in
   prebuiltPackages = (lib.optionalAttrs graphical {
     inherit
       rviz2
-      #gazebo
-      #gz-launch-vendor
-      #gz-ros2-control-demos
       ros-gz
       gps-umd
       rqt rqt-common-plugins;

--- a/nixfiles/revisions.json
+++ b/nixfiles/revisions.json
@@ -4,8 +4,8 @@
     "hash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis="
   },
   "nix-ros-overlay": {
-    "rev": "1992646cf65ac8f036a21a2005e10c4454c9e3fc",
-    "hash": "sha256-syYDeNi50lYGaSajggdgcLbV8P/E3v77F2fF5vTuCoI="
+    "rev": "e3115496885bcefee3aa9ff073836e7634661e11",
+    "hash": "sha256-4bVp9z6xm0MP3XROK1Hz2OtO3/6EPNly7rzWfYGZ5pU="
   },
   "nix-ros-workspace": {
     "rev": "d389c0ad68267b85b9ac3b7350801dd0110ed669",

--- a/nixfiles/revisions.json
+++ b/nixfiles/revisions.json
@@ -4,8 +4,8 @@
     "hash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis="
   },
   "nix-ros-overlay": {
-    "rev": "6d04148eac0727be34e5333f6e12cfc7e86673c3",
-    "hash": "sha256-rl8LapLO6rXvHjacIlFZNthQ5h4DpWiFzhmcNvRUbVM="
+    "rev": "1992646cf65ac8f036a21a2005e10c4454c9e3fc",
+    "hash": "sha256-syYDeNi50lYGaSajggdgcLbV8P/E3v77F2fF5vTuCoI="
   },
   "nix-ros-workspace": {
     "rev": "d389c0ad68267b85b9ac3b7350801dd0110ed669",

--- a/nixfiles/revisions.json
+++ b/nixfiles/revisions.json
@@ -4,8 +4,8 @@
     "hash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis="
   },
   "nix-ros-overlay": {
-    "rev": "1992646cf65ac8f036a21a2005e10c4454c9e3fc",
-    "hash": "sha256-syYDeNi50lYGaSajggdgcLbV8P/E3v77F2fF5vTuCoI="
+    "rev": "6d04148eac0727be34e5333f6e12cfc7e86673c3",
+    "hash": "sha256-rl8LapLO6rXvHjacIlFZNthQ5h4DpWiFzhmcNvRUbVM="
   },
   "nix-ros-workspace": {
     "rev": "d389c0ad68267b85b9ac3b7350801dd0110ed669",

--- a/src/ros/rover/auto_bringup/launch/gazebo.launch.py
+++ b/src/ros/rover/auto_bringup/launch/gazebo.launch.py
@@ -13,11 +13,12 @@ PACKAGE: 	core
 CREATION:	27/04/2023
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
+import os
 
 from ament_index_python.packages import get_package_share_path, get_package_share_directory
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, AppendEnvironmentVariable
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -30,7 +31,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     auto_bringup_dir = FindPackageShare('auto_bringup')
     rover_description_dir = FindPackageShare('rover_description')
-    gazebo_dir = FindPackageShare('gazebo_ros')
+    gazebo_dir = FindPackageShare('ros_gz_sim')
     nova_gazebo_dir = FindPackageShare('nova_gazebo')
 
     pose = {'x': LaunchConfiguration('x_pose', default='-2.0'),
@@ -86,12 +87,13 @@ def generate_launch_description():
     )
 
     start_gazebo_server_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gzserver.launch.py'])),
-        launch_arguments={"world": world}.items()
+        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gz_sim.launch.py'])),
+        launch_arguments={'gz_args': ['-r -s -v4 ', world], 'on_exit_shutdown': 'true'}.items()
     )
 
     start_gazebo_client_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gzclient.launch.py'])),
+        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gz_sim.launch.py'])),
+        launch_arguments={'gz_args': '-g -v4 '}.items(),
         condition=UnlessCondition(headless),
     )
 
@@ -103,15 +105,19 @@ def generate_launch_description():
     )
 
     spawn_rover_cmd = Node(
-        package='gazebo_ros',
-        executable='spawn_entity.py',
+        package='ros_gz_sim',
+        executable='create',
         output='screen',
         arguments=[
             '-topic', 'robot_description',
-            '-entity', robot_name,
+            '-name', robot_name,
             '-robot_namespace', namespace,
             '-x', pose['x'], '-y', pose['y'], '-z', pose['z'],
             '-R', pose['R'], '-P', pose['P'], '-Y', pose['Y']])
+
+    set_env_vars_resources = AppendEnvironmentVariable(
+        'GZ_SIM_RESOURCE_PATH',
+        os.path.join(nova_gazebo_dir, 'models'))
 
     return LaunchDescription([
         namespace_arg,
@@ -125,4 +131,5 @@ def generate_launch_description():
         start_gazebo_client_cmd,
         spawn_rover_cmd,
         control_cmd,
+        set_env_vars_resources,
     ])

--- a/src/ros/rover/auto_bringup/launch/gazebo.launch.py
+++ b/src/ros/rover/auto_bringup/launch/gazebo.launch.py
@@ -34,6 +34,9 @@ def generate_launch_description():
     gazebo_dir = FindPackageShare('ros_gz_sim')
     nova_gazebo_dir = FindPackageShare('nova_gazebo')
 
+    ros_gz_sim = get_package_share_directory('ros_gz_sim')
+    nova_gazebo_dir_alt = get_package_share_path('nova_gazebo')
+
     pose = {'x': LaunchConfiguration('x_pose', default='-2.0'),
             'y': LaunchConfiguration('y_pose', default='-2.0'),
             'z': LaunchConfiguration('z_pose', default='0.05'),
@@ -87,12 +90,12 @@ def generate_launch_description():
     )
 
     start_gazebo_server_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gz_sim.launch.py'])),
+        PythonLaunchDescriptionSource(os.path.join(ros_gz_sim, 'launch', 'gz_sim.launch.py')),
         launch_arguments={'gz_args': ['-r -s -v4 ', world], 'on_exit_shutdown': 'true'}.items()
     )
 
     start_gazebo_client_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(PathJoinSubstitution([gazebo_dir, 'launch', 'gz_sim.launch.py'])),
+        PythonLaunchDescriptionSource(os.path.join(ros_gz_sim, 'launch', 'gz_sim.launch.py')),
         launch_arguments={'gz_args': '-g -v4 '}.items(),
         condition=UnlessCondition(headless),
     )
@@ -117,7 +120,7 @@ def generate_launch_description():
 
     set_env_vars_resources = AppendEnvironmentVariable(
         'GZ_SIM_RESOURCE_PATH',
-        os.path.join(nova_gazebo_dir, 'models'))
+        os.path.join(nova_gazebo_dir_alt, 'models'))
 
     return LaunchDescription([
         namespace_arg,

--- a/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller.cpp
+++ b/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller.cpp
@@ -125,7 +125,7 @@ controller_interface::return_type NovaDiffDriveController::update(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   auto logger = get_node()->get_logger();
-  if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
+  if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
   {
     if (!is_halted)
     {

--- a/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller.cpp
+++ b/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller.cpp
@@ -125,7 +125,7 @@ controller_interface::return_type NovaDiffDriveController::update(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
   auto logger = get_node()->get_logger();
-  if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
+  if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
   {
     if (!is_halted)
     {

--- a/src/ros/rover/controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
+++ b/src/ros/rover/controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
@@ -117,7 +117,7 @@ namespace pivot_drive_controller
         //        We should make right the negative direction to match
         auto logger = get_node()->get_logger();
         
-        if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
+        if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
         {
             if (!is_halted)
             {

--- a/src/ros/rover/controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
+++ b/src/ros/rover/controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
@@ -117,7 +117,7 @@ namespace pivot_drive_controller
         //        We should make right the negative direction to match
         auto logger = get_node()->get_logger();
         
-        if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
+        if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
         {
             if (!is_halted)
             {

--- a/src/ros/rover/controllers/strafe_controller/src/strafe_controller.cpp
+++ b/src/ros/rover/controllers/strafe_controller/src/strafe_controller.cpp
@@ -112,7 +112,7 @@ namespace strafe_controller
     {
         auto logger = get_node()->get_logger();
         
-        if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
+        if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
         {
             if (!is_halted)
             {

--- a/src/ros/rover/controllers/strafe_controller/src/strafe_controller.cpp
+++ b/src/ros/rover/controllers/strafe_controller/src/strafe_controller.cpp
@@ -112,7 +112,7 @@ namespace strafe_controller
     {
         auto logger = get_node()->get_logger();
         
-        if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
+        if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
         {
             if (!is_halted)
             {

--- a/src/ros/rover/default.nix
+++ b/src/ros/rover/default.nix
@@ -24,7 +24,7 @@
     nova-auto-bringup = callPackage ./nix/packages/auto-bringup { };
     nova-interfaces = callPackage ./nix/packages/nova-interfaces { };
     nova-rover-description = callPackage ./nix/packages/rover-description { };
-    nova-gazebo = callPackage ./nix/packages/nova-gazebo { };
+    #nova-gazebo = callPackage ./nix/packages/nova-gazebo { };
     nova-python-control = callPackage ./nix/packages/python-control { };
     nova-excavation-construction = callPackage ./nix/packages/excavation-construction { };
     nova-detection-overlay = callPackage ./nix/packages/nova-detection-overlay { };

--- a/src/ros/rover/default.nix
+++ b/src/ros/rover/default.nix
@@ -24,7 +24,7 @@
     nova-auto-bringup = callPackage ./nix/packages/auto-bringup { };
     nova-interfaces = callPackage ./nix/packages/nova-interfaces { };
     nova-rover-description = callPackage ./nix/packages/rover-description { };
-    #nova-gazebo = callPackage ./nix/packages/nova-gazebo { };
+    nova-gazebo = callPackage ./nix/packages/nova-gazebo { };
     nova-python-control = callPackage ./nix/packages/python-control { };
     nova-excavation-construction = callPackage ./nix/packages/excavation-construction { };
     nova-detection-overlay = callPackage ./nix/packages/nova-detection-overlay { };

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -23,7 +23,7 @@
 , nova-costmap-2d
 , nova-pointcloud-filter
 , nova-rover-description
-#, nova-gazebo
+, nova-gazebo
 , nova-auto-interfaces
 , nova-bt-navigators
 , rviz-imu-plugin
@@ -64,7 +64,7 @@ buildRosPackage rec {
       nova-costmap-2d
       nova-pointcloud-filter
       nova-rover-description
-      #nova-gazebo
+      nova-gazebo
       nova-auto-interfaces
       nova-bt-navigators
       rviz-imu-plugin

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -9,9 +9,9 @@
 , robot-state-publisher
 , controller-manager
 , ros2-control
-, gazebo-ros
-, gazebo-ros2-control
-, gazebo-ros-pkgs
+#, gazebo-ros
+#, gazebo-ros2-control
+#, gazebo-ros-pkgs
 , ros2-controllers
 , pluginlib
 , robot-localization
@@ -23,7 +23,7 @@
 , nova-costmap-2d
 , nova-pointcloud-filter
 , nova-rover-description
-, nova-gazebo
+#, nova-gazebo
 , nova-auto-interfaces
 , nova-bt-navigators
 , rviz-imu-plugin
@@ -48,9 +48,9 @@ buildRosPackage rec {
       robot-state-publisher
       controller-manager
       ros2-control
-      gazebo-ros
-      gazebo-ros2-control
-      gazebo-ros-pkgs
+      #gazebo-ros
+      #gazebo-ros2-control
+      #gazebo-ros-pkgs
       ros2-controllers
       aruco-opencv
       aruco-opencv-msgs
@@ -64,7 +64,7 @@ buildRosPackage rec {
       nova-costmap-2d
       nova-pointcloud-filter
       nova-rover-description
-      nova-gazebo
+      #nova-gazebo
       nova-auto-interfaces
       nova-bt-navigators
       rviz-imu-plugin

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -9,6 +9,8 @@
 , robot-state-publisher
 , controller-manager
 , ros2-control
+# TODO: Replace with gazebo harmonic, after migrating the launch files
+# https://gazebosim.org/docs/harmonic/migrating_gazebo_classic_ros2_packages/
 #, gazebo-ros
 #, gazebo-ros2-control
 #, gazebo-ros-pkgs

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -9,11 +9,7 @@
 , robot-state-publisher
 , controller-manager
 , ros2-control
-# TODO: Replace with gazebo harmonic, after migrating the launch files
-# https://gazebosim.org/docs/harmonic/migrating_gazebo_classic_ros2_packages/
-#, gazebo-ros
-#, gazebo-ros2-control
-#, gazebo-ros-pkgs
+, ros-gz
 , ros2-controllers
 , pluginlib
 , robot-localization
@@ -50,9 +46,7 @@ buildRosPackage rec {
       robot-state-publisher
       controller-manager
       ros2-control
-      #gazebo-ros
-      #gazebo-ros2-control
-      #gazebo-ros-pkgs
+      ros-gz
       ros2-controllers
       aruco-opencv
       aruco-opencv-msgs

--- a/src/ros/rover/nix/packages/core/default.nix
+++ b/src/ros/rover/nix/packages/core/default.nix
@@ -13,11 +13,11 @@
 , joint-state-publisher
 , controller-manager
 , ros2-control
-, gazebo-ros
-, gazebo-ros2-control
+#, gazebo-ros
+#, gazebo-ros2-control
 , ros2-controllers
 , pluginlib
-, gazebo-ros-pkgs
+#, gazebo-ros-pkgs
 , robot-localization
 , nova-behavior-tree
 , nova-costmap-2d
@@ -47,13 +47,13 @@ buildRosPackage rec {
       joint-state-publisher
       controller-manager
       ros2-control
-      gazebo-ros
-      gazebo-ros2-control
+      #gazebo-ros
+      #gazebo-ros2-control
       ros2-controllers
       pluginlib
       image-view
       robot-localization
-      gazebo-ros-pkgs
+      #gazebo-ros-pkgs
       navigation2
       depthai-ros;
   };

--- a/src/ros/rover/nix/packages/core/default.nix
+++ b/src/ros/rover/nix/packages/core/default.nix
@@ -13,6 +13,8 @@
 , joint-state-publisher
 , controller-manager
 , ros2-control
+# TODO: Replace with gazebo harmonic, after migrating the launch files
+# https://gazebosim.org/docs/harmonic/migrating_gazebo_classic_ros2_packages/
 #, gazebo-ros
 #, gazebo-ros2-control
 , ros2-controllers

--- a/src/ros/rover/nova_gazebo/worlds/flat.model
+++ b/src/ros/rover/nova_gazebo/worlds/flat.model
@@ -16,11 +16,11 @@
 
     <!-- Random features for visual odometry and obstacle avoidance -->
     
-    <include>
+    <!-- <include>
       <uri>model://ar_tag</uri>
       <pose>2.985127 -4.943043 0 0 -0 0</pose>
     </include>
-   
+    -->
 
     <spherical_coordinates>
       <!-- currently gazebo has a bug: instead of outputting lat, long, altitude in ENU

--- a/src/ros/rover/nova_gazebo/worlds/flat.model
+++ b/src/ros/rover/nova_gazebo/worlds/flat.model
@@ -2,11 +2,15 @@
 <sdf version="1.6">
   <world name="urc_er">
     <include>
-      <uri>model://ground_plane</uri>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Ground Plane
+      </uri>
     </include>
 
     <include>
-      <uri>model://sun</uri>
+      <uri>
+        https://fuel.gazebosim.org/1.0/OpenRobotics/models/Sun
+      </uri>
       <pose>2 -10 10 0.8 -0.8 0</pose>
     </include>
 

--- a/src/ros/rover/rover_description/urdf/depth_camera.xacro
+++ b/src/ros/rover/rover_description/urdf/depth_camera.xacro
@@ -33,7 +33,7 @@ which is how it gets added to the gazebo sim. Author/s: Victor Bartlinski-->
           <far>100.0</far>
         </clip>
       </camera>
-      <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+      <plugin name="gz::sim::systems::Sensors" filename="gz-sim-sensors-system">
         <frame_name>oak_rgb_camera_optical_frame</frame_name>
             <ros>
               <remapping>/oak/image_raw:=/oak/rgb/image_rect</remapping>
@@ -54,7 +54,7 @@ which is how it gets added to the gazebo sim. Author/s: Victor Bartlinski-->
 
   <gazebo reference="oak_imu_frame">
     <sensor name="imu_sensor" type="imu">
-    <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
+    <plugin filename="gz-sim-imu-system" name="gz::sim::systems::Imu">
     <frame_name>oak_imu_frame</frame_name>
         <ros>
           <remapping>~/out:=/oak/imu/transformed</remapping>

--- a/src/ros/rover/rover_description/urdf/gazebo_ros2_control.xacro
+++ b/src/ros/rover/rover_description/urdf/gazebo_ros2_control.xacro
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-    <ros2_control name="GazeboSystem" type="system">
+    <ros2_control name="GazeboSimSystem" type="system">
         <hardware>
-            <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+            <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </hardware>
 
         <joint name='flw'>
@@ -150,7 +150,7 @@
     </ros2_control>
 
     <gazebo>
-        <plugin filename="libgazebo_ros2_control.so" name="gazebo_ros2_control">
+        <plugin filename="libgz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
             <parameters>$(find auto_bringup)/params/controllers.yaml</parameters>
         </plugin>
     </gazebo>

--- a/src/ros/rover/rover_description/urdf/gps.xacro
+++ b/src/ros/rover/rover_description/urdf/gps.xacro
@@ -29,7 +29,7 @@ which is how it gets added to the gazebo sim. Author/s: Dylan Gonzalez-->
 
   <gazebo reference="gps">
     <sensor name="skytraq_gps" type="gps">
-      <plugin filename="libgazebo_ros_gps_sensor.so" name="gps_plugin">
+      <plugin filename="gz-sim-navsat-system" name="gz::sim::systems::NavSat">
         <ros>
           <remapping>~/out:=/fix</remapping>
         </ros>

--- a/src/ros/rover/rover_description/urdf/p3d.xacro
+++ b/src/ros/rover/rover_description/urdf/p3d.xacro
@@ -5,7 +5,7 @@ which is how it gets added to the gazebo sim. Author/s: Victor Bartlinski-->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" >
   
   <gazebo>
-    <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
+    <plugin name="gz::sim::systems::PosePublisher" filename="gz-sim-pose-publisher-system">
       <ros>
         <remapping>odom:=odom/gazebo</remapping>
       </ros>


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Follows [this guide](https://gazebosim.org/docs/harmonic/migrating_gazebo_classic_ros2_packages/) to migrate auto_bringup from Gazebo Classic to Gazebo Harmonic

WIP because running gazebo through ros2 is broken, where it runs `ruby $(which gz) sim-1`. The person who made the PR we are using currently said they changed their launch file to avoid using `ruby $(which gz) sim-1`, but didn't fix it. We either need to fix it, or do the same to the launch files.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
