### PR TITLE
Added aliases for LED control, nix-daemon starting, and cop mode

### DIFF
--- a/nixfiles/doc/rover-help.md
+++ b/nixfiles/doc/rover-help.md
@@ -98,6 +98,9 @@ leds-red: cansend can0 095#0100
 leds-green: cansend can0 095#0200
 leds-blue: cansend can0 095#0300
 leds-pink: cansend can0 096#
+leds-100 = "cansend can0 091#8000";
+leds-75 = "cansend can0 091#6000";
+leds-50 = "cansend can0 091#4000";
 leds-off: cansend can0 091#0000
 
 =========================

--- a/nixfiles/doc/rover-help.md
+++ b/nixfiles/doc/rover-help.md
@@ -1,4 +1,3 @@
-
 =========================
 RUNNING THE ROVER
 =========================
@@ -94,10 +93,25 @@ http://10.0.1.100
 
 =========================
 
+# LEDs
+leds-red: cansend can0 095#0100
+leds-green: cansend can0 095#0200
+leds-blue: cansend can0 095#0300
+leds-pink: cansend can0 096#
+leds-off: cansend can0 091#0000
+
+=========================
+
 # Zero Pivots
 Type 'zero-pivots' and follow the prompts. Use 'list-blcmds' if you're looking for the ID of a specific BLCMD.
 
 # Zero Arm
 Type 'zero-arm' and follow the prompts.
+
+=========================
+
+# NixOS
+nix-enable: sudo systemctl enable nix-daemon.service
+nix-start: sudo systemctl start nix-daemon.service
 
 =========================

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -105,6 +105,8 @@ in
             launch-drive = "~/Builds/master/bin/ros2 launch nova_bringup drive.launch.py";
             launch-arm = "~/Builds/master/bin/ros2 launch nova_bringup arm.launch.py";
             launch-ec = "~/Builds/master/bin/ros2 launch nova_bringup ec_rover.launch.py";
+            launch-science-arc = "~/Builds/master/bin/ros2 launch nova_bringup arc_science.launch.py";
+            launch-science-urc = "~/Builds/master/bin/ros2 launch nova_bringup urc_science.launch.py";
 
             # Rover setup aliases
             zero-arm = "${pkgs.bash}/bin/bash ${../../../scripts/zero-arm.sh}";
@@ -126,10 +128,6 @@ in
             leds-50 = "cansend can0 091#4000";
             leds-off = "cansend can0 091#0000";
 
-            # Reolink camera
-            reolink-low = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=512K --demuxer-max-back-bytes=512K rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_sub";
-            reolink-high = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=1M --demuxer-max-back-bytes=1M rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_main";
-
             # Bonus
             cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh} on";
             cop-mode-off = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh} off";
@@ -138,6 +136,9 @@ in
             cameras-legacy = "~/Builds/cameras2legacy/bin/gst-nova-launcher ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params' autostart:=true";
             nix-enable = "sudo systemctl enable nix-daemon.service";
             nix-start = "sudo systemctl start nix-daemon.service";
+            reolink-low = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=512K --demuxer-max-back-bytes=512K rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_sub";
+            reolink-high = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=1M --demuxer-max-back-bytes=1M rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_main";
+
           }
         ];
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -113,9 +113,6 @@ in
             zero-pivots = "${pkgs.bash}/bin/bash ${../../../scripts/zero-pivots.sh}";
             list-blcmds = "more ${cfg.nixfileDir}/doc/blcmd-ids.md";
 
-            # Temporary aliases (remove when a better solution has been implemented)
-            cameras-legacy = "~/Builds/cameras2legacy/bin/gst-nova-launcher ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params' autostart:=true";
-          
             # GUI aliases
             gui-shell = "nova-shell -A pkgs.ros.nova-gui";
             gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" src/ros/rosTypes.ts";
@@ -134,6 +131,11 @@ in
             # Bonus
             cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh on}";
             cop-mode-off = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh off}";
