### PR TITLE
Adding optional support for teleop to base and drive

### DIFF
--- a/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller_parameter.yaml
+++ b/src/ros/rover/controllers/nova_diff_drive_controller/src/nova_diff_drive_controller_parameter.yaml
@@ -21,22 +21,22 @@ nova_diff_drive_controller:
   }
   steering_track: {
     type: double,
-    default_value: 0.0,
+    default_value: 0.65274049,
     description: "Shortest distance between the left and right wheels. If this parameter is wrong, the robot will not behave correctly in curves.",
   }
   wheel_base: {
     type: double,
-    default_value: 0.0,
+    default_value: 0.64565131,
     description: "Shortest distance between the front and rear wheels. If this parameter is wrong, the robot will not behave correctly in curves.",
   }
   wheels_per_side: {
     type: int,
-    default_value: 0,
+    default_value: 2,
     description: "Number of wheels on each side of the robot. This is important to take the wheels slip into account when multiple wheels on each side are present. If there are more wheels then control signals for each side, you should enter number for control signals. For example, Husky has two wheels on each side, but they use one control signal, in this case '1' is the correct value of the parameter.",
   }
   wheel_radius: {
     type: double,
-    default_value: 0.0,
+    default_value: 0.15692321,
     description: "Radius of a wheel, i.e., wheels size, used for transformation of linear velocity into wheel rotations. If this parameter is wrong the robot will move faster or slower then expected.",
   }
   wheel_separation_multiplier: {
@@ -121,7 +121,7 @@ nova_diff_drive_controller:
   }
   enable_twist_cmd: {
     type: bool,
-    default_value: true,
+    default_value: false,
     description: "Subscribe to TwistStamped or DriveInputStamped",
   }
 

