### PR TITLE
New camera and better GUI aliases

### DIFF
--- a/nixfiles/doc/rover-help.md
+++ b/nixfiles/doc/rover-help.md
@@ -38,10 +38,9 @@ Launch the following on the metabox.
 In one terminal:
 1. Try the 'gui-shell' alias otherwise:
      nova-shell -A pkgs.ros.nova-gui
-3. Try the 'gui' alias otherwise:
+2. Try the 'gui-run' alias otherwise:
      cd ~/nova/src/ros/nova-gui/nova-gui
-5. yarn install
-6. yarn dev
+     yarn dev
 
 In another terminal:
 1. Try the 'gui-rosbridge' alias, otherwise: 
@@ -57,7 +56,7 @@ Try the 'launch-arm' alias, otherwise use the command below.
 
 # C&E
 Launch this on the jetson.
-When running the construction & excavation payload, you DON'T need to run drive.
+When running the excavation & construction payload, you DON'T need to run drive.
 Try the 'launch-ec' alias, otherwise use the command below.
 ~/Builds/master/bin/ros2 launch nova_bringup ec_rover.launch.py
 
@@ -76,7 +75,11 @@ Try the 'launch-science-urc' alias, otherwise use the command below.
 =========================
 
 # Cameras
-Replace '?' with either 'arm', 'ce', or 'science'.
+Launch this on the jetson
+Replace '?' with either 'arm', 'ec', or 'arc_science'.
+launch-cameras payload:=?
+
+if that doesn't work try:
 cameras-legacy payload:=?
 
 # Reolink Camera

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -107,6 +107,8 @@ in
             launch-ec = "~/Builds/master/bin/ros2 launch nova_bringup ec_rover.launch.py";
             launch-science-arc = "~/Builds/master/bin/ros2 launch nova_bringup arc_science.launch.py";
             launch-science-urc = "~/Builds/master/bin/ros2 launch nova_bringup urc_science.launch.py";
+            launch-cameras = "~/Builds/master/bin/ros2 launch cameras2 camera_server_launch.py platform:=rover param-dir:='/home/nvidia/nova/src/ros/cameras2/cameras2/params'";
+            launch-cameras-all = "${launch-cameras} autostart:=true";
 
             # Rover setup aliases
             zero-arm = "${pkgs.bash}/bin/bash ${../../../scripts/zero-arm.sh}";
@@ -118,8 +120,9 @@ in
           
             # GUI aliases
             gui-shell = "nova-shell -A pkgs.ros.nova-gui";
-            gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" src/ros/rosTypes.ts";
+            gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" ~/nova/src/ros/nova-gui/nova-gui/src/ros/rosTypes.ts";
             gui-rosbridge = "~/Builds/master/bin/ros2 launch rosbridge_server rosbridge_websocket_launch.xml";
+            gui-run = "yarn --cwd ~/nova/src/ros/nova-gui/nova-gui dev";
 
             # Reolink camera
             reolink-low = "mpv --rtsp-transport=udp --no-cache --untimed --video-sync=display-resample --deinterlace=no --profile=low-latency --demuxer-max-bytes=512K --demuxer-max-back-bytes=512K rtsp://admin:Lab188b37@10.0.1.100:554/h264Preview_01_sub";


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

I created new camera aliases that should work better (?) (or at least the same as) the `cameras-legacy` alias that refer to the up to date cameras2 build.

Updated the rover help page with the new information.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

### Three new commands:
- `launch-cameras` should be succeeded with a payload:={payload} parameter
  - eg `launch-cameras payload:=ec`
  - ** note this command can only be used on a jetson as the parameters will be different on another device
  - This is the command that was used for the E&C payload camera testing.
- `launch-cameras-all' same as above but will auto start all cameras (can be a bit iffy)
- `gui-run` will launch the gui from anywhere

### Updated command:
- `gui-link` this command can now be called anywhere.

** note that `yarn install` still needs to be called in the right directory

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->
![image](https://github.com/user-attachments/assets/27f490b3-12ba-4ca8-876b-f6e2a0633498)


## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

- `sudo nixos-rebuild switch` and try them yourselves.

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
![image](https://github.com/user-attachments/assets/3f7292f9-2570-4913-a10c-934f92967668)