+
+            # Temporary aliases (remove when a better solution has been implemented)
+            cameras-legacy = "~/Builds/cameras2legacy/bin/gst-nova-launcher ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params' autostart:=true";
+            nix-enable = "sudo systemctl enable nix-daemon.service"
+            nix-start = "sudo systemctl start nix-daemon.service"
           }
         ];
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -124,9 +124,9 @@ in
             leds-blue = "cansend can0 095#0300";
             leds-pink = "cansend can9 096#";
             leds-100 = "cansend can0 091#FF00";
-            leds-75 = "cansend can0 091#C000"
-            leds-50 = "cansend can0 091#8000"
-            leds-off = "cansend can0 091#0000"
+            leds-75 = "cansend can0 091#C000";
+            leds-50 = "cansend can0 091#8000";
+            leds-off = "cansend can0 091#0000";
 
             # Bonus
             cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh on}";
@@ -134,8 +134,8 @@ in
 
             # Temporary aliases (remove when a better solution has been implemented)
             cameras-legacy = "~/Builds/cameras2legacy/bin/gst-nova-launcher ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params' autostart:=true";
-            nix-enable = "sudo systemctl enable nix-daemon.service"
-            nix-start = "sudo systemctl start nix-daemon.service"
+            nix-enable = "sudo systemctl enable nix-daemon.service";
+            nix-start = "sudo systemctl start nix-daemon.service";
           }
         ];
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -129,6 +129,7 @@ in
             leds-100 = "cansend can0 091#FF00";
             leds-75 = "cansend can0 091#C000"
             leds-50 = "cansend can0 091#8000"
+            leds-off = "cansend can0 091#0000"
 
             # Bonus
             cop-mode = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh}";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -105,8 +105,6 @@ in
             launch-drive = "~/Builds/master/bin/ros2 launch nova_bringup drive.launch.py";
             launch-arm = "~/Builds/master/bin/ros2 launch nova_bringup arm.launch.py";
             launch-ec = "~/Builds/master/bin/ros2 launch nova_bringup ec_rover.launch.py";
-            launch-science-arc = "~/Builds/master/bin/ros2 launch nova_bringup arc_science.launch.py";
-            launch-science-urc = "~/Builds/master/bin/ros2 launch nova_bringup urc_science.launch.py";
 
             # Rover setup aliases
             zero-arm = "${pkgs.bash}/bin/bash ${../../../scripts/zero-arm.sh}";
@@ -117,16 +115,20 @@ in
             gui-shell = "nova-shell -A pkgs.ros.nova-gui";
             gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" src/ros/rosTypes.ts";
             gui-rosbridge = "~/Builds/master/bin/ros2 launch rosbridge_server rosbridge_websocket_launch.xml";
-
+            
             # LEDs
             leds-red = "cansend can0 095#0100";
             leds-green = "cansend can0 095#0200";
             leds-blue = "cansend can0 095#0300";
-            leds-pink = "cansend can9 096#";
-            leds-100 = "cansend can0 091#FF00";
-            leds-75 = "cansend can0 091#C000";
-            leds-50 = "cansend can0 091#8000";
+            leds-pink = "cansend can0 096#";
+            leds-100 = "cansend can0 091#8000";
+            leds-75 = "cansend can0 091#6000";
+            leds-50 = "cansend can0 091#4000";
             leds-off = "cansend can0 091#0000";
+
+            # Reolink camera
+            reolink-low = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=512K --demuxer-max-back-bytes=512K rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_sub";
+            reolink-high = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=1M --demuxer-max-back-bytes=1M rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_main";
 
             # Bonus
             cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh} on";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -121,10 +121,17 @@ in
             gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" src/ros/rosTypes.ts";
             gui-rosbridge = "~/Builds/master/bin/ros2 launch rosbridge_server rosbridge_websocket_launch.xml";
 