--- a/src/ros/rover/nova_bringup/launch/base.launch.py
+++ b/src/ros/rover/nova_bringup/launch/base.launch.py
@@ -1,4 +1,4 @@
-"""
+'''
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Monash Nova Rover Team
 
@@ -12,76 +12,83 @@ NODES:
 PACKAGE: 	core
 CREATION:	15/12/2021
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-
-# Include the required launch parameters
+'''
 from launch import LaunchDescription
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.substitutions import FindPackageShare
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch_ros.actions import Node
+from launch.conditions import UnlessCondition, IfCondition
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.conditions import IfCondition
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
-# Generate the launch file with all inputs
-def generate_launch_description():
-    description_dir = FindPackageShare('rover_description')
-    gazebo = LaunchConfiguration('gazebo', default=False)
+def launch_setup(context, *args, **kwargs):
+    nova_bringup_dir = FindPackageShare('nova_bringup')
+    teleop_drive_joy_dir = FindPackageShare('teleop_drive_joy')
+    
+    arm_urdf = LaunchConfiguration('arm_urdf')
+    arm_urdf_path = LaunchConfiguration('arm_urdf_path')
+    rover_urdf = LaunchConfiguration('rover_urdf')
+    teleop = LaunchConfiguration('teleop')
+    urdf = LaunchConfiguration('urdf')
 
-    return LaunchDescription([
-        DeclareLaunchArgument(
-            'arm_urdf', 
-            default_value='True',
-            description="Include arm URDF in robot_description?"
+    return [
+        GroupAction(
+            condition=UnlessCondition(teleop),
+            actions=[
+                Node(
+                    package='inputs',
+                    executable='inputs_publisher',
+                    output='screen',
+                    emulate_tty=True,
+                    parameters=[{'use_sim_time': False}],
+                ),
+                IncludeLaunchDescription(
+                    condition=IfCondition(urdf),
+                    launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([nova_bringup_dir, 'launch', 'urdf.launch.py'])),
+                    launch_arguments = {
+                        'arm_urdf_path': arm_urdf_path,
+                        'arm': arm_urdf,
+                        'rover': rover_urdf,
+                    }.items(),
+                ),
+            ],
         ),
-
-        DeclareLaunchArgument(
-            'rover_urdf', 
-            default_value='True',
-            description="Include rover URDF in robot_description?"
-        ),
-                              
-        DeclareLaunchArgument(
-            'urdf', 
-            default_value='False',
-            description="Publish robot_description?"
-        ),
-
-        DeclareLaunchArgument(
-            'arm_urdf_path', 
-            default_value = PathJoinSubstitution(
-                [
-                    description_dir, 
-                    'arm',
-                    'urdf', 
-                    'arm.urdf.xacro'
-                ]
-            ), 
-        ),
-
-        Node(
-            package='inputs',
-            executable='inputs_publisher',
-            output='screen',
-            emulate_tty=True,
-            parameters=[{'use_sim_time': gazebo}]
-        ),
-
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource(
-                PathJoinSubstitution(
-                    [
-                        FindPackageShare('nova_bringup'),
-                        'launch',
-                        'urdf.launch.py'
-                    ]
-                )
-            ),
-            launch_arguments = {
-                "arm_urdf_path": LaunchConfiguration('arm_urdf_path'),
-                "arm": LaunchConfiguration('arm_urdf'),
-                "rover": LaunchConfiguration('rover_urdf')
-            }.items(),
-            condition=IfCondition(LaunchConfiguration('urdf'))
+            condition=IfCondition(teleop),
+            launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([teleop_drive_joy_dir, 'launch', 'teleop.launch.py'])),
         ),
-    ])
+    ]
+
+def generate_launch_description():
+    rover_description_dir = FindPackageShare('rover_description')
+
+    declared_arguments = [      
+        DeclareLaunchArgument(
+            name='arm_urdf', 
+            default_value='False',
+            description='Include arm URDF in robot_description?',
+        ),
+        DeclareLaunchArgument(
+            name='arm_urdf_path', 
+            default_value = PathJoinSubstitution([rover_description_dir, 'arm', 'urdf', 'arm.urdf.xacro']), 
+        ),
+        DeclareLaunchArgument(
+            name='rover_urdf', 
+            default_value='True',
+            description='Include rover URDF in robot_description?',
+        ),
+        DeclareLaunchArgument(
+            name='teleop', 
+            default_value='False',
+            description='Use ROS2 Controllers?',
+        ),
+        DeclareLaunchArgument(
+            name='urdf', 
+            default_value='False',
+            description='Publish robot_description?',
+        ),
+    ]
+
+    return LaunchDescription(  
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/src/ros/rover/nova_bringup/launch/drive.launch.py
+++ b/src/ros/rover/nova_bringup/launch/drive.launch.py
@@ -29,7 +29,6 @@ def launch_setup(context, *args, **kwargs):
     controllers = LaunchConfiguration('controllers')
     rover_urdf = LaunchConfiguration('rover_urdf')
     teleop = LaunchConfiguration('teleop')
-    urdf = LaunchConfiguration('urdf')
 
     return [
         GroupAction(
@@ -105,11 +104,6 @@ def generate_launch_description():
 
     declared_arguments = [      
         DeclareLaunchArgument(
-            name='controllers',
-            default_value=PathJoinSubstitution([nova_bringup_dir, 'params', 'controllers.yaml']),
-            description='Absolute path to controller params file',
-        ),
-        DeclareLaunchArgument(
             name='arm_urdf', 
             default_value='False',
             description='Include arm URDF in robot_description?',
@@ -117,6 +111,11 @@ def generate_launch_description():
         DeclareLaunchArgument(
             name='arm_urdf_path', 
             default_value = PathJoinSubstitution([rover_description_dir, 'arm', 'urdf', 'arm.urdf.xacro']), 
+        ),
+        DeclareLaunchArgument(
+            name='controllers',
+            default_value=PathJoinSubstitution([nova_bringup_dir, 'params', 'controllers.yaml']),
+            description='Absolute path to controller params file',
         ),
         DeclareLaunchArgument(
             name='rover_urdf', 

--- a/src/ros/rover/nova_bringup/launch/drive.launch.py
+++ b/src/ros/rover/nova_bringup/launch/drive.launch.py
@@ -1,4 +1,4 @@
-"""
+'''
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Monash Nova Rover Team
 
@@ -12,29 +12,124 @@ NODES:
 PACKAGE: 	core
 CREATION:	15/12/2021
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-
-# Include the required launch parameters
+'''
 from launch import LaunchDescription
