### PR TITLE
Fix camera.launch.py

### DIFF
--- a/src/ros/rover/auto_bringup/CMakeLists.txt
+++ b/src/ros/rover/auto_bringup/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(ament_cmake REQUIRED)
 install(DIRECTORY
   launch
   params
+  resources
   rviz
   DESTINATION share/${PROJECT_NAME}
 )

--- a/src/ros/rover/auto_bringup/launch/camera.launch.py
+++ b/src/ros/rover/auto_bringup/launch/camera.launch.py
@@ -1,113 +1,55 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.conditions import IfCondition, LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import LoadComposableNodes, Node, ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes, Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
-    auto_bringup_dir = get_package_share_directory('auto_bringup')
-    depthai_prefix = get_package_share_directory('depthai_ros_driver')
-    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
-
-    camera_model = LaunchConfiguration('camera_model')
     name = LaunchConfiguration('name').perform(context)
-    namespace = LaunchConfiguration('namespace').perform(context)
-    params_file = LaunchConfiguration('params_file')
-    parent_frame = LaunchConfiguration('parent_frame').perform(context)
-    rectify_rgb = LaunchConfiguration('rectify_rgb')
-    use_camera = LaunchConfiguration('use_camera')
-    yolo_file = LaunchConfiguration('yolo_file').perform(context)
+    depthai_prefix = get_package_share_directory('depthai_ros_driver')
+    bringup_dir = get_package_share_directory('auto_bringup')
 
