### PR TITLE
feat: Added urdf-modifier to urdf-tool

### DIFF
--- a/nixfiles/modules/home/macros/urdf-tool.nix
+++ b/nixfiles/modules/home/macros/urdf-tool.nix
@@ -51,11 +51,34 @@ let
       SECRET_KEY = "";
     };  # If the file does not exist, use set with empty values to avoid errors
 
+  urdf-modifier = pkgs.python3Packages.buildPythonApplication rec {
+    pname = "urdf-modifier";
+    version = "1.0";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "V01DBREAKER";
+      repo = pname;
+      rev = "eac72564eadf6778ea63e4d89b3cd588ecb3c316";
+      hash = "sha256-OtwYxlHKxruVxJmosMbvT//FM5gPV+75MCG1zKyEuuE=";
+    };
+
+    buildInputs = with pkgs.python3Packages; [
+      pymeshlab
+    ];
+
+    meta = with pkgs.lib; {
+      description = "A Python script used to modify generated URDFs and recalculate inertias.";
+      homepage = "https://github.com/V01DBREAKER/urdf-modifier";
+      license = licenses.mit;
+    };
+  };
+
 in
 pkgs.mkShell {
   buildInputs = [
     pkgs.openscad
     onshapeToRobot
+    urdf-modifier
     pkgs.python3Packages.numpy
     pkgs.python3Packages.pybullet
     pkgs.python3Packages.requests
@@ -70,6 +93,7 @@ pkgs.mkShell {
   # Set up PYTHONPATH to include all dependencies
   shellHook = ''
     export PATH=${onshapeToRobot}/bin:$PATH
+    export PATH=${urdf-modifier}/bin:$PATH
     export PYTHONPATH=${pkgs.python3Packages.python.sitePackages}:${pkgs.python3Packages."numpy-stl"}/lib/python3.12/site-packages:$PYTHONPATH
     export ONSHAPE_API=https://cad.onshape.com
     # Check if Onshape API keys are defined, and warn if not


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

Adds urdf-modifier to the urdf-tool shell alias
<!--- Elaborate on your Wonderful Work! --->

the urdf-modifier is a command line script that takes any urdf/xacro/xml file and will:
- Recalculate all link inertia tags which have an attached stl model
    - To address incorrect inertias by onshape-to-robot
- Remove _continuous from any joint tag name
    - To address onshape-to-robot requiring _continuous being suffixed to any continuous joint you wish to make
- Rewrite any mesh urls from package:// to file://
    - Since this caused issues with gazebo
 
 This tool should streamline the export of future URDFs

Inertias have been tested and are comparable to https://www.hamzamerzic.info/mesh_cleaner/
Which is the tool we used to fix the arm-urdf inertias.

https://github.com/V01DBREAKER/urdf-modifier - Source code can be found here

## Usage:
`urdf-tool`
`urdf-modifier <urdf-file> [mesh-directory]`

## Memes

![image](https://github.com/user-attachments/assets/f7ed025a-f727-42f2-90d7-ae95b3b8fd66)