-from launch.substitutions import LaunchConfiguration
-from launch.conditions import UnlessCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, GroupAction, IncludeLaunchDescription
+from launch.conditions import UnlessCondition, IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
+def launch_setup(context, *args, **kwargs):
+    nova_bringup_dir = FindPackageShare('nova_bringup')
 
-# Generate the launch file with all inputs
-def generate_launch_description():
-    gazebo = LaunchConfiguration('gazebo', default=False)
-    return LaunchDescription([
-        Node(
-            package='drive', executable='drive_inputs', output='screen', emulate_tty=True,
-            parameters=[{'use_sim_time': gazebo}]),
-        Node(
-            package='drive', executable='driver', output='screen', emulate_tty=True,
-            parameters=[{'use_sim_time': gazebo, 'gazebo': gazebo}]),
-        Node(
-            package='blcmd_utils', executable='status_monitor', output='screen', emulate_tty=True,
+    arm_urdf = LaunchConfiguration('arm_urdf')
+    arm_urdf_path = LaunchConfiguration('arm_urdf_path')
+    controllers = LaunchConfiguration('controllers')
+    rover_urdf = LaunchConfiguration('rover_urdf')
+    teleop = LaunchConfiguration('teleop')
+    urdf = LaunchConfiguration('urdf')
+
+    return [
+        GroupAction(
+            condition=IfCondition(teleop),
+            actions=[
+                Node(
+                    package='blcmd_utils', 
+                    executable='status_monitor', 
+                    output='screen', 
+                    emulate_tty=True,
+                ),
+                Node(
+                    package='controller_manager',
+                    executable='spawner',
+                    arguments=['pivot_drive_controller', '--switch-timeout', '10'],
+                ),
+                Node(
+                    package='controller_manager',
+                    executable='spawner',
+                    arguments=['strafe_controller', '--inactive'],
+                ),
+                Node(
+                    package='controller_manager',
+                    executable='spawner',
+                    arguments=['nova_diff_drive_controller', '--inactive'],
+                ),
+                Node(
+                    package='controller_manager',
+                    executable='spawner',
+                    arguments=['joint_state_broadcaster'],
+                ),
+                Node(
+                    package='controller_manager',
+                    executable='ros2_control_node',
+                    parameters=[controllers],
+                    remappings=[('/controller_manager/robot_description', '/robot_description')],
+                ),
+                IncludeLaunchDescription(
+                    launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([nova_bringup_dir, 'launch', 'urdf.launch.py'])),
+                    launch_arguments = {
+                        'arm_urdf_path': arm_urdf_path,
+                        'arm': arm_urdf,
+                        'rover': rover_urdf,
+                    }.items(),
+                ),
+            ],
         ),
-        # Node(
-        #     package='electronics', executable='LED_transmitter.py', output='screen', emulate_tty=True,
-        #     condition=UnlessCondition(gazebo)),
-    ])
+        GroupAction(
+            condition=UnlessCondition(teleop),
+            actions=[
+                Node(
+                    package='drive',
+                    executable='drive_inputs',
+                    output='screen',
+                    emulate_tty=True,
+                    parameters=[{'use_sim_time': False}],
+                ),
+                Node(
+                    package='drive',
+                    executable='driver',
+                    output='screen',
+                    emulate_tty=True,
+                    parameters=[{'use_sim_time': False, 'gazebo': False}],
+                ),
+            ],
+        ),
+    ]
+
+
+def generate_launch_description():
+    nova_bringup_dir = FindPackageShare('nova_bringup')
+    rover_description_dir = FindPackageShare('rover_description')
+
+    declared_arguments = [      
+        DeclareLaunchArgument(
+            name='controllers',
+            default_value=PathJoinSubstitution([nova_bringup_dir, 'params', 'controllers.yaml']),
+            description='Absolute path to controller params file',
+        ),
+        DeclareLaunchArgument(
+            name='arm_urdf', 
+            default_value='False',
+            description='Include arm URDF in robot_description?',
+        ),
+        DeclareLaunchArgument(
+            name='arm_urdf_path', 
+            default_value = PathJoinSubstitution([rover_description_dir, 'arm', 'urdf', 'arm.urdf.xacro']), 
+        ),
+        DeclareLaunchArgument(
+            name='rover_urdf', 
+            default_value='True',
+            description='Include rover URDF in robot_description?',
+        ),
+        DeclareLaunchArgument(
+            name='teleop', 
+            default_value='False',
+            description='Use ROS2 Controllers?',
+        ),
+    ]
+
+    return LaunchDescription(  
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/src/ros/rover/nova_bringup/params/controllers.yaml
+++ b/src/ros/rover/nova_bringup/params/controllers.yaml
@@ -1,0 +1,89 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 20 
+    use_sim_time: false
+
+    wheel_velocity_controller:
+      type: velocity_controllers/JointGroupVelocityController
+
+    pivot_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+    pivot_joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    pivot_drive_controller:
+      type: pivot_drive_controller/PivotDriveController
+
+    strafe_controller:
+      type: strafe_controller/StrafeController
+
+    nova_diff_drive_controller:
+      type: nova_diff_drive_controller/NovaDiffDriveController
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+wheel_velocity_controller:
+  ros__parameters:
+    joints:
+      - flw
+      - blw
+      - brw
+      - frw
+
+pivot_position_controller:
+  ros__parameters:
+    joints:
+      - flp
+      - blp
+      - brp
+      - frp
+
+joint_state_broadcaster:
+  ros__parameters:
+    interfaces:
+       ["position",
+      "velocity"]
+
+    joints:
+      ["blp", "brp", "flp", "frp",
+      "blw", "brw", "flw", "frw"]
+
+    use_local_topics: false
+    
+pivot_drive_controller:
+  ros__parameters:
+    left_drive_names: ["flw", "blw"]
+    right_drive_names: ["frw", "brw"]
+    left_pivot_names: ["flp", "blp"]
+    right_pivot_names: ["frp", "brp"]
+    open_loop: false
+    has_velocity_limits: true
+    has_acceleration_limits: true
+    max_velocity: 2.794144
+    min_velocity: -2.794144 
+    max_acceleration: 0.1
+    min_acceleration: -0.1
+    twist_covariance_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+strafe_controller:
+  ros__parameters:
+    left_drive_names: ["flw", "blw"]
+    right_drive_names: ["frw", "brw"]
+    left_pivot_names: ["flp", "blp"]
+    right_pivot_names: ["frp", "brp"]
+    open_loop: true
+    max_acceleration: 5.0
+
+nova_diff_drive_controller:
+  ros__parameters:
+    left_drive_names: ["flw", "blw"]
+    right_drive_names: ["frw", "brw"]
+    left_pivot_names: ["flp", "blp"]
+    right_pivot_names: ["frp", "brp"]
+    linear:
+      x:
+        max_acceleration: 5.0
+    twist_covariance_diagonal: [0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+

--- a/src/ros/rover/teleop_drive_joy/include/teleop_drive_joy/colors.h
+++ b/src/ros/rover/teleop_drive_joy/include/teleop_drive_joy/colors.h
@@ -1,0 +1,20 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Stores information about all of the colors
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+AUTHOR(S):  Harrison Verrios
+CREATION:	15/12/2021
+EDITED:		17/12/2021
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+// Define all colors
+#define C_END       "\033[0m"
+#define C_SUCCESS   "\033[1;32m"
+#define C_FAIL      "\033[1;31m"
+#define C_TITLE     "\033[1;34m"
+#define C_INPUT     "\033[;33m"
+#define C_MODE      "\033[;35m"

--- a/src/ros/rover/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "teleop_drive_joy/teleop_drive_joy.hpp"
+#include "teleop_drive_joy/colors.h"
 
 using namespace std::chrono_literals;
 
@@ -38,6 +39,24 @@ namespace teleop_drive_joy
     nova_diff_drive_client = this->create_client<rcl_interfaces::srv::SetParameters>("/nova_diff_drive_controller/set_parameters");
 
     control_mode = ControlMode::PIVOT_DRIVE;
+
+    RCLCPP_INFO_STREAM(this->get_logger(), C_TITLE << "Drive Controls:" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "       Left Stick Y      |  Forward/Back" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "       Right Stick X     |  Left/Right" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "      Right Trigger      |  Speed Multiplier" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "             DPAD Y      |  Speed Incr/Decr Course" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "             DPAD X      |  Speed Incr/Decr Fine" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "    Left Joy Button      |  Handbrake Enabled" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "   Right Joy Button      |  Handbrake Disabled" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "               Back      |  Lock" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "              Start      |  Unlock" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "                  A      |  Autonomous Control" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "                  B      |  Manual Control" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "                  Y      |  Tank Mode" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "       Right Bumper      |  Pivot Mode" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "       Left Bumper       |  Strafe Mode" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_FAIL << "Gamepad Locked" << C_END);
+    RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Pivot Mode" << C_END);
   }
 
   void TeleopDriveJoy::initializeParams()
@@ -163,12 +182,12 @@ namespace teleop_drive_joy
     if (isDebounced(joy_msg->buttons[params_.button_unlock], params_.button_unlock) && current_state.locked)
     {
       current_state.locked = false;
-      RCLCPP_INFO(this->get_logger(), "BUTTON: unlock");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_SUCCESS << "Gamepad Unlocked" << C_END);
     }
     else if (isDebounced(joy_msg->buttons[params_.button_lock], params_.button_lock) && !current_state.locked)
     {
       current_state.locked = true;
-      RCLCPP_INFO(this->get_logger(), "BUTTON: lock");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_FAIL << "Gamepad Locked" << C_END);
     }
 
     // Autonomous and Manual
