### PR TITLE
Merge Fix/nav2 rviz plugins

### DIFF
--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -148,6 +148,7 @@ self: super:
 
       nav2-rviz-plugins = rosSuper.nav2-rviz-plugins.overrideAttrs ({ postPatch ? "", ... }: {
         # remove broken updateAutoDeactivate() symbol, 20/11/2024, Navigation2 1.3.2
+        # https://github.com/MonashNovaRover/nova/issues/96
         postPatch = postPatch + ''
           substituteInPlace src/costmap_cost_tool.cpp --replace "SLOT(updateAutoDeactivate())" "nullptr"
           substituteInPlace include/nav2_rviz_plugins/costmap_cost_tool.hpp --replace "private Q_SLOTS:" "" 

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -145,6 +145,22 @@ self: super:
           substituteInPlace CMakeLists.txt --replace 'find_package(octomap 1.9.7...<1.10.0 REQUIRED)' 'find_package(octomap 1.9.7...1.10.0 REQUIRED)'
         '';
       });
+
+      nav2-rviz-plugins = rosSuper.nav2-rviz-plugins.overrideAttrs ({ postPatch ? "", ... }: {
+          #src = self.fetchFromGitHub {
+          #  owner = "ros-navigation";
+          #  repo = "navigation2";
+          #  rev = "3140a6a65c2ecbcf975dac94e3f3c64c0d9efc84"; # jazzy 1.3.3
+          #  sha256 = "sha256-3140a6a65c2ecbcf975dac94e3f3c64c0d9efc84=";
+          #};
+        postPatch = postPatch + ''
+          ls
+          echo "rviz plugin was patched rohit is cool :D"
+          substituteInPlace src/costmap_cost_tool.cpp --replace "SLOT(updateAutoDeactivate())" "nullptr"
+          cat src/costmap_cost_tool.cpp
+        '';
+      });
+
     } // (
       let
         fixRtabmapDependent = pkg: pkg.overrideAttrs ({ buildInputs ? [ ], ... }: {

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -152,8 +152,6 @@ self: super:
           substituteInPlace src/costmap_cost_tool.cpp --replace "SLOT(updateAutoDeactivate())" "nullptr"
           substituteInPlace include/nav2_rviz_plugins/costmap_cost_tool.hpp --replace "private Q_SLOTS:" "" 
           substituteInPlace include/nav2_rviz_plugins/costmap_cost_tool.hpp --replace "void updateAutoDeactivate();" ""
-          cat include/nav2_rviz_plugins/costmap_cost_tool.hpp
-          echo "nav2_rviz_plugin was patched, removing broken updateAutoDeactivate() symbol | rohit is cool :D"
         '';
       });
 

--- a/nixfiles/overlay/ros/maintanence.nix
+++ b/nixfiles/overlay/ros/maintanence.nix
@@ -147,17 +147,13 @@ self: super:
       });
 
       nav2-rviz-plugins = rosSuper.nav2-rviz-plugins.overrideAttrs ({ postPatch ? "", ... }: {
-          #src = self.fetchFromGitHub {
-          #  owner = "ros-navigation";
-          #  repo = "navigation2";
-          #  rev = "3140a6a65c2ecbcf975dac94e3f3c64c0d9efc84"; # jazzy 1.3.3
-          #  sha256 = "sha256-3140a6a65c2ecbcf975dac94e3f3c64c0d9efc84=";
-          #};
+        # remove broken updateAutoDeactivate() symbol, 20/11/2024, Navigation2 1.3.2
         postPatch = postPatch + ''
-          ls
-          echo "rviz plugin was patched rohit is cool :D"
           substituteInPlace src/costmap_cost_tool.cpp --replace "SLOT(updateAutoDeactivate())" "nullptr"
-          cat src/costmap_cost_tool.cpp
+          substituteInPlace include/nav2_rviz_plugins/costmap_cost_tool.hpp --replace "private Q_SLOTS:" "" 
+          substituteInPlace include/nav2_rviz_plugins/costmap_cost_tool.hpp --replace "void updateAutoDeactivate();" ""
+          cat include/nav2_rviz_plugins/costmap_cost_tool.hpp
+          echo "nav2_rviz_plugin was patched, removing broken updateAutoDeactivate() symbol | rohit is cool :D"
         '';
       });
 


### PR DESCRIPTION
Fixes the nav2_rviz_plugins so that they are no longer brokey.

## Description

This removes all mention of the ` updateAutoDeactivate()` function from the c++ code as it was causing issues loading the plugins in rviz.

details here: https://www.notion.so/Figure-out-why-rviz-nav2-plugins-are-brokey-3f104d21bc9c4881ba702ab44a1cbfdf

## Changelogs

maintanence.nix has some added code to modify the postPatch phase of building the package.

## Screenshots

![image](https://github.com/user-attachments/assets/0e6de88a-2b99-4a8c-a440-6a151b7853c1)

## Steps to Test

run `ros2 launch auto_bringup rviz.launch.py` and enjoy the now working nav2 panel 
or run `ros2 run rviz2 rviz2` and attempt to use any of the nav2 plugins 

## Memes
[Me when i copy rohit's moveit2 nix code](https://www.youtube.com/shorts/H3MgcNJG8J8)

Thanks Rohit for teaching me how to patch with nix!