### PR TITLE
Feat/SCIENCE control map

### DIFF
--- a/src/ros/rover/science/science/arc_spinny_part.py
+++ b/src/ros/rover/science/science/arc_spinny_part.py
@@ -94,11 +94,11 @@ class SpinnyPartNode(JoystickControllerNode):
         :return: None
         """
         # change position
-        if joystick_l.btn_bottom_r1_state == 1:
+        if joystick_l.btn_bottom_r4_state == 1:
             self.spinny_part.update_position(self.MICROSCOPE)
-        elif joystick_l.btn_bottom_r2_state == 1:
+        elif joystick_l.btn_bottom_r5_state == 1:
             self.spinny_part.update_position(self.SWEEPER)
-        elif joystick_l.btn_bottom_r3_state == 1:
+        elif joystick_l.btn_bottom_r6_state == 1:
             self.spinny_part.update_position(self.NIR_PROBE)
 
         # twitch/update offset

--- a/src/ros/rover/science/science/arc_spinny_part.py
+++ b/src/ros/rover/science/science/arc_spinny_part.py
@@ -94,11 +94,11 @@ class SpinnyPartNode(JoystickControllerNode):
         :return: None
         """
         # change position
-        if joystick_l.btn_thumb_l_state == 1:
+        if joystick_l.btn_bottom_r1_state == 1:
             self.spinny_part.update_position(self.MICROSCOPE)
-        elif joystick_l.btn_thumb_d_state == 1:
+        elif joystick_l.btn_bottom_r2_state == 1:
             self.spinny_part.update_position(self.SWEEPER)
-        elif joystick_l.btn_thumb_r_state == 1:
+        elif joystick_l.btn_bottom_r3_state == 1:
             self.spinny_part.update_position(self.NIR_PROBE)
 
         # twitch/update offset

--- a/src/ros/rover/science/science/urc_auger.py
+++ b/src/ros/rover/science/science/urc_auger.py
@@ -47,10 +47,10 @@ class URCAuger(JoystickControllerNode):
     
     # CONTROL DIRECTIONS
     # Add any CONTROL DIRECTIONS here
-    AUGER_ACTUATION_UP = Direction.POSITIVE
-    AUGER_ACTUATION_DOWN = Direction.NEGATIVE
-    AUGER_DRILL_CLOCKWISE = Direction.POSITIVE
-    AUGER_DRILL_COUNTERCLOCKWISE = Direction.NEGATIVE
+    AUGER_ACTUATION_UP = Direction.NEGATIVE
+    AUGER_ACTUATION_DOWN = Direction.POSITIVE
+    AUGER_DRILL_CLOCKWISE = Direction.NEGATIVE
+    AUGER_DRILL_COUNTERCLOCKWISE = Direction.POSITIVE
 
     def __init__(self):
         super(URCAuger, self).__init__(name="URCAuger", can_bus=self.CAN_BUS)

--- a/src/ros/rover/science/science/urc_auger.py
+++ b/src/ros/rover/science/science/urc_auger.py
@@ -117,7 +117,7 @@ class URCAuger(JoystickControllerNode):
 
     def update_auger_actuation(self, joystick_r: InputJoystick):
         # Auger height direction is determined by the right joystick's x-axis direction
-        self.auger_actuation.update_direction(self.AUGER_ACTUATION_UP if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_DOWN)
+        self.auger_actuation.update_direction(self.AUGER_ACTUATION_DOWN if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_UP)
 
         # Auger velocity is determined by the right joystick's x-axis magnitude
         if joystick_r.btn_thumb_d_state >= 1 or joystick_r.ax_stick_x < 0:

--- a/src/ros/rover/science/science/urc_auger.py
+++ b/src/ros/rover/science/science/urc_auger.py
@@ -117,7 +117,7 @@ class URCAuger(JoystickControllerNode):
 
     def update_auger_actuation(self, joystick_r: InputJoystick):
         # Auger height direction is determined by the right joystick's x-axis direction
-        self.auger_actuation.update_direction(self.AUGER_ACTUATION_DOWN if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_UP)
+        self.auger_actuation.update_direction(self.AUGER_ACTUATION_UP if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_DOWN)
 
         # Auger velocity is determined by the right joystick's x-axis magnitude
         if joystick_r.btn_thumb_d_state >= 1 or joystick_r.ax_stick_x < 0:


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description
Remap controls to not assign more than one function to each control, and invert directions to be more intuative/as intended

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs
Spinny controls remapped to left thrustmuster buttons of right of base 2nd row
Auger up/down inverted
Auger CW/Anti-CW spin inverted

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test
- SSH into rover (orin) & build feat/spinny-control-map
- run base (on laptop)
- - **can start can1 25000**
- Run science payload (on orin): **<path>/ros 2 launch nova_bringup arc_science.launch.py**
- Check controls


<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