@@ -178,7 +197,7 @@ namespace teleop_drive_joy
       setEnableTwistCmdForController(pivot_drive_client, true);
       setEnableTwistCmdForController(strafe_client, true);
 	    setEnableTwistCmdForController(nova_diff_drive_client, true);
-      RCLCPP_INFO(this->get_logger(), "BUTTON: autonomous_control");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "Autonomous Control" << C_END);
     }
     else if (isDebounced(joy_msg->buttons[params_.button_manual_control], params_.button_manual_control) && current_state.autonomous_mode)
     {
@@ -186,23 +205,23 @@ namespace teleop_drive_joy
       setEnableTwistCmdForController(pivot_drive_client, false);
       setEnableTwistCmdForController(strafe_client, false);
       setEnableTwistCmdForController(nova_diff_drive_client, false);
-      RCLCPP_INFO(this->get_logger(), "BUTTON: manual_control");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_INPUT << "Manual Control" << C_END);
     }
 
     // Controller Switches
     if (isDebounced(joy_msg->buttons[params_.button_pivot_drive_controller], params_.button_pivot_drive_controller) && control_mode != ControlMode::PIVOT_DRIVE)
     {
-      RCLCPP_INFO(this->get_logger(), "BUTTON: pivot_drive_mode");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Pivot Mode" << C_END);
       switchController(ControlMode::PIVOT_DRIVE);
     }
     else if (isDebounced(joy_msg->buttons[params_.button_strafe_controller], params_.button_strafe_controller) && control_mode != ControlMode::STRAFE_DRIVE)
     {
-      RCLCPP_INFO(this->get_logger(), "BUTTON: strafe_mode");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Strafe Mode" << C_END);
       switchController(ControlMode::STRAFE_DRIVE);
     }
     else if (isDebounced(joy_msg->buttons[params_.button_nova_diff_drive_controller], params_.button_nova_diff_drive_controller) && control_mode != ControlMode::DIFF_DRIVE)
     {
-      RCLCPP_INFO(this->get_logger(), "BUTTON: diff_drive_mode");
+      RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Tank Mode" << C_END);
       switchController(ControlMode::DIFF_DRIVE);
     }
 


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

- Added a `teleop` argument (default = false) to base.launch.py and drive.launch.py in nova_bringup, that converts base.launch.py to teleop.launch.py (teleop_drive_joy) and drive.launch.py to control.launch.py (auto_bringup); it uses teleop and ros2 control instead of drive and base.
- Also added a bunch of terminal printouts from base/drive to teleop to minimise confusion for operators

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

- Run base/drive on rover with/without the teleop flag

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

![image](https://github.com/user-attachments/assets/a89656d3-9101-4fd2-823f-6bddc66e9433)

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

  <!-- TAGS START -->
  Tags for Notion Integration:
  
  <!-- TAGS END -->