-    parameter_overrides = {
-        "nn": {
-            "i_nn_config_path": yolo_file,
-        },
-    }
+    params_file= LaunchConfiguration('params_file')
+    
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    use_camera = LaunchConfiguration('use_camera')
 
     return [
-        GroupAction(
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                PathJoinSubstitution([depthai_prefix, 'launch', 'camera.launch.py'])),
             condition=IfCondition(use_camera),
-            actions=[
-                IncludeLaunchDescription(
-                    PythonLaunchDescriptionSource(os.path.join(urdf_launch_dir, 'urdf_launch.py')),
-                    launch_arguments={
-                        'namespace': namespace,
-                        'tf_prefix': name,
-                        'camera_model': camera_model,
-                        'base_frame': name,
-                        'parent_frame': parent_frame,
-                        'cam_pos_x': '0.0',
-                        'cam_pos_y': '0.0',
-                        'cam_pos_z': '0.0',
-                        'cam_roll': '0.0',
-                        'cam_pitch': '0.0',
-                        'cam_yaw': '0.0',
-                        'use_composition': 'true',
-                        'use_base_descr': 'false',
-                        'rs_compat': 'false',
-                    }.items()
-                ),
-                ComposableNodeContainer(
-                    name=f'{name}_container',
-                    namespace=namespace,
-                    package='rclcpp_components',
-                    executable='component_container',
-                    composable_node_descriptions=[
-                        ComposableNode(
-                            package='depthai_ros_driver',
-                            plugin='depthai_ros_driver::Camera',
-                            name=name,
-                            namespace=namespace,
-                            parameters=[
-                                params_file,
-                                parameter_overrides])],
-                    arguments=['--ros-args', '--log-level', 'info'],
-                    prefix=[''],
-                    output='both'
-                ),
-                LoadComposableNodes(
-                    condition=IfCondition(rectify_rgb),
-                    target_container=f'{namespace}/{name}_container',
-                    composable_node_descriptions=[
-                        ComposableNode(
-                            package='image_proc',
-                            plugin='image_proc::RectifyNode',
-                            name='rectify_color_node',
-                            namespace=namespace,
-                            remappings=[
-                                ('image', f'{name}/rgb/image_raw'),
-                                ('camera_info', f'{name}/rgb/camera_info'),
-                                ('image_rect', f'{name}/rgb/image_rect'),
-                                ('image_rect/compressed', f'{name}/rgb/image_rect/compressed'),
-                                ('image_rect/compressedDepth', f'{name}/rgb/image_rect/compressedDepth'),
-                                ('image_rect/theora', f'{name}/rgb/image_rect/theora')])],
-                )]
-        ),
+            launch_arguments={"name": name,
+                              "parent_frame": "camera_link",
+                              "params_file": params_file,
+                              "camera_model": "OAK-D-LR"}.items()),
+
         LoadComposableNodes(
-            condition=IfCondition(rectify_rgb),
-            target_container=f'{name}_container',
+            condition=IfCondition(LaunchConfiguration("rectify_rgb")),
+            target_container=name+"_container",
             composable_node_descriptions=[
                 ComposableNode(
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzNode',
                     name='point_cloud_xyz',
-                    remappings=[('image_rect', f'{name}/stereo/image_filtered'),
-                                ('camera_info', f'{name}/stereo/camera_info'),
-                                ('points', f'{name}/points')
+                    remappings=[('image_rect', name+'/stereo/image_filtered'),
+                                ('camera_info', name+'/stereo/camera_info'),
+                                ('points', name+'/points')
                                 ]),
             ]),
+
         Node(
             condition=IfCondition(LaunchConfiguration('use_camera')),
             package='nova_pointcloud_filter',
             executable='depth_filter',
             name='depth_filter',
-            remappings=[('/depth/image', f'{name}/stereo/image_raw'),
-                        ('/depth/image_filtered', f'{name}/stereo/image_filtered'),
+            remappings=[('/depth/image', name+'/stereo/image_raw'),
+                        ('/depth/image_filtered', name+'/stereo/image_filtered'),
                         ],
             parameters=[{'t_filter': 0, 'r_filter': 0, 'b_filter': 75, 'l_filter': 0, }] 
         ),
@@ -115,7 +57,7 @@ def launch_setup(context, *args, **kwargs):
             condition=IfCondition(LaunchConfiguration('ar_tag')),
             package='aruco_opencv',
             executable='aruco_tracker_autostart',
-            arguments=['--ros-args', '--params-file', PathJoinSubstitution([auto_bringup_dir, 'params', 'aruco_tracker.yaml'])],
+            arguments=['--ros-args', '--params-file', PathJoinSubstitution([bringup_dir, 'params', 'aruco_tracker.yaml'])],
         ),
         Node(
             package='imu_transformer',
@@ -130,21 +72,18 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    auto_bringup_prefix = get_package_share_directory('auto_bringup')
+    auto_bringup_prefix = FindPackageShare('auto_bringup')
     declared_arguments = [
-        DeclareLaunchArgument('ar_tag', default_value='true'),
-        DeclareLaunchArgument('camera_model', default_value='OAK-D-LR'),
         DeclareLaunchArgument('name', default_value='oak'),
-        DeclareLaunchArgument('namespace', default_value=''),
         DeclareLaunchArgument('params_file', default_value=PathJoinSubstitution([auto_bringup_prefix, 'params', 'depthai_oakd_rgbd.yaml'])),
-        DeclareLaunchArgument('parameter_overrides', default_value=''),
-        DeclareLaunchArgument('parent_frame', default_value='camera_link'),
-        DeclareLaunchArgument('rectify_rgb', default_value='true'),
-        DeclareLaunchArgument('rtabmap_pointcloud', default_value='true'),
-        DeclareLaunchArgument('use_camera', default_value='true'),
-        DeclareLaunchArgument('yolo_file', default_value=os.path.join(auto_bringup_prefix, 'resources', 'URC_V5', 'URC_V5.json')),
+        DeclareLaunchArgument('rectify_rgb', default_value='True'),
+        DeclareLaunchArgument('use_sim_time', default_value='False'),
+        DeclareLaunchArgument('rtabmap_pointcloud', default_value='True'),
+        DeclareLaunchArgument('ar_tag', default_value='True'),
+        DeclareLaunchArgument('use_camera', default_value='True'),
     ]
 
     return LaunchDescription(  
         declared_arguments + [OpaqueFunction(function=launch_setup)]
     )
+    

--- a/src/ros/rover/auto_bringup/launch/camera.launch.py
+++ b/src/ros/rover/auto_bringup/launch/camera.launch.py
@@ -1,4 +1,17 @@
-import os
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Execute this code on the rover to start all
+   auto camera scripts.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NODES:
+  - 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE: 	auto_bringup
+CREATION:	13/11/2024
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
@@ -10,46 +23,44 @@ from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
-    name = LaunchConfiguration('name').perform(context)
-    depthai_prefix = get_package_share_directory('depthai_ros_driver')
-    bringup_dir = get_package_share_directory('auto_bringup')
+    auto_bringup_dir = get_package_share_directory('auto_bringup')
+    depthai_dir = get_package_share_directory('depthai_ros_driver')
 
-    params_file= LaunchConfiguration('params_file')
-    
-    use_sim_time = LaunchConfiguration('use_sim_time')
+    camera_model = LaunchConfiguration('camera_model').perform(context)
+    name = LaunchConfiguration('name').perform(context)
+    params_file = LaunchConfiguration('params_file')
+    parent_frame = LaunchConfiguration('parent_frame').perform(context)
     use_camera = LaunchConfiguration('use_camera')
 
     return [
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                PathJoinSubstitution([depthai_prefix, 'launch', 'camera.launch.py'])),
+            PythonLaunchDescriptionSource(PathJoinSubstitution([depthai_dir, 'launch', 'camera.launch.py'])),
             condition=IfCondition(use_camera),
-            launch_arguments={"name": name,
-                              "parent_frame": "camera_link",
-                              "params_file": params_file,
-                              "camera_model": "OAK-D-LR"}.items()),
-
+            launch_arguments={'name': name,
+                              'parent_frame': parent_frame,
+                              'params_file': params_file,
+                              'camera_model': camera_model}.items()
+        ),
         LoadComposableNodes(
-            condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            condition=IfCondition(LaunchConfiguration('rectify_rgb')),
+            target_container=name+'_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzNode',
                     name='point_cloud_xyz',
-                    remappings=[('image_rect', name+'/stereo/image_filtered'),
-                                ('camera_info', name+'/stereo/camera_info'),
-                                ('points', name+'/points')
+                    remappings=[('image_rect', f'{name}/stereo/image_filtered'),
+                                ('camera_info', f'{name}/stereo/camera_info'),
+                                ('points', f'{name}/points')
                                 ]),
-            ]),
-
+        ]),
         Node(
             condition=IfCondition(LaunchConfiguration('use_camera')),
             package='nova_pointcloud_filter',
             executable='depth_filter',
             name='depth_filter',
-            remappings=[('/depth/image', name+'/stereo/image_raw'),
-                        ('/depth/image_filtered', name+'/stereo/image_filtered'),
+            remappings=[('/depth/image', f'{name}/stereo/image_raw'),
+                        ('/depth/image_filtered', f'{name}/stereo/image_filtered'),
                         ],
             parameters=[{'t_filter': 0, 'r_filter': 0, 'b_filter': 75, 'l_filter': 0, }] 
         ),
@@ -57,7 +68,7 @@ def launch_setup(context, *args, **kwargs):
             condition=IfCondition(LaunchConfiguration('ar_tag')),
             package='aruco_opencv',
             executable='aruco_tracker_autostart',
-            arguments=['--ros-args', '--params-file', PathJoinSubstitution([bringup_dir, 'params', 'aruco_tracker.yaml'])],
+            arguments=['--ros-args', '--params-file', PathJoinSubstitution([auto_bringup_dir, 'params', 'aruco_tracker.yaml'])],
         ),
         Node(
             package='imu_transformer',
@@ -72,12 +83,13 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    auto_bringup_prefix = FindPackageShare('auto_bringup')
+    auto_bringup_dir = FindPackageShare('auto_bringup')
     declared_arguments = [
         DeclareLaunchArgument('name', default_value='oak'),
-        DeclareLaunchArgument('params_file', default_value=PathJoinSubstitution([auto_bringup_prefix, 'params', 'depthai_oakd_rgbd.yaml'])),
+        DeclareLaunchArgument('parent_frame', default_value='camera_link'),
+        DeclareLaunchArgument('camera_model', default_value='OAK-D-LR'),
+        DeclareLaunchArgument('params_file', default_value=PathJoinSubstitution([auto_bringup_dir, 'params', 'depthai_oakd_rgbd.yaml'])),
         DeclareLaunchArgument('rectify_rgb', default_value='True'),
-        DeclareLaunchArgument('use_sim_time', default_value='False'),
         DeclareLaunchArgument('rtabmap_pointcloud', default_value='True'),
         DeclareLaunchArgument('ar_tag', default_value='True'),
         DeclareLaunchArgument('use_camera', default_value='True'),

--- a/src/ros/rover/auto_bringup/launch/camera.launch.py
+++ b/src/ros/rover/auto_bringup/launch/camera.launch.py
@@ -86,4 +86,3 @@ def generate_launch_description():
     return LaunchDescription(  
         declared_arguments + [OpaqueFunction(function=launch_setup)]
     )
-    

--- a/src/ros/rover/auto_bringup/launch/camera.launch.py
+++ b/src/ros/rover/auto_bringup/launch/camera.launch.py
@@ -1,55 +1,113 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction
 from launch.conditions import IfCondition, LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import LoadComposableNodes, Node
+from launch_ros.actions import LoadComposableNodes, Node, ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
-    name = LaunchConfiguration('name').perform(context)
+    auto_bringup_dir = get_package_share_directory('auto_bringup')
     depthai_prefix = get_package_share_directory('depthai_ros_driver')
-    bringup_dir = get_package_share_directory('auto_bringup')
+    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_descriptions'), 'launch')
 
-    params_file= LaunchConfiguration('params_file')
-    
-    use_sim_time = LaunchConfiguration('use_sim_time')
+    camera_model = LaunchConfiguration('camera_model')
+    name = LaunchConfiguration('name').perform(context)
+    namespace = LaunchConfiguration('namespace').perform(context)
+    params_file = LaunchConfiguration('params_file')
+    parent_frame = LaunchConfiguration('parent_frame').perform(context)
+    rectify_rgb = LaunchConfiguration('rectify_rgb')
     use_camera = LaunchConfiguration('use_camera')
+    yolo_file = LaunchConfiguration('yolo_file').perform(context)
+
+    parameter_overrides = {
+        "nn": {
+            "i_nn_config_path": yolo_file,
+        },
+    }
 
     return [
-        IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                PathJoinSubstitution([depthai_prefix, 'launch', 'camera.launch.py'])),
+        GroupAction(
             condition=IfCondition(use_camera),
-            launch_arguments={"name": name,
-                              "parent_frame": "camera_link",
-                              "params_file": params_file,
-                              "camera_model": "OAK-D-LR"}.items()),
-
+            actions=[
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(os.path.join(urdf_launch_dir, 'urdf_launch.py')),
+                    launch_arguments={
+                        'namespace': namespace,
+                        'tf_prefix': name,
+                        'camera_model': camera_model,
+                        'base_frame': name,
+                        'parent_frame': parent_frame,
+                        'cam_pos_x': '0.0',
+                        'cam_pos_y': '0.0',
+                        'cam_pos_z': '0.0',
+                        'cam_roll': '0.0',
+                        'cam_pitch': '0.0',
+                        'cam_yaw': '0.0',
+                        'use_composition': 'true',
+                        'use_base_descr': 'false',
+                        'rs_compat': 'false',
+                    }.items()
+                ),
+                ComposableNodeContainer(
+                    name=f'{name}_container',
+                    namespace=namespace,
+                    package='rclcpp_components',
+                    executable='component_container',
+                    composable_node_descriptions=[
+                        ComposableNode(
+                            package='depthai_ros_driver',
+                            plugin='depthai_ros_driver::Camera',
+                            name=name,
+                            namespace=namespace,
+                            parameters=[
+                                params_file,
+                                parameter_overrides])],
+                    arguments=['--ros-args', '--log-level', 'info'],
+                    prefix=[''],
+                    output='both'
+                ),
+                LoadComposableNodes(
+                    condition=IfCondition(rectify_rgb),
+                    target_container=f'{namespace}/{name}_container',
+                    composable_node_descriptions=[
+                        ComposableNode(
+                            package='image_proc',
+                            plugin='image_proc::RectifyNode',
+                            name='rectify_color_node',
+                            namespace=namespace,
+                            remappings=[
+                                ('image', f'{name}/rgb/image_raw'),
+                                ('camera_info', f'{name}/rgb/camera_info'),
+                                ('image_rect', f'{name}/rgb/image_rect'),
+                                ('image_rect/compressed', f'{name}/rgb/image_rect/compressed'),
+                                ('image_rect/compressedDepth', f'{name}/rgb/image_rect/compressedDepth'),
+                                ('image_rect/theora', f'{name}/rgb/image_rect/theora')])],
+                )]
+        ),
         LoadComposableNodes(
-            condition=IfCondition(LaunchConfiguration("rectify_rgb")),
-            target_container=name+"_container",
+            condition=IfCondition(rectify_rgb),
+            target_container=f'{name}_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='depth_image_proc',
                     plugin='depth_image_proc::PointCloudXyzNode',
                     name='point_cloud_xyz',
-                    remappings=[('image_rect', name+'/stereo/image_filtered'),
-                                ('camera_info', name+'/stereo/camera_info'),
-                                ('points', name+'/points')
+                    remappings=[('image_rect', f'{name}/stereo/image_filtered'),
+                                ('camera_info', f'{name}/stereo/camera_info'),
+                                ('points', f'{name}/points')
                                 ]),
             ]),
