### PR TITLE
Move camera tabs

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasPage.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasPage.tsx
@@ -31,6 +31,7 @@ export const CameraPage = (props: CameraPageProps) => {
             <Button
               size="md"
               color="primary"
+              className="w-28"
               onPress={() => setAllCamsOn(true)}
             >
               <Play size="15px" fill="white" /> Start All
@@ -62,6 +63,7 @@ export const CameraPage = (props: CameraPageProps) => {
           size="md"
           color="primary"
           variant="ghost"
+          className="w-36"
           onPress={() => setControlPanelOpen(true)}
         >
           Control Panel

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasPage.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasPage.tsx
@@ -1,10 +1,11 @@
-import { Button, Tab, Tabs } from "@nextui-org/react";
+import { Button } from "@nextui-org/react";
 import { Play, Square } from "react-feather";
 import { useCameraStreamer } from "../../../components/CameraComponent/hooks/useCameraStreamer";
 import { CameraView } from "./CameraPageConstants";
 import { useState } from "react";
 import { CameraControlPanelModal } from "../../../components/CameraComponent/components/CamerasControlPanelModal";
 import SerialMappedCameraComponent from "./SerialMappedCameraComponent.tsx";
+import SegmentedPicker from "../../../components/SegmentedPicker/SegmentedPicker.tsx";
 
 export interface CameraPageProps {
   views: CameraView[];
@@ -24,7 +25,7 @@ export const CameraPage = (props: CameraPageProps) => {
 
   return (
     <div className="p-3 flex flex-col gap-0">
-      <div className="flex flex-row justify-between items-center gap-3 pl-1 mb-3">
+      <div className="flex flex-row justify-between items-center gap-32 pl-1 mb-3">
         <div className="flex flex-row gap-3 items-center">
           {!allCamsOn ? (
             <Button
@@ -44,6 +45,19 @@ export const CameraPage = (props: CameraPageProps) => {
             </Button>
           )}
         </div>
+
+        <SegmentedPicker
+          selectedIndex={selectedTab}
+          onIndexChange={setSelectedTab}
+          children={[
+            views.map(v => v.viewTitle)
+          ]}
+          color="primary"
+          className="pb-0"
+          fullWidth
+          variant="bordered"
+        />
+
         <Button
           size="md"
           color="primary"
@@ -53,31 +67,19 @@ export const CameraPage = (props: CameraPageProps) => {
           Control Panel
         </Button>
       </div>
-      <Tabs
-        size="lg"
-        color="primary"
-        className="pb-0"
-        fullWidth
-        variant="bordered"
-        selectedKey={selectedTab}
-        onSelectionChange={(key) => {
-          setSelectedTab(key as number);
-        }}
-      >
-        {views.map((view, i) => (
-          <Tab title={view.viewTitle} key={i}>
-            <div className="grid grid-cols-4 gap-3">
-              {view.cameraSerials.map((serial, i) => (
-                <SerialMappedCameraComponent
-                  cameraSerial={serial}
-                  key={i}
-                  autostart={allCamsOn}
-                />
-              ))}
-            </div>
-          </Tab>
-        ))}
-      </Tabs>
+
+      {
+        <div className="grid grid-cols-4 gap-3">
+          {views[selectedTab].cameraSerials.map((serial, i) => (
+            <SerialMappedCameraComponent
+              cameraSerial={serial}
+              key={i}
+              autostart={allCamsOn}
+            />
+          ))}
+        </div>
+      }
+
       <CameraControlPanelModal
         showModal={controlPanelOpen}
         closeModal={closeControlPanel}


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

When cameras are running we found that we had to scroll down to see drive telemetry which can be a bit stressful in the middle of a comp sim where every moment counts. I wanted a way to reduce the size of the top bars and bring the components up and thought that merging the camera tabs and buttons was a great way to do this.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- converted camera tabs to use the segmented picker

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->
Before:
![Screenshot From 2025-03-23 10-35-00](https://github.com/user-attachments/assets/5ea4f1ef-cf2b-46d1-bcdd-8062993f2e73)


After:
![image](https://github.com/user-attachments/assets/1e0162f0-6a11-4284-b991-1a043998913c)


## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

![image](https://github.com/user-attachments/assets/f31793b6-0b73-46de-aa6f-79787c21b341)

