### PR TITLE
more reliable can, added support for can2

### DIFF
--- a/nixfiles/modules/home/macros/can.sh
+++ b/nixfiles/modules/home/macros/can.sh
@@ -11,11 +11,12 @@
 #   can stop vcan0
 #
 # The options are:
-#   can0 -  CAN 1 Line
-#   can1 -  CAN 2 Line
-#   all -   CAN 1 and CAN 2 Line
-#   vcan0 - Virtual CAN 1 Line
-#   vcan1 - Virtual CAN 2 Line
+#   can0 -  CAN 0 Line
+#   can1 -  CAN 1 Line
+#   can2 -  CAN 2 Line
+#   all -   CAN 0, CAN 1, and CAN 2 Line
+#   vcan0 - Virtual CAN 0 Line
+#   vcan1 - Virtual CAN 1 Line
 #
 # +--------------------------------------------+
 
@@ -52,6 +53,9 @@ then
 elif [[ $2 = "can1" ]]
 then
     can="can1"
+elif [[ $2 = "can2" ]]
+then
+    can="can2"
 elif [[ $2 = "vcan0" ]]
 then
     can="vcan0"
@@ -64,6 +68,7 @@ elif [[ $2 = "all" ]]
 then
     can start can0
     can start can1
+    can start can2
     failed="1"
 
 # If invalid argument
@@ -76,6 +81,9 @@ fi
 # If the bitrate parameter exists
 if [[ -z "${3:-}" ]]; then
     if [[ $2 = "can0" ]]
+    then
+        bitrate=250000
+    elif [[ $2 = "can2" ]]
     then
         bitrate=250000
     else

--- a/src/ros/rover/nova_bringup/launch/drive.launch.py
+++ b/src/ros/rover/nova_bringup/launch/drive.launch.py
@@ -10,15 +10,24 @@ NODES:
   - control/drive/driver            [driver]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CREATION:   15/12/2021
-EDITED:     04/02/2025
+EDITED:     19/03/2025
 EDITED BY: Max Tory, Taaj Street, 
-    Victor Bartlinski
+    Victor Bartlinski, Jared Landau
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+import subprocess
+
+try:
+    subprocess.run(["can", "start", "can0", "250000"], check=True)
+    print("can0 started successfully")
+except subprocess.CalledProcessError as e:
+    print(f"Error: Failed to start can0.")
+    print("{e}")
+    exit(1)
 
 def launch_setup(context, *args, **kwargs):
     gazebo = LaunchConfiguration('gazebo')


### PR DESCRIPTION
## Description

* can0 starts automatically in drive.launch.py
* can1 starts automatically in arm.launch.py and arc_science.launch.py
* can2 support added to can.sh

will test this asap (they took the metabox away from me to test kiln)