### PR TITLE
[WIP] Updates to latest packages before hydra vomitting

### DIFF
--- a/nixfiles/scripts/hydra-vomit.sh
+++ b/nixfiles/scripts/hydra-vomit.sh
@@ -9,6 +9,7 @@
 # Update git
 echo "Refreshing git repo"
 git -C ~/nova pull
+git switch master
 
 jobset=${1:-workspaces}
 oraclekey=${2:-~/nova-oracle.key}

--- a/nixfiles/scripts/hydra-vomit.sh
+++ b/nixfiles/scripts/hydra-vomit.sh
@@ -6,6 +6,10 @@
 #
 # , assuming you have the nova-oracle.key in ~, and the mono-repo cloned in ~
 
+# Update git
+echo "Refreshing git repo"
+git -C ~/nova pull
+
 jobset=${1:-workspaces}
 oraclekey=${2:-~/nova-oracle.key}
 


### PR DESCRIPTION
The hydra vomitter server doesn't always build the most up to date packages. This request makes the pc do a git pull first and then checkout master, then nix-build.