### PR TITLE
Filter out non-raw cameras in the directory server

### DIFF
--- a/nixfiles/packages/python/default.nix
+++ b/nixfiles/packages/python/default.nix
@@ -7,4 +7,5 @@
   ultralytics = callPackage ./ultralytics { };
   super-gradients = callPackage ./super-gradients { };
   lap = callPackage ./lap { };
+  linuxpy = callPackage ./linuxpy { };
 }

--- a/nixfiles/packages/python/linuxpy/default.nix
+++ b/nixfiles/packages/python/linuxpy/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "linuxpy";
+  version = "0.20.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mNWmzl52GEZUEL3q8cP59qxMduG1ijgsvGoD5ddSG94=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  pythonImportsCheck = [ "linuxpy" ];
+}

--- a/src/ros/cameras2/cameras2/cameras2/camera_scanner.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_scanner.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional, NamedTuple
 
 import pyudev
+from linuxpy.video.device import Device as VideoDevice, PixelFormat as VideoPixelFormat
 
 
 class CameraScanner:
@@ -51,6 +52,18 @@ class CameraScanner:
             capabilities = []
         if "capture" not in capabilities:
             return None
+
+        # Filter out any devices that do not support YUYV formats.
+        # Some devices, such as the SN9C292A, expose multiple UVC devices that
+        # can be opened simultaneously - one for YUYV and MJPEG, and another for
+        # H.264.
+        #
+        # The most correct solution here would be to redesign the directory
+        # service API to allow for multiple device nodes per camera, but we'll
+        # implement that when we need it.
+        with VideoDevice.from_id(int(device.sys_number)) as video_device:
+            if not any(fmt.pixel_format == VideoPixelFormat.YUYV for fmt in video_device.info.formats):
+                return None
 
         serial = device["ID_SERIAL"]
         path = device["ID_PATH"]

--- a/src/ros/cameras2/nix/packages/cameras2/default.nix
+++ b/src/ros/cameras2/nix/packages/cameras2/default.nix
@@ -58,6 +58,7 @@ buildRosPackage {
     pythonPackages.pygobject3
     pythonPackages.gst-python
     pythonPackages.psutil
+    pythonPackages.linuxpy
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

The Arducams have two UVC devices that can be opened simultaneously. The camera directory server expects one UVC device per USB device, though. Luckily, we only need one of them, so filter the one we don't need out.

A better long term fix will be to update the directory server API to support multiple UVCs per camera.

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

![image](https://github.com/user-attachments/assets/d25a1c47-689b-4d84-a953-de8d29d9d698)