-
         Node(
             condition=IfCondition(LaunchConfiguration('use_camera')),
             package='nova_pointcloud_filter',
             executable='depth_filter',
             name='depth_filter',
-            remappings=[('/depth/image', name+'/stereo/image_raw'),
-                        ('/depth/image_filtered', name+'/stereo/image_filtered'),
+            remappings=[('/depth/image', f'{name}/stereo/image_raw'),
+                        ('/depth/image_filtered', f'{name}/stereo/image_filtered'),
                         ],
             parameters=[{'t_filter': 0, 'r_filter': 0, 'b_filter': 75, 'l_filter': 0, }] 
         ),
@@ -57,7 +115,7 @@ def launch_setup(context, *args, **kwargs):
             condition=IfCondition(LaunchConfiguration('ar_tag')),
             package='aruco_opencv',
             executable='aruco_tracker_autostart',
-            arguments=['--ros-args', '--params-file', PathJoinSubstitution([bringup_dir, 'params', 'aruco_tracker.yaml'])],
+            arguments=['--ros-args', '--params-file', PathJoinSubstitution([auto_bringup_dir, 'params', 'aruco_tracker.yaml'])],
         ),
         Node(
             package='imu_transformer',
@@ -72,15 +130,19 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-    auto_bringup_prefix = FindPackageShare('auto_bringup')
+    auto_bringup_prefix = get_package_share_directory('auto_bringup')
     declared_arguments = [
+        DeclareLaunchArgument('ar_tag', default_value='true'),
+        DeclareLaunchArgument('camera_model', default_value='OAK-D-LR'),
         DeclareLaunchArgument('name', default_value='oak'),
+        DeclareLaunchArgument('namespace', default_value=''),
         DeclareLaunchArgument('params_file', default_value=PathJoinSubstitution([auto_bringup_prefix, 'params', 'depthai_oakd_rgbd.yaml'])),
-        DeclareLaunchArgument('rectify_rgb', default_value='True'),
-        DeclareLaunchArgument('use_sim_time', default_value='False'),
-        DeclareLaunchArgument('rtabmap_pointcloud', default_value='True'),
-        DeclareLaunchArgument('ar_tag', default_value='True'),
-        DeclareLaunchArgument('use_camera', default_value='True'),
+        DeclareLaunchArgument('parameter_overrides', default_value=''),
+        DeclareLaunchArgument('parent_frame', default_value='camera_link'),
+        DeclareLaunchArgument('rectify_rgb', default_value='true'),
+        DeclareLaunchArgument('rtabmap_pointcloud', default_value='true'),
+        DeclareLaunchArgument('use_camera', default_value='true'),
+        DeclareLaunchArgument('yolo_file', default_value=os.path.join(auto_bringup_prefix, 'resources', 'URC_V5', 'URC_V5.json')),
     ]
 
     return LaunchDescription(  

--- a/src/ros/rover/auto_bringup/params/aruco_tracker.yaml
+++ b/src/ros/rover/auto_bringup/params/aruco_tracker.yaml
@@ -22,7 +22,7 @@
       perspectiveRemovePixelPerCell: 4
       polygonalApproxAccuracyRate: 0.03
     board_descriptions_path: ''
-    cam_base_topic: /oak/right/image_rect
+    cam_base_topic: /oak/rgb/image_rect
     image_is_rectified: true # Only true if subscribed to '/oak/rgb/image_rect' or rectified-image equivalent.
     image_sub_qos:
       depth: 1

--- a/src/ros/rover/auto_bringup/params/aruco_tracker.yaml
+++ b/src/ros/rover/auto_bringup/params/aruco_tracker.yaml
@@ -22,7 +22,7 @@
       perspectiveRemovePixelPerCell: 4
       polygonalApproxAccuracyRate: 0.03
     board_descriptions_path: ''
-    cam_base_topic: /oak/rgb/image_rect
+    cam_base_topic: /oak/right/image_rect
     image_is_rectified: true # Only true if subscribed to '/oak/rgb/image_rect' or rectified-image equivalent.
     image_sub_qos:
       depth: 1

--- a/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
+++ b/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
@@ -7,7 +7,6 @@
       i_disable_resize: true
       i_num_inference_threads: 2
       i_num_pool_frames: 4
-      i_nn_config_path: /home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
     imu:
       i_enable_rotation: true
       i_message_type: IMU

--- a/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
+++ b/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
@@ -7,6 +7,7 @@
       i_disable_resize: true
       i_num_inference_threads: 2
       i_num_pool_frames: 4
+      i_nn_config_path: auto_bringup/resources/URC_V5/URC_V5.json
     imu:
       i_enable_rotation: true
       i_message_type: IMU

--- a/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
+++ b/src/ros/rover/auto_bringup/params/depthai_oakd_rgbd.yaml
@@ -7,7 +7,7 @@
       i_disable_resize: true
       i_num_inference_threads: 2
       i_num_pool_frames: 4
-      i_nn_config_path: src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
+      i_nn_config_path: /home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
     imu:
       i_enable_rotation: true
       i_message_type: IMU
@@ -20,6 +20,8 @@
       i_preview_size: 640
       i_preview_width: 640 #300
       i_width: 1280
+      i_isp_den: 3
+      i_isp_num: 2
     left:
       i_set_isp_scale: true
       i_fps: 5.0

--- a/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
+++ b/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
@@ -1,7 +1,7 @@
 {
     "model": {
         "xml": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.xml",
-        "bin": "/home/nova/nova/src/ros/rover/core/auto_bringup/URC_V5/URC_V5.bin",
+        "bin": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.bin",
         "model_name": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
         "zoo": "path"
     },

--- a/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
+++ b/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
@@ -1,8 +1,8 @@
 {
     "model": {
-        "xml": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.xml",
-        "bin": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.bin",
-        "model_name": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
+        "xml": "auto_bringup/resources/URC_V5/URC_V5.xml",
+        "bin": "auto_bringup/resources/URC_V5/URC_V5.bin",
+        "model_name": "auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
         "zoo": "path"
     },
     "nn_config": {

--- a/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
+++ b/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.json
@@ -1,8 +1,8 @@
 {
     "model": {
-        "xml": "src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.xml",
-        "bin": "src/ros/rover/core/auto_bringup/URC_V5/URC_V5.bin",
-        "model_name": "src/ros/rover/auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
+        "xml": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5.xml",
+        "bin": "/home/nova/nova/src/ros/rover/core/auto_bringup/URC_V5/URC_V5.bin",
+        "model_name": "/home/nova/nova/src/ros/rover/auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
         "zoo": "path"
     },
     "nn_config": {

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -1,4 +1,5 @@
 { lib
+, pkgs
 , buildRosPackage
 , ament-cmake
 , launch
@@ -68,4 +69,32 @@ buildRosPackage rec {
       nova-pivot-drive-controller
       imu-transformer;
   };
+
+  # After installing params and resources folders in nix store's auto_bringup, 
+  # we need to generate absolute filepaths for files in that auto_bringup, to 
+  # point to the nix store's folders
+  buildInputs = [ pkgs.jq pkgs.yq ];
+  postInstall = ''
+    # Generate absolute nix store filepaths for JSON files
+    jsonFilepath="$out/share/auto_bringup/resources/URC_V5/URC_V5.json"
+    jsonFile=$(cat $jsonFilepath)
+
+    updatedJsonFile=$(echo "$jsonFile" | jq --arg out "$out" '. + {
+      model: {
+        bin: "\($out)/share/auto_bringup/resources/URC_V5/URC_V5.bin",
+        model_name: "\($out)/share/auto_bringup/resources/URC_V5/URC_V5_openvino_2022.1_5shave.blob",
+        xml: "\($out)/share/auto_bringup/resources/URC_V5/URC_V5.xml",
+        zoo: "path"
+      }
+    }')
+
+    echo "$updatedJsonFile" > $jsonFilepath
+
+    # Generate absolute nix store filepaths for YAML files
+    yamlFilepath="$out/share/auto_bringup/params/depthai_oakd_rgbd.yaml"
+
+    yq -y -i "
+      .\"/oak\".ros__parameters.nn.i_nn_config_path = \"$jsonFilepath\"
+    " $yamlFilepath
+  '';
 }


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Initially just to fix a few minor changes causing the oak nodes to fail, @hacker1024 pointed out I shouldn't be using absolute filepaths based off my own file system structure. 

These filepaths are used in parameters for the oak camera (depthai_oakd_rgbd.yaml) and the camera's nn model (.json files), and need to be absolute (relative filepaths would be independent of file system structure, but would require users to always launch from a specific directory, which sucks). 

Because YAML and JSON (as far as I can tell) don't support any way to natively generate absolute filepaths, and filepaths can't be generated after being built into the nix store (nix store is a read-only file system), I've made a change during the postInstall phase of auto_bringup to manually overwrite those values with absolute paths dependent on the nix store hash (which will always be present).


<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

- `ws-build`
- Check the parameter values for the relevant yaml and json files in `result/share/auto_bringup`
- Enter `result/bin/ros2 launch auto_bringup camera.launch.py` and make sure it works (no errors or unexpected behaviour)

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

![image](https://github.com/user-attachments/assets/8f4227fa-5b0d-4d8d-910c-dcd66ef2c7c8)


<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