-            # Reolink camera
-            reolink-low = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=512K --demuxer-max-back-bytes=512K rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_sub";
-            reolink-high = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=1M --demuxer-max-back-bytes=1M rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_main";
+            # LEDs
+            leds-red = "cansend can0 095#0100";
+            leds-green = "cansend can0 095#0200";
+            leds-blue = "cansend can0 095#0300";
+            leds-pink = "cansend can9 096#";
+            leds-100 = "cansend can0 091#FF00";
+            leds-75 = "cansend can0 091#C000"
+            leds-50 = "cansend can0 091#8000"
 
+            # Bonus
+            cop-mode = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh}";
           }
         ];
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -132,7 +132,8 @@ in
             leds-off = "cansend can0 091#0000"
 
             # Bonus
-            cop-mode = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh}";
+            cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh on}";
+            cop-mode-off = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh off}";
           }
         ];
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -129,8 +129,8 @@ in
             leds-off = "cansend can0 091#0000";
 
             # Bonus
-            cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh on}";
-            cop-mode-off = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh off}";
+            cop-mode-on = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh} on";
+            cop-mode-off = "${pkgs.bash}/bin/bash ${../../../scripts/cop-mode.sh} off";
 
             # Temporary aliases (remove when a better solution has been implemented)
             cameras-legacy = "~/Builds/cameras2legacy/bin/gst-nova-launcher ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params' autostart:=true";

--- a/nixfiles/scripts/cop-mode.sh
+++ b/nixfiles/scripts/cop-mode.sh
@@ -1,8 +1,17 @@
 #! /usr/bin/env bash
 
-while true; do
-    cansend can0 095#0100
-    sleep 0.3
-    cansend can0 095#0300
-    sleep 0.3
-done
+if [ "$1" == "on" ]; then
+    echo "Cop Mode Enabled"
+    while true; do
+        cansend can0 095#0100
+        sleep 0.3
+        cansend can0 095#0300
+        sleep 0.3
+    done
+elif [ "$1" == "off" ]; then
+    echo "Cop Mode Disabled"
+    cansend can0 091#0000
+else
+    echo "Usage: $0 {on|off}"
+    exit 1
+fi

--- a/nixfiles/scripts/cop-mode.sh
+++ b/nixfiles/scripts/cop-mode.sh
@@ -1,15 +1,34 @@
 #! /usr/bin/env bash
 
+PID_FILE="/tmp/cop_mode.pid"
+
 if [ "$1" == "on" ]; then
     echo "Cop Mode Enabled"
-    while true; do
+    
+    # Prevent multiple instances
+    if [ -f "$PID_FILE" ]; then
+        echo "Cop Mode already active!"
+        exit 1
+    fi
+
+    # Run loop in the background and save PID
+    ( while true; do
         cansend can0 095#0100
         sleep 0.3
         cansend can0 095#0300
         sleep 0.3
-    done
+    done ) &
+
+    echo $! > "$PID_FILE"  # Save PID of background process
+
 elif [ "$1" == "off" ]; then
     echo "Cop Mode Disabled"
+
+    if [ -f "$PID_FILE" ]; then
+        kill "$(cat "$PID_FILE")" 2>/dev/null
+        rm -f "$PID_FILE"
+    fi
+
     cansend can0 091#0000
 else
     echo "Usage: $0 {on|off}"

--- a/nixfiles/scripts/cop-mode.sh
+++ b/nixfiles/scripts/cop-mode.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+while true; do
+    cansend can0 095#0100
+    sleep 0.3
+    cansend can0 095#0300
+    sleep 0.3
+done

--- a/src/ros/rover/drive/drive/include/drive/drive_inputs.h
+++ b/src/ros/rover/drive/drive/include/drive/drive_inputs.h
@@ -88,6 +88,9 @@ private:
     // A lock on the controls - can be unlocked
     bool locked = true;
 
+    // Extra mode
+    bool cop_mode = false;
+
     // Autonomous mode
     bool autonomous = false;
 

--- a/src/ros/rover/drive/drive/include/drive/drive_inputs.h
+++ b/src/ros/rover/drive/drive/include/drive/drive_inputs.h
@@ -89,7 +89,7 @@ private:
     bool locked = true;
 
     // Extra mode
