### PR TITLE
Fix hydra PR inputs

### DIFF
--- a/nixfiles/ci/generation/variation/prs.nix
+++ b/nixfiles/ci/generation/variation/prs.nix
@@ -23,13 +23,13 @@ let
           (pr.base.ref == (if branch == null then pr.base.repo.default_branch else branch)))
         repoPrs)
     [ ]
-    ([ "nova" ] ++ builtins.attrNames allNovaRepos);
+    ([ "nova-monorepo" ] ++ builtins.attrNames allNovaRepos);
 in
 {
   planPrJobsets = name: { description, inputs ? { }, ... }@args:
     let
       # Exclude PRs for repositories that aren't used in the jobset.
-      repoWhitelist = [ "nova" ] ++ builtins.attrNames inputs;
+      repoWhitelist = [ "nova-monorepo" ] ++ builtins.attrNames inputs;
       relevantPrs = builtins.filter (pr: builtins.elem pr.base.repo.name repoWhitelist) novaPrs;
     in
     { ${name} = args; }
@@ -41,7 +41,7 @@ in
           # Replace the input in question with the PR's merge ref.
           ${pr.base.repo.name} = mkGitHubInput {
             owner = pr.head.repo.owner.login;
-            repo = pr.head.repo.name;
+            repo = pkgs.lib.removeSuffix "-monorepo" pr.head.repo.name;
             branch = "pull/${pr.number}/merge";
           };
 

--- a/nixfiles/ci/spec.json
+++ b/nixfiles/ci/spec.json
@@ -21,7 +21,7 @@
             "value": "git@github.com:MonashNovaRover/nova.git",
             "emailresponsible": false
         },
-        "nova-pr-json": {
+        "nova-monorepo-pr-json": {
             "type": "githubpulls",
             "value": "MonashNovaRover nova",
             "emailresponsible": false


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Previously, jobsets for PRs pulled the nova monorepo into an input of the wrong name (`nova` instead of `nova-monorepo`)

https://hydra.novarover.space/eval/303382#tabs-inputs

This change attempts to make this input resolve to a name of `nova-monorepo`, whille still pulling from github.com/MonashNovaRover/nova.git

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

#### Previously: 
![image](https://github.com/user-attachments/assets/211d3aea-f3c1-47b1-b75b-c748609a371a)

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