-    bool cop_mode = false;
+    bool bonus_mode = false;
 
     // Autonomous mode
     bool autonomous = false;

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -139,11 +139,10 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
             if (autonomous)
                 RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Autonomous Mode Disabled" << C_END);
             autonomous = false;
-        }
        
         } else if (msg->btn_x_state == 1) {
             if(cop_mode)
-                system("bash -c '~/nova/nixfiles/scripts/cop-mode.sh'");
+                system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "off" : "on")).c_str());
             cop_mode = !cop_mode;
         }
    

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -142,7 +142,7 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
        
         } else if (msg->btn_x_state == 1) {
             if(cop_mode)
-                system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "off" : "on")).c_str());
+                system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "off" : "on") + " &").c_str());
             cop_mode = !cop_mode;
         }
    

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -140,7 +140,11 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
                 RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Autonomous Mode Disabled" << C_END);
             autonomous = false;
         }
-
+       
+        } else if (msg->btn_x_state == 1) {
+              // PLACEHOLDER
+        }
+   
         if (msg->btn_thumb_l_state == 1) {
             if (!latest_drive_input.handbrake)
                 RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Handbrake Enabled" << C_END);

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -141,8 +141,8 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
             autonomous = false;
        
         } else if (msg->btn_x_state == 1) {
-            cop_mode = !cop_mode;
-            system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "on" : "off") + " &").c_str());
+            bonus_mode = !bonus_mode;
+            // system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "on" : "off") + " &").c_str());
         }
    
         if (msg->btn_thumb_l_state == 1) {

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -142,7 +142,9 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
         }
        
         } else if (msg->btn_x_state == 1) {
-              // PLACEHOLDER
+            if(cop_mode)
+                system("bash -c '~/nova/nixfiles/scripts/cop-mode.sh'");
+            cop_mode = !cop_mode;
         }
    
         if (msg->btn_thumb_l_state == 1) {

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -141,9 +141,8 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
             autonomous = false;
        
         } else if (msg->btn_x_state == 1) {
-            if(cop_mode)
-                system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "off" : "on") + " &").c_str());
             cop_mode = !cop_mode;
+            system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "on" : "off") + " &").c_str());
         }
    
         if (msg->btn_thumb_l_state == 1) {

--- a/src/ros/rover/drive/drive/src/drive_inputs.cpp
+++ b/src/ros/rover/drive/drive/src/drive_inputs.cpp
@@ -140,10 +140,10 @@ void DriveInputs::input_callback(const input_interfaces::msg::InputGamepad::Shar
                 RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << "Autonomous Mode Disabled" << C_END);
             autonomous = false;
        
-        } else if (msg->btn_x_state == 1) {
-            bonus_mode = !bonus_mode;
-            // system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "on" : "off") + " &").c_str());
-        }
+        } //else if (msg->btn_x_state == 1) {
+            //bonus_mode = !bonus_mode;
+            //system(("bash ~/nova/nixfiles/scripts/cop-mode.sh " + std::string(cop_mode ? "on" : "off") + " &").c_str());
+        //}
    
         if (msg->btn_thumb_l_state == 1) {
             if (!latest_drive_input.handbrake)


### PR DESCRIPTION
## Description

* LED colours can be controlled through the following aliases: leds-red, leds-green, leds-blue, leds-pink, leds-off
* LED brightness aliases have been partially implemented according to Electrical's instructions, but do not presently work (will be fixed shortly)
* nix daemon can also now be enabled and started through the following aliases: nix-enable, nix-start
* cop-mode-on and cop-mode-off aliases have been implemented
* a listener for the x button has been implemented so that I can use it for bonus functionality in the future, but I have presently disabled this button to prevent operators from accidentally enabling any unintended functionality

## Steps to Test

Run the rover and then try the aliases. These have all been tested in the workshop and work properly.

## Memes

![image](https://github.com/user-attachments/assets/257cec6b-c34b-4320-873c-ed3b459335f7)