### PR TITLE
Make the IK controller chainable with a distinct Twistmapper controller

### DIFF
--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -42,6 +42,7 @@
 , nova-utils ? throw "nova-utils is needed, but not available!"
 , nova-arm-controller ? throw "nova-arm-controller is needed, but not available!"
 , nova-ik-controller ? throw "nova-ik-controller is needed, but not available!"
+, nova-twistmapper ? throw "nova-twistmapper is needed, but not available!"
 
   # Configuration options
   ## Include graphical applications in the workspace.
@@ -86,7 +87,8 @@
       nova-utils
       reolink
       nova-arm-controller
-      nova-ik-controller;
+      nova-ik-controller
+      nova-twistmapper;
   }
 
   ## Extra packages to add to the workspace.

--- a/src/ros/rover/auto_bringup/launch/control.launch.py
+++ b/src/ros/rover/auto_bringup/launch/control.launch.py
@@ -47,6 +47,11 @@ def launch_setup(context, *args, **kwargs):
             executable='spawner',
             arguments=['nova_ik_controller', '--inactive']
         ),
+        Node( # TODO: only when arm is enabled
+            package='controller_manager',
+            executable='spawner',
+            arguments=['nova_twistmapper', '--inactive']
+        ),
         Node(
             package='controller_manager',
             executable='spawner',

--- a/src/ros/rover/auto_bringup/params/controllers.yaml
+++ b/src/ros/rover/auto_bringup/params/controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 30
+    update_rate: 60
     use_sim_time: false
 
     nova_arm_velocity_controller:

--- a/src/ros/rover/auto_bringup/params/controllers.yaml
+++ b/src/ros/rover/auto_bringup/params/controllers.yaml
@@ -12,6 +12,9 @@ controller_manager:
     nova_ik_controller:
       type: nova_ik_controller/NovaIKController
 
+    nova_twistmapper:
+      type: nova_twistmapper/NovaTwistmapper
+
     wheel_velocity_controller:
       type: velocity_controllers/JointGroupVelocityController
 
@@ -65,6 +68,10 @@ nova_ik_controller:
       - J4
       - J5
       - J6
+
+nova_twistmapper:
+  ros__parameters:
+    chained_controller_name: "nova_ik_controller"
 
 wheel_velocity_controller:
   ros__parameters:

--- a/src/ros/rover/auto_bringup/params/controllers.yaml
+++ b/src/ros/rover/auto_bringup/params/controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 144
+    update_rate: 30
     use_sim_time: false
 
     nova_arm_velocity_controller:

--- a/src/ros/rover/controllers/nova_arm_controller/include/nova_arm_controller/nova_arm_controller.hpp
+++ b/src/ros/rover/controllers/nova_arm_controller/include/nova_arm_controller/nova_arm_controller.hpp
@@ -68,7 +68,7 @@ protected:
   struct JointHandle
   {
     std::string name;
-    // std::reference_wrapper<const hardware_interface::LoanedStateInterface> state;
+    std::reference_wrapper<const hardware_interface::LoanedStateInterface> state;
     std::reference_wrapper<hardware_interface::LoanedCommandInterface> command;
     // SpeedLimiter speed_limiter;
     // float target_direction = 0.0;

--- a/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
+++ b/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
@@ -51,7 +51,7 @@ controller_interface::CallbackReturn NovaArmController::on_init()
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  return controller_interface::CallbackReturn::SUCCESS;
+return controller_interface::CallbackReturn::SUCCESS;
 }
 
 InterfaceConfiguration NovaArmController::command_interface_configuration() const
@@ -75,6 +75,7 @@ InterfaceConfiguration NovaArmController::state_interface_configuration() const 
 }
 
 std::vector<hardware_interface::CommandInterface> NovaArmController::on_export_reference_interfaces() {
+
   std::vector<hardware_interface::CommandInterface> reference_interfaces;
   RCLCPP_INFO(get_node()->get_logger(), "Export reference interfaces");
 

--- a/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
+++ b/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
@@ -64,13 +64,12 @@ InterfaceConfiguration NovaArmController::command_interface_configuration() cons
   return {interface_configuration_type::INDIVIDUAL, conf_names};
 }
 
-InterfaceConfiguration NovaArmController::state_interface_configuration() const {
+InterfaceConfiguration NovaArmController::state_interface_configuration() const
+{
   std::vector<std::string> conf_names;
-  /*
   for (const auto &joint_name: params_.joint_names) {
     conf_names.push_back(joint_name + "/" + joint_feedback_type());
   }
-   */
   return {interface_configuration_type::INDIVIDUAL, conf_names};
 }
 
@@ -180,8 +179,14 @@ controller_interface::return_type NovaArmController::update_and_write_commands(
     }
 
     const auto reference_value = reference_interfaces_[i];
-    if (std::isnan(reference_value))
+    if (std::isnan(reference_value)) {
+
+      // When dealing with invalid or missing inputs, don't move
+      const auto halt_value = params_.use_position_control ? joint_handle.state.get().get_value() : 0.0;
+      RCLCPP_WARN(get_node()->get_logger(), "Missing or NaN input received. Trying to do nothing with value %f for joint \"%s\".", halt_value, joint_handle.name.c_str());
+      joint_handle.command.get().set_value(halt_value);
       continue;
+    }
 
     joint_handle.command.get().set_value(reference_value);
   }
@@ -369,40 +374,35 @@ controller_interface::CallbackReturn NovaArmController::configure_joints(
   {
     const auto state_interface_name = joint_feedback_type();
     const auto command_interface_name = joint_command_type();
-/*
-    // TODO: Change this filter to be useful, and not get the same as the command_interface
-    const auto state_handle = std::find_if(
-        state_interfaces_.cbegin(), state_interfaces_.cend(),
-        [&joint_name, &state_interface_name](const auto &interface)
-        {
-          return interface.get_prefix_name() == joint_name &&
-                 interface.get_interface_name() == state_interface_name;
-        });
 
-    if (state_handle == state_interfaces_.cend())
-    {
+    const auto state_handle = std::find_if(
+      state_interfaces_.begin(), state_interfaces_.end(),
+      [&joint_name, &state_interface_name](const auto &interface)
+      {
+        return interface.get_prefix_name() == joint_name &&
+               interface.get_interface_name() == state_interface_name;
+      });
+
+    if (state_handle == state_interfaces_.end()) {
       RCLCPP_ERROR(logger, "Unable to obtain joint state handle for %s", joint_name.c_str());
       return controller_interface::CallbackReturn::ERROR;
     }
-*/
-    // TODO: Change this filter to be useful, and not get the same as the state_interface
-    const auto command_handle = std::find_if(
-        command_interfaces_.begin(), command_interfaces_.end(),
-        [&joint_name, &command_interface_name](const auto &interface)
-        {
-          return interface.get_prefix_name() == joint_name &&
-                 interface.get_interface_name() == command_interface_name;
-        });
 
-    if (command_handle == command_interfaces_.end())
-    {
+    const auto command_handle = std::find_if(
+      command_interfaces_.begin(), command_interfaces_.end(),
+      [&joint_name, &command_interface_name](const auto &interface)
+      {
+        return interface.get_prefix_name() == joint_name &&
+               interface.get_interface_name() == command_interface_name;
+      });
+
+    if (command_handle == command_interfaces_.end()) {
       RCLCPP_ERROR(logger, "Unable to obtain joint command handle for %s", joint_name.c_str());
       return controller_interface::CallbackReturn::ERROR;
     }
 
     registered_handles.emplace_back(
-        JointHandle{joint_name, std::ref(*command_handle)});
-    // std::ref(*state_handle),
+        JointHandle{joint_name, std::ref(*state_handle), std::ref(*command_handle)});
   }
 
   return controller_interface::CallbackReturn::SUCCESS;

--- a/src/ros/rover/controllers/nova_ik_controller/ik_plugin.xml
+++ b/src/ros/rover/controllers/nova_ik_controller/ik_plugin.xml
@@ -1,5 +1,6 @@
 <library path="nova_ik_controller">
-  <class name="nova_ik_controller/NovaIKController" type="nova_ik_controller::NovaIKController" base_class_type="controller_interface::ControllerInterface">
+  <class name="nova_ik_controller/NovaIKController" type="nova_ik_controller::NovaIKController"
+         base_class_type="controller_interface::ChainableControllerInterface">
   <description>
     The ik controller TODO XXX
   </description>

--- a/src/ros/rover/controllers/nova_ik_controller/include/nova_ik_controller/nova_ik_controller.hpp
+++ b/src/ros/rover/controllers/nova_ik_controller/include/nova_ik_controller/nova_ik_controller.hpp
@@ -10,16 +10,13 @@
 
 #include "visibility_control.h"
 #include "controller_interface/controller_interface.hpp"
-#include "geometry_msgs/msg/twist.hpp"
-#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "controller_interface/chainable_controller_interface.hpp"
 #include "hardware_interface/handle.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp/node.hpp"
 #include "realtime_tools/realtime_box.h"
-//#include "realtime_tools/realtime_buffer.h"
-//#include "realtime_tools/realtime_publisher.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2/LinearMath/Scalar.h"
 #include "nova_ik_controller/speed_limiter.hpp"
@@ -35,7 +32,7 @@
 
 namespace nova_ik_controller
 {
-class NovaIKController : public controller_interface::ControllerInterface
+class NovaIKController : public controller_interface::ChainableControllerInterface
 {
 public:
   NovaIKController();
@@ -44,8 +41,10 @@ public:
 
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
-  controller_interface::return_type update(
-    const rclcpp::Time &time, const rclcpp::Duration &period) override;
+  std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
+
+  controller_interface::return_type update_and_write_commands(
+    const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
   controller_interface::CallbackReturn on_init() override;
 
@@ -66,6 +65,9 @@ public:
 
   controller_interface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::return_type update_reference_from_subscribers(
+    const rclcpp::Time & time, const rclcpp::Duration & period) override;
 
   /// @brief Calculates the IK given a frame, pose and set of lengths.
   /// @brief See Keenan's IK notes.
@@ -93,11 +95,7 @@ protected:
   {
     std::string name;
     std::reference_wrapper<hardware_interface::LoanedCommandInterface> command;
-    // TODO: Add state interfaces to be used by the twistmapper for resetting on activation (or after activation upon receiving the first bit of meaningful data)
     // SpeedLimiter speed_limiter;
-    // float target_direction = 0.0;
-    // float best_effort_rotational_velocity = 0.0;
-    // store per joint odometry here maybe?
   };
 
   controller_interface::CallbackReturn configure_joints(
@@ -107,52 +105,13 @@ protected:
   // Helpers
   std::string joint_to_command_interface_name(const std::string& joint_name) const;
 
-  // TODO: change this message when we get one
-
   std::vector<JointHandle> registered_joint_handles_;
 
   // Parameters from ROS for nova_diff_drive_controller
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
-  // Twistmapper
-
-  // TODO: Initialize twist stamped topic and write callback
-  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub = nullptr;
-  realtime_tools::RealtimeBox<std::shared_ptr<geometry_msgs::msg::TwistStamped>> received_twist_stamped_ptr{nullptr};
-  /// Result of the twistmapper, and input to IK. Desired position and orientation of the end effector relative to the base.
-  tf2::Transform twistmapper_pose_ = tf2::Transform();
-  tf2::Vector3 twistmapper_pose_rpy_ = tf2::Vector3();
-  rclcpp::Time twistmapper_pose_update_time_ = rclcpp::Time();
-  /// True when initial state has been received to confirm that the value in _twistmapper_pose is safe and valid
-  // TODO: Make invalid when deactivated
-  bool twistmapper_pose_validated_ = false;
-
-  // broadcasting twistmapper
-  std::shared_ptr<tf2_ros::TransformBroadcaster> twistmapper_pose_tf_broadcaster_;
-  // FK for getting the initial state for twistmapper_pose_
-  std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
-  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
-
-  // TODO: Detection of initial state, setting initial twistmapper pose
-
-  // TODO: Timeout and halt for safety!
-
-  // TODO: Implement
-  void update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period);
-
-  // Timeout to consider cmd_vel commands old
-  std::chrono::milliseconds cmd_vel_timeout_{500};
-  bool subscriber_is_active_ = false; // not sure what this is for yet
-  rclcpp::Time previous_update_timestamp_{0};
-
-  // publish rate limiter
-  double publish_rate_ = 50.0;
-  rclcpp::Duration publish_period_ = rclcpp::Duration::from_nanoseconds(0);
-  rclcpp::Time previous_publish_timestamp_{0, 0, RCL_CLOCK_UNINITIALIZED};
-  bool is_halted = false;
   bool reset();
-  void halt();
 };
 } // namespace nova_ik_controller
 #endif // NOVA_IK_CONTROLLER__NOVA_IK_CONTROLLER_HPP_

--- a/src/ros/rover/controllers/nova_ik_controller/include/nova_ik_controller/nova_ik_controller.hpp
+++ b/src/ros/rover/controllers/nova_ik_controller/include/nova_ik_controller/nova_ik_controller.hpp
@@ -43,6 +43,8 @@ public:
 
   std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
 
+  bool on_set_chained_mode(bool chained_mode) override;
+
   controller_interface::return_type update_and_write_commands(
     const rclcpp::Time& time, const rclcpp::Duration& period) override;
 

--- a/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
+++ b/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
@@ -102,6 +102,14 @@ namespace nova_ik_controller
       return controller_interface::return_type::OK;
     }
 
+    // Do nothing if any input is missing or invalid
+    for (auto& reference_value : reference_interfaces_) {
+      if (std::isnan(reference_value)) {
+        RCLCPP_WARN(get_node()->get_logger(), "Missing or NaN input received. Doing nothing.");
+        return controller_interface::return_type::OK;
+      }
+    }
+
     // Target pose from reference interfaces
     tf2::Vector3 reference_origin = tf2::Vector3(
       reference_interfaces_[0],
@@ -168,6 +176,12 @@ namespace nova_ik_controller
           "Some joint interfaces are non existent");
       return controller_interface::CallbackReturn::ERROR;
     }
+
+    // Reset reference interfaces
+    // https://github.com/ros-controls/ros2_control_demos/blob/f09c24040243973d48f7a102afc70559b2dc3908/example_12/controllers/src/passthrough_controller.cpp#L115
+    std::fill(
+      reference_interfaces_.begin(), reference_interfaces_.end(),
+      std::numeric_limits<double>::quiet_NaN());
 
     return controller_interface::CallbackReturn::SUCCESS;
   }

--- a/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
+++ b/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
@@ -14,12 +14,18 @@
 
 namespace
 {
-  constexpr auto DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST = "/arm_ik_twist_stamped"; // TODO: changeme
   /// The inverse of the global orientation the kinematics origin frame wants to rotate to for a roll,pitch,yaw of 0,0,0
   const auto ENDEFFECTOR_BASIS_INVERSE = tf2::Matrix3x3(tf2::Quaternion(-0.5, 0.5, -0.5, -0.5)).inverse();
-  constexpr auto ENDEFFECTOR_KINEMATICS_FRAME = "endeffector_kinematics";
-  constexpr auto KINEMATICS_ORIGIN_FRAME = "arm_kinematics_origin";
-  constexpr auto TWISTMAPPER_TARGET_FRAME = "arm_twistmapper_target";
+
+  constexpr std::array<const char* const, 7> POSE_COMPONENTS = {
+    "x",
+    "y",
+    "z",
+    "qx",
+    "qy",
+    "qz",
+    "qw",
+  };
 } // namespace
 
 using std::placeholders::_1;
@@ -31,7 +37,7 @@ namespace nova_ik_controller
   using controller_interface::InterfaceConfiguration;
   using lifecycle_msgs::msg::State;
 
-  NovaIKController::NovaIKController() : controller_interface::ControllerInterface() {}
+  NovaIKController::NovaIKController() : controller_interface::ChainableControllerInterface() {}
 
   controller_interface::CallbackReturn NovaIKController::on_init()
   {
@@ -68,80 +74,50 @@ namespace nova_ik_controller
     return {interface_configuration_type::INDIVIDUAL, conf_names};
   }
 
-  void NovaIKController::update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period) {
-    std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
-    received_twist_stamped_ptr.get(twist_stamped);
+  std::vector<hardware_interface::CommandInterface> NovaIKController::on_export_reference_interfaces() {
 
-    if (twist_stamped == nullptr) {
-      RCLCPP_WARN(get_node()->get_logger(), "Haven't yet received a TwistStamped message to use for the twistmapper.");
-      return;
+    std::vector<hardware_interface::CommandInterface> reference_interfaces;
+    reference_interfaces_.reserve(POSE_COMPONENTS.size());
+
+    for (unsigned int i = 0; i < POSE_COMPONENTS.size(); i++) {
+      const auto name = POSE_COMPONENTS[i];
+      reference_interfaces.push_back(hardware_interface::CommandInterface(get_node()->get_name(), name,
+                                                                          &reference_interfaces_[i]));
     }
 
-    const auto& twist = twist_stamped->twist;
-
-    tf2::Vector3 tf2_twist_angular;
-    tf2::fromMsg(twist.angular, tf2_twist_angular);
-
-    twistmapper_pose_rpy_ = twistmapper_pose_rpy_ + tf2_twist_angular * period.seconds();
-
-    // Create rotation matrix from twist.angular as XYZ euler
-    auto rotation_matrix = tf2::Matrix3x3();
-    /*rotation_matrix.setRPY(
-      twist.angular.x * period.seconds(),
-      twist.angular.y * period.seconds(),
-      twist.angular.z * period.seconds());
-      */
-    rotation_matrix.setRPY(twistmapper_pose_rpy_.x(), twistmapper_pose_rpy_.y(), twistmapper_pose_rpy_.z());
-
-    const auto linear = tf2::Vector3(
-      twist.linear.x * period.seconds(),
-      twist.linear.y * period.seconds(),
-      twist.linear.z * period.seconds());
-
-    // TODO: Test this actually works as expected.
-    // TODO: Add a tf buffer and make use of the header.frame_id from the twist_stamped to allow IK to be done relative to anything. Then Teleop would just need to use the end effector frame by default
-    // TODO: If using tf like this, also have the twistmapper broadcast the target frame, so it can reference itself.
-    twistmapper_pose_.setOrigin(linear + twistmapper_pose_.getOrigin());
-    twistmapper_pose_.setBasis(rotation_matrix);
-
-    // Publish twistmapper pose to tf2
-    geometry_msgs::msg::TransformStamped transform_stamped;
-    transform_stamped.transform = toMsg(twistmapper_pose_);
-    transform_stamped.header.stamp = time;
-
-    // TODO: Parameterize
-    transform_stamped.child_frame_id = TWISTMAPPER_TARGET_FRAME;
-    transform_stamped.header.frame_id = KINEMATICS_ORIGIN_FRAME;
-
-    RCLCPP_INFO_ONCE(get_node()->get_logger(), "Broadcasting twistmapper pose as '%s', child of '%s'.",
-                     transform_stamped.child_frame_id.c_str(),
-                     transform_stamped.header.frame_id.c_str());
-
-    twistmapper_pose_tf_broadcaster_->sendTransform(transform_stamped);
+    return reference_interfaces;
   }
 
-  controller_interface::return_type NovaIKController::update(
+  controller_interface::return_type NovaIKController::update_reference_from_subscribers(
+    const rclcpp::Time &time, const rclcpp::Duration &period) {
+    return controller_interface::return_type::OK;
+  }
+
+  controller_interface::return_type NovaIKController::update_and_write_commands(
       const rclcpp::Time &time, const rclcpp::Duration &period)
   {
     auto logger = get_node()->get_logger();
     if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
     {
-      if (!is_halted)
-      {
-        halt();
-        is_halted = true;
-      }
-
       return controller_interface::return_type::OK;
     }
 
-    update_twistmapper(time, period);
+    // Target pose from reference interfaces
+    tf2::Vector3 reference_origin = tf2::Vector3(
+      reference_interfaces_[0],
+      reference_interfaces_[1],
+      reference_interfaces_[2]);
+    tf2::Quaternion reference_quat = tf2::Quaternion(
+      reference_interfaces_[3],
+      reference_interfaces_[4],
+      reference_interfaces_[5],
+      reference_interfaces_[6]);
+    tf2::Transform reference_target_pose = tf2::Transform(reference_quat, reference_origin);
 
     // TODO: Retrieve these values from the robot description, rather than specifying them directly
     // TODO: Or even simpler, just put these in params!!!
     constexpr std::array<double, 3> lengths = {0.5, 0.68332, 0.11073};
-
-    auto joint_angles = calculate_ik(twistmapper_pose_, lengths);
+    auto joint_angles = calculate_ik(reference_target_pose, lengths);
 
     for (unsigned int i = 0; i < joint_angles.size(); i++)
     {
@@ -174,40 +150,8 @@ namespace nova_ik_controller
       return controller_interface::CallbackReturn::ERROR;
     }
 
-    twistmapper_pose_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(tf2_ros::TransformBroadcaster(*get_node()));
-    tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_node()->get_clock());
-    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-
-    // TODO: insert correct subscriber here
-    twist_stamped_sub = get_node()->create_subscription<geometry_msgs::msg::TwistStamped>(
-      DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST,
-      rclcpp::SystemDefaultsQoS(),
-      [this, logger](const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg) -> void
-      {
-        RCLCPP_INFO_ONCE(logger, "Twist message received.");
-
-        if (!subscriber_is_active_)
-        {
-          RCLCPP_WARN_ONCE(
-            logger, "Can't accept new commands. subscriber is inactive");
-          return;
-        }
-        if ((msg->header.stamp.sec == 0) && (msg->header.stamp.nanosec == 0))
-        {
-          RCLCPP_WARN_ONCE(
-            logger,
-            "Received message with zero timestamp, setting it to current "
-            "time, this message will only be shown once");
-          msg->header.stamp = get_node()->get_clock()->now();
-        }
-
-        received_twist_stamped_ptr.set(std::move(msg));
-      });
-    subscriber_is_active_ = true;
-
     RCLCPP_INFO(logger, "Created twist stamped subscription");
 
-    previous_update_timestamp_ = get_node()->get_clock()->now();
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
@@ -224,41 +168,13 @@ namespace nova_ik_controller
           "Some joint interfaces are non existent");
       return controller_interface::CallbackReturn::ERROR;
     }
-    is_halted = false;
-    subscriber_is_active_ = true;
 
-    try {
-      auto tf_transform = tf_buffer_->lookupTransform(
-        KINEMATICS_ORIGIN_FRAME, ENDEFFECTOR_KINEMATICS_FRAME, tf2::TimePointZero);
-      tf2::fromMsg(tf_transform.transform, twistmapper_pose_);
-
-      double roll, pitch, yaw;
-      twistmapper_pose_.getBasis().getRPY(roll, pitch, yaw);
-
-      twistmapper_pose_rpy_.setX(roll);
-      twistmapper_pose_rpy_.setY(pitch);
-      twistmapper_pose_rpy_.setZ(yaw);
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_INFO(
-        get_node()->get_logger(), "Could not transform %s to %s: %s",
-        ENDEFFECTOR_KINEMATICS_FRAME, KINEMATICS_ORIGIN_FRAME, ex.what());
-      return controller_interface::CallbackReturn::FAILURE;
-    }
-
-    // TODO: setup sub and pub
-    RCLCPP_DEBUG(get_node()->get_logger(), "Subscriber and publisher are now active.");
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
   controller_interface::CallbackReturn NovaIKController::on_deactivate(
       const rclcpp_lifecycle::State &)
   {
-    subscriber_is_active_ = false;
-    if (!is_halted)
-    {
-      halt();
-      is_halted = true;
-    }
     registered_joint_handles_.clear();
 
     return controller_interface::CallbackReturn::SUCCESS;
@@ -286,10 +202,6 @@ namespace nova_ik_controller
 
   bool NovaIKController::reset()
   {
-    // release the old queue
-    subscriber_is_active_ = false;
-
-    is_halted = false;
     return true;
   }
 
@@ -297,21 +209,6 @@ namespace nova_ik_controller
       const rclcpp_lifecycle::State &)
   {
     return controller_interface::CallbackReturn::SUCCESS;
-  }
-
-  void NovaIKController::halt()
-  {
-    // Set twistmapper velocities to 0
-    std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
-    received_twist_stamped_ptr.get(twist_stamped);
-
-    twist_stamped->twist.linear.x = 0;
-    twist_stamped->twist.linear.y = 0;
-    twist_stamped->twist.linear.z = 0;
-
-    twist_stamped->twist.angular.x = 0;
-    twist_stamped->twist.angular.y = 0;
-    twist_stamped->twist.angular.z = 0;
   }
 
   std::string NovaIKController::joint_to_command_interface_name(const std::string& joint_name) const {
@@ -437,9 +334,11 @@ namespace nova_ik_controller
     std::array<double, 6> new_joints = { -j1, -j2bo, -j3bo, -j4, -j5, -j6 };
     return new_joints;
   }
+
+
 } // namespace nova_ik_controller
 
 #include "class_loader/register_macro.hpp"
 
 CLASS_LOADER_REGISTER_CLASS(
-    nova_ik_controller::NovaIKController, controller_interface::ControllerInterface)
+    nova_ik_controller::NovaIKController, controller_interface::ChainableControllerInterface)

--- a/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
+++ b/src/ros/rover/controllers/nova_ik_controller/src/nova_ik_controller.cpp
@@ -335,7 +335,10 @@ namespace nova_ik_controller
     return new_joints;
   }
 
-
+  bool NovaIKController::on_set_chained_mode(bool chained_mode) {
+    // This method is called when the chained mode is set.
+    return true;
+  }
 } // namespace nova_ik_controller
 
 #include "class_loader/register_macro.hpp"

--- a/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
+++ b/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
@@ -27,7 +27,6 @@ foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
 endforeach()
 
 include_directories(
-	${EIGEN3_INCLUDE_DIRS}
 )
 
 generate_parameter_library(nova_twistmapper_parameters
@@ -35,8 +34,8 @@ generate_parameter_library(nova_twistmapper_parameters
 )
 
 add_library(nova_twistmapper SHARED
-  src/PoseHandle.cpp
   src/nova_twistmapper.cpp
+  src/PoseHandle.cpp
 )
 target_compile_features(nova_twistmapper PUBLIC cxx_std_17)
 target_include_directories(nova_twistmapper PUBLIC

--- a/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
+++ b/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
@@ -10,7 +10,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   generate_parameter_library
   geometry_msgs
   hardware_interface
-  nav_msgs
   pluginlib
   rclcpp
   rclcpp_lifecycle
@@ -19,8 +18,6 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   tf2
   tf2_msgs
   tf2_geometry_msgs
-  nova_interfaces
-  Eigen3
 )
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
+++ b/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
@@ -38,6 +38,7 @@ generate_parameter_library(nova_twistmapper_parameters
 )
 
 add_library(nova_twistmapper SHARED
+  src/PoseHandle.cpp
   src/nova_twistmapper.cpp
 )
 target_compile_features(nova_twistmapper PUBLIC cxx_std_17)

--- a/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
+++ b/src/ros/rover/controllers/nova_twistmapper/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.16)
+project(nova_twistmapper LANGUAGES CXX)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_interface
+  generate_parameter_library
+  geometry_msgs
+  hardware_interface
+  nav_msgs
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  rcpputils
+  realtime_tools
+  tf2
+  tf2_msgs
+  tf2_geometry_msgs
+  nova_interfaces
+  Eigen3
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+include_directories(
+	${EIGEN3_INCLUDE_DIRS}
+)
+
+generate_parameter_library(nova_twistmapper_parameters
+  src/nova_twistmapper_parameter.yaml
+)
+
+add_library(nova_twistmapper SHARED
+  src/nova_twistmapper.cpp
+)
+target_compile_features(nova_twistmapper PUBLIC cxx_std_17)
+target_include_directories(nova_twistmapper PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/nova_twistmapper>
+)
+target_link_libraries(nova_twistmapper PUBLIC nova_twistmapper_parameters)
+ament_target_dependencies(nova_twistmapper PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(nova_twistmapper PRIVATE "NOVA_TWISTMAPPER_BUILDING_DLL")
+pluginlib_export_plugin_description_file(controller_interface twistmapper_plugin.xml)
+
+install(DIRECTORY
+  #launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/nova_twistmapper
+)
+install(TARGETS nova_twistmapper nova_twistmapper_parameters
+  EXPORT export_nova_twistmapper
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+ament_export_targets(export_nova_twistmapper HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/PoseHandle.hpp
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/PoseHandle.hpp
@@ -1,0 +1,83 @@
+//
+// Created by Bailey Chessum on 4/5/25.
+// Helper struct to just collate the different component command interfaces
+//
+
+#ifndef NOVA_IK_CONTROLLER_POSEHANDLE_HPP
+#define NOVA_IK_CONTROLLER_POSEHANDLE_HPP
+
+#include <hardware_interface/loaned_command_interface.hpp>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
+
+namespace nova_twistmapper {
+
+//
+  class PoseHandle {
+  public:
+    struct ComponentHandle {
+      ComponentHandle(std::reference_wrapper<hardware_interface::LoanedCommandInterface> command) : command(command) {
+      }
+
+      std::reference_wrapper<hardware_interface::LoanedCommandInterface> command;
+    };
+
+    struct VectorHandle {
+      VectorHandle(std::reference_wrapper<hardware_interface::LoanedCommandInterface> x,
+                   std::reference_wrapper<hardware_interface::LoanedCommandInterface> y,
+                   std::reference_wrapper<hardware_interface::LoanedCommandInterface> z)
+        : x(x), y(y), z(z) {}
+
+      void set_value(const tf2::Vector3 &quat) const;
+
+      ComponentHandle x;
+      ComponentHandle y;
+      ComponentHandle z;
+    };
+
+    struct QuatHandle {
+      QuatHandle(std::reference_wrapper<hardware_interface::LoanedCommandInterface> x,
+                 std::reference_wrapper<hardware_interface::LoanedCommandInterface> y,
+                 std::reference_wrapper<hardware_interface::LoanedCommandInterface> z,
+                 std::reference_wrapper<hardware_interface::LoanedCommandInterface> w)
+        : x(x), y(y), z(z), w(w) {}
+
+      void set_value(const tf2::Quaternion &quat) const;
+
+      ComponentHandle x;
+      ComponentHandle y;
+      ComponentHandle z;
+      ComponentHandle w;
+    };
+
+    PoseHandle(std::reference_wrapper<hardware_interface::LoanedCommandInterface> x,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> y,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> z,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> qx,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> qy,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> qz,
+               std::reference_wrapper<hardware_interface::LoanedCommandInterface> qw)
+               : origin(x, y, z), rotation(qx, qy, qz, qw) {}
+
+    void set_value(const tf2::Transform &transform) const;
+
+    VectorHandle origin;
+    QuatHandle rotation;
+
+  /**
+   * @brief Assigns command interfaces given the list of available command interfaces and a string suffix for the name
+   * of each component
+   */
+  static PoseHandle pose_handle_from_command_interfaces(
+    std::vector<hardware_interface::LoanedCommandInterface> &command_interfaces,
+    const std::string &prefix);
+
+protected:
+  static std::reference_wrapper<hardware_interface::LoanedCommandInterface> find_command_interface(
+    std::vector<hardware_interface::LoanedCommandInterface> &command_interfaces, const std::string &name);
+
+};
+}
+
+#endif //NOVA_IK_CONTROLLER_POSEHANDLE_HPP

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -1,0 +1,158 @@
+#ifndef NOVA_TWISTMAPPER__NOVA_TWISTMAPPER_HPP_
+#define NOVA_TWISTMAPPER__NOVA_TWISTMAPPER_HPP_
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "visibility_control.h"
+#include "controller_interface/controller_interface.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "hardware_interface/handle.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/state.hpp"
+#include "rclcpp/node.hpp"
+#include "realtime_tools/realtime_box.h"
+//#include "realtime_tools/realtime_buffer.h"
+//#include "realtime_tools/realtime_publisher.h"
+#include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2/LinearMath/Scalar.h"
+#include "nova_twistmapper/speed_limiter.hpp"
+#include <Eigen/Dense>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include "tf2_ros/transform_listener.h"
+#include "tf2_ros/buffer.h"
+
+// To test in development, run from the root nova_twistmapper dir:
+// generate_parameter_library_cpp include/nova_twistmapper/nova_twistmapper_parameters.hpp src/nova_twistmapper_parameter.yaml
+#include "nova_twistmapper_parameters.hpp"
+
+namespace nova_twistmapper
+{
+class NovaTwistmapper : public controller_interface::ControllerInterface
+{
+public:
+  NovaTwistmapper();
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::return_type update(
+    const rclcpp::Time &time, const rclcpp::Duration &period) override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+  controller_interface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn on_activate(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn on_deactivate(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn on_error(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  controller_interface::CallbackReturn on_shutdown(
+    const rclcpp_lifecycle::State &previous_state) override;
+
+  /// @brief Calculates the IK given a frame, pose and set of lengths.
+  /// @brief See Keenan's IK notes.
+  /// @param frame is ???
+  /// @param pose is a struct combining a position (x,y,z) and a quaternion (x,y,z,w).
+  /// @param Lengths are [fill this].
+  /// @returns an array of joint angles in joint space for each of J1 through J6, through joints.
+  std::array<double, 6> calculate_ik(tf2::Transform pose, std::array<double, 3> lengths);
+
+  // substitutes values into our DH table.
+  // see: https://www.notion.so/Inverse-Kinematics-ddfe35179c1f4959850bd28b2195be8a
+  // equivalent line: DHs = [cos(the) -sin(the) 0 a; sin(the)*cos(alp) cos(the)*cos(alp) -sin(alp) -sin(alp)*d; sin(the)*sin(alp) cos(the)*sin(alp) cos(alp) cos(alp)*d; 0 0 0 1];
+  Eigen::Matrix4d sub_dh(double alp, double a, double d, double the) const
+  {
+    return Eigen::Matrix4d {
+      { cos(the), 			-sin(the), 			0, 			a },
+      { sin(the)*cos(alp),	cos(the)*cos(alp), 	-sin(alp), 	-sin(alp)*d },
+      { sin(the)*sin(alp),	cos(the)*sin(alp),	cos(alp),	cos(alp)*d },
+      { 0,					0,					0,			1 }
+    };
+  }
+
+protected:
+  struct JointHandle
+  {
+    std::string name;
+    std::reference_wrapper<hardware_interface::LoanedCommandInterface> command;
+    // TODO: Add state interfaces to be used by the twistmapper for resetting on activation (or after activation upon receiving the first bit of meaningful data)
+    // SpeedLimiter speed_limiter;
+    // float target_direction = 0.0;
+    // float best_effort_rotational_velocity = 0.0;
+    // store per joint odometry here maybe?
+  };
+
+  controller_interface::CallbackReturn configure_joints(
+    const std::vector<std::string> &joint_names,
+    std::vector<JointHandle> &registered_handles);
+
+  // Helpers
+  std::string joint_to_command_interface_name(const std::string& joint_name) const;
+
+  // TODO: change this message when we get one
+
+  std::vector<JointHandle> registered_joint_handles_;
+
+  // Parameters from ROS for nova_diff_drive_controller
+  std::shared_ptr<ParamListener> param_listener_;
+  Params params_;
+
+  // Twistmapper
+
+  // TODO: Initialize twist stamped topic and write callback
+  rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub = nullptr;
+  realtime_tools::RealtimeBox<std::shared_ptr<geometry_msgs::msg::TwistStamped>> received_twist_stamped_ptr{nullptr};
+  /// Result of the twistmapper, and input to IK. Desired position and orientation of the end effector relative to the base.
+  tf2::Transform twistmapper_pose_ = tf2::Transform();
+  tf2::Vector3 twistmapper_pose_rpy_ = tf2::Vector3();
+  rclcpp::Time twistmapper_pose_update_time_ = rclcpp::Time();
+  /// True when initial state has been received to confirm that the value in _twistmapper_pose is safe and valid
+  // TODO: Make invalid when deactivated
+  bool twistmapper_pose_validated_ = false;
+
+  // broadcasting twistmapper
+  std::shared_ptr<tf2_ros::TransformBroadcaster> twistmapper_pose_tf_broadcaster_;
+  // FK for getting the initial state for twistmapper_pose_
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  // TODO: Detection of initial state, setting initial twistmapper pose
+
+  // TODO: Timeout and halt for safety!
+
+  // TODO: Implement
+  void update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period);
+
+  // Timeout to consider cmd_vel commands old
+  std::chrono::milliseconds cmd_vel_timeout_{500};
+  bool subscriber_is_active_ = false; // not sure what this is for yet
+  rclcpp::Time previous_update_timestamp_{0};
+
+  // publish rate limiter
+  double publish_rate_ = 50.0;
+  rclcpp::Duration publish_period_ = rclcpp::Duration::from_nanoseconds(0);
+  rclcpp::Time previous_publish_timestamp_{0, 0, RCL_CLOCK_UNINITIALIZED};
+  bool is_halted = false;
+  bool reset();
+  void halt();
+};
+} // namespace nova_twistmapper
+#endif // NOVA_TWISTMAPPER__NOVA_TWISTMAPPER_HPP_

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -82,7 +82,6 @@ protected:
   tf2::Transform twistmapper_pose_ = tf2::Transform();
   tf2::Vector3 twistmapper_pose_rpy_ = tf2::Vector3();
   rclcpp::Time twistmapper_pose_update_time_ = rclcpp::Time();
-  /// True when initial state has been received to confirm that the value in _twistmapper_pose is safe and valid
 
   // broadcasting twistmapper
   std::shared_ptr<tf2_ros::TransformBroadcaster> twistmapper_pose_tf_broadcaster_;

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -22,12 +22,12 @@
 //#include "realtime_tools/realtime_publisher.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2/LinearMath/Scalar.h"
-#include "nova_twistmapper/speed_limiter.hpp"
 #include <Eigen/Dense>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/buffer.h"
+#include "PoseHandle.hpp"
 
 // To test in development, run from the root nova_twistmapper dir:
 // generate_parameter_library_cpp include/nova_twistmapper/nova_twistmapper_parameters.hpp src/nova_twistmapper_parameter.yaml
@@ -67,66 +67,26 @@ public:
   controller_interface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State &previous_state) override;
 
-  /// @brief Calculates the IK given a frame, pose and set of lengths.
-  /// @brief See Keenan's IK notes.
-  /// @param frame is ???
-  /// @param pose is a struct combining a position (x,y,z) and a quaternion (x,y,z,w).
-  /// @param Lengths are [fill this].
-  /// @returns an array of joint angles in joint space for each of J1 through J6, through joints.
-  std::array<double, 6> calculate_ik(tf2::Transform pose, std::array<double, 3> lengths);
-
-  // substitutes values into our DH table.
-  // see: https://www.notion.so/Inverse-Kinematics-ddfe35179c1f4959850bd28b2195be8a
-  // equivalent line: DHs = [cos(the) -sin(the) 0 a; sin(the)*cos(alp) cos(the)*cos(alp) -sin(alp) -sin(alp)*d; sin(the)*sin(alp) cos(the)*sin(alp) cos(alp) cos(alp)*d; 0 0 0 1];
-  Eigen::Matrix4d sub_dh(double alp, double a, double d, double the) const
-  {
-    return Eigen::Matrix4d {
-      { cos(the), 			-sin(the), 			0, 			a },
-      { sin(the)*cos(alp),	cos(the)*cos(alp), 	-sin(alp), 	-sin(alp)*d },
-      { sin(the)*sin(alp),	cos(the)*sin(alp),	cos(alp),	cos(alp)*d },
-      { 0,					0,					0,			1 }
-    };
-  }
-
 protected:
-  struct JointHandle
-  {
-    std::string name;
-    std::reference_wrapper<hardware_interface::LoanedCommandInterface> command;
-    // TODO: Add state interfaces to be used by the twistmapper for resetting on activation (or after activation upon receiving the first bit of meaningful data)
-    // SpeedLimiter speed_limiter;
-    // float target_direction = 0.0;
-    // float best_effort_rotational_velocity = 0.0;
-    // store per joint odometry here maybe?
-  };
-
-  controller_interface::CallbackReturn configure_joints(
-    const std::vector<std::string> &joint_names,
-    std::vector<JointHandle> &registered_handles);
+  // Holds command interfaces for different components of the pose
+  std::optional<PoseHandle> pose_handle;
 
   // Helpers
-  std::string joint_to_command_interface_name(const std::string& joint_name) const;
-
-  // TODO: change this message when we get one
-
-  std::vector<JointHandle> registered_joint_handles_;
+  std::string pose_component_to_command_interface_name(const std::string& component_name) const;
 
   // Parameters from ROS for nova_diff_drive_controller
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;
 
   // Twistmapper
-
-  // TODO: Initialize twist stamped topic and write callback
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub = nullptr;
   realtime_tools::RealtimeBox<std::shared_ptr<geometry_msgs::msg::TwistStamped>> received_twist_stamped_ptr{nullptr};
+
   /// Result of the twistmapper, and input to IK. Desired position and orientation of the end effector relative to the base.
   tf2::Transform twistmapper_pose_ = tf2::Transform();
   tf2::Vector3 twistmapper_pose_rpy_ = tf2::Vector3();
   rclcpp::Time twistmapper_pose_update_time_ = rclcpp::Time();
   /// True when initial state has been received to confirm that the value in _twistmapper_pose is safe and valid
-  // TODO: Make invalid when deactivated
-  bool twistmapper_pose_validated_ = false;
 
   // broadcasting twistmapper
   std::shared_ptr<tf2_ros::TransformBroadcaster> twistmapper_pose_tf_broadcaster_;
@@ -134,12 +94,7 @@ protected:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
 
-  // TODO: Detection of initial state, setting initial twistmapper pose
-
-  // TODO: Timeout and halt for safety!
-
-  // TODO: Implement
-  void update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period);
+  void update_twistmapper_pose(const rclcpp::Time &time, const rclcpp::Duration &period);
 
   // Timeout to consider cmd_vel commands old
   std::chrono::milliseconds cmd_vel_timeout_{500};
@@ -147,12 +102,14 @@ protected:
   rclcpp::Time previous_update_timestamp_{0};
 
   // publish rate limiter
-  double publish_rate_ = 50.0;
-  rclcpp::Duration publish_period_ = rclcpp::Duration::from_nanoseconds(0);
-  rclcpp::Time previous_publish_timestamp_{0, 0, RCL_CLOCK_UNINITIALIZED};
+  // double publish_rate_ = 50.0;
+  // rclcpp::Duration publish_period_ = rclcpp::Duration::from_nanoseconds(0);
+  // rclcpp::Time previous_publish_timestamp_{0, 0, RCL_CLOCK_UNINITIALIZED};
   bool is_halted = false;
   bool reset();
   void halt();
+
+  void publish_to_tf2(const rclcpp::Time &time);
 };
 } // namespace nova_twistmapper
 #endif // NOVA_TWISTMAPPER__NOVA_TWISTMAPPER_HPP_

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -13,16 +13,12 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "geometry_msgs/msg/twist_stamped.hpp"
 #include "hardware_interface/handle.hpp"
-#include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "rclcpp/node.hpp"
 #include "realtime_tools/realtime_box.h"
-//#include "realtime_tools/realtime_buffer.h"
-//#include "realtime_tools/realtime_publisher.h"
 #include "tf2_msgs/msg/tf_message.hpp"
 #include "tf2/LinearMath/Scalar.h"
-#include <Eigen/Dense>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include "tf2_ros/transform_listener.h"

--- a/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/visibility_control.h
+++ b/src/ros/rover/controllers/nova_twistmapper/include/nova_twistmapper/visibility_control.h
@@ -1,0 +1,35 @@
+#ifndef NOVA_TWISTMAPPER__VISIBILITY_CONTROL_H_
+#define NOVA_TWISTMAPPER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define NOVA_TWISTMAPPER_EXPORT __attribute__((dllexport))
+#define NOVA_TWISTMAPPER_IMPORT __attribute__((dllimport))
+#else
+#define NOVA_TWISTMAPPER_EXPORT __declspec(dllexport)
+#define NOVA_TWISTMAPPER_IMPORT __declspec(dllimport)
+#endif
+#ifdef NOVA_TWISTMAPPER_BUILDING_DLL
+#define NOVA_TWISTMAPPER_PUBLIC NOVA_TWISTMAPPER_EXPORT
+#else
+#define NOVA_TWISTMAPPER_PUBLIC NOVA_TWISTMAPPER_IMPORT
+#endif
+#define NOVA_TWISTMAPPER_PUBLIC_TYPE NOVA_TWISTMAPPER_PUBLIC
+#define NOVA_TWISTMAPPER_LOCAL
+#else
+#define NOVA_TWISTMAPPER_EXPORT __attribute__((visibility("default")))
+#define NOVA_TWISTMAPPER_IMPORT
+#if __GNUC__ >= 4
+#define NOVA_TWISTMAPPER_PUBLIC __attribute__((visibility("default")))
+#define NOVA_TWISTMAPPER_LOCAL __attribute__((visibility("hidden")))
+#else
+#define NOVA_TWISTMAPPER_PUBLIC
+#define NOVA_TWISTMAPPER_LOCAL
+#endif
+#define NOVA_TWISTMAPPER_PUBLIC_TYPE
+#endif
+
+#endif // NOVA_TWISTMAPPER__VISIBILITY_CONTROL_H_

--- a/src/ros/rover/controllers/nova_twistmapper/package.xml
+++ b/src/ros/rover/controllers/nova_twistmapper/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>nova_ik_controller</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>Controller to convert twist messages to a virtual target end effector pose for the arm</description>
   <maintainer email="novaroverteam@monash.edu">nova</maintainer>
   <license>TODO: License declaration</license>
 

--- a/src/ros/rover/controllers/nova_twistmapper/package.xml
+++ b/src/ros/rover/controllers/nova_twistmapper/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>nova_ik_controller</name>
+  <name>nova_twistmapper</name>
   <version>0.0.0</version>
   <description>Controller to convert twist messages to a virtual target end effector pose for the arm</description>
   <maintainer email="novaroverteam@monash.edu">nova</maintainer>

--- a/src/ros/rover/controllers/nova_twistmapper/src/PoseHandle.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/PoseHandle.cpp
@@ -1,0 +1,55 @@
+//
+// Created by Bailey Chessum on 4/5/25.
+// Helper struct to just collate the different component command interfaces
+//
+
+#include <optional>
+#include "nova_twistmapper/PoseHandle.hpp"
+
+void nova_twistmapper::PoseHandle::VectorHandle::set_value(const tf2::Vector3 &vec) const {
+  x.command.get().set_value(vec.x());
+  y.command.get().set_value(vec.y());
+  z.command.get().set_value(vec.z());
+}
+
+void nova_twistmapper::PoseHandle::QuatHandle::set_value(const tf2::Quaternion &quat) const {
+  x.command.get().set_value(quat.x());
+  y.command.get().set_value(quat.y());
+  z.command.get().set_value(quat.z());
+  w.command.get().set_value(quat.w());
+}
+
+void nova_twistmapper::PoseHandle::set_value(const tf2::Transform &transform) const {
+  origin.set_value(transform.getOrigin());
+  rotation.set_value(transform.getRotation());
+}
+
+std::reference_wrapper<hardware_interface::LoanedCommandInterface> nova_twistmapper::PoseHandle::find_command_interface(
+  std::vector<hardware_interface::LoanedCommandInterface>& command_interfaces,
+  const std::string& name) {
+
+  const auto command_handle = std::find_if(
+    command_interfaces.begin(), command_interfaces.end(),
+    [&name](const auto &interface)
+    {
+      return interface.get_name() == name;
+    });
+
+  if (command_handle == command_interfaces.end()) {
+    throw std::runtime_error("Command interface not found: " + name);
+  }
+
+  return std::ref(*command_handle);
+}
+
+nova_twistmapper::PoseHandle nova_twistmapper::PoseHandle::pose_handle_from_command_interfaces(
+  std::vector<hardware_interface::LoanedCommandInterface> &command_interfaces, const std::string &prefix) {
+  return PoseHandle(
+    find_command_interface(command_interfaces, prefix + "x"),
+    find_command_interface(command_interfaces, prefix + "y"),
+    find_command_interface(command_interfaces, prefix + "z"),
+    find_command_interface(command_interfaces, prefix + "qx"),
+    find_command_interface(command_interfaces, prefix + "qy"),
+    find_command_interface(command_interfaces, prefix + "qz"),
+    find_command_interface(command_interfaces, prefix + "qw"));
+}

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -218,7 +218,8 @@ namespace nova_twistmapper
       return controller_interface::CallbackReturn::FAILURE;
     }
 
-    // TODO: Potentially initialise the command interface values
+    // Set the initial command interface values
+    pose_handle->set_value(twistmapper_pose_);
 
     RCLCPP_DEBUG(get_node()->get_logger(), "Subscriber and publisher are now active.");
     return controller_interface::CallbackReturn::SUCCESS;

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -233,7 +233,9 @@ namespace nova_twistmapper
       halt();
       is_halted = true;
     }
-    // TODO: Clear PoseHandle
+
+    // Clean up command interfaces
+    pose_handle.reset();
 
     return controller_interface::CallbackReturn::SUCCESS;
   }

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -1,25 +1,29 @@
 #include <memory>
-#include <queue>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "nova_twistmapper/nova_twistmapper.hpp"
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "rclcpp/logging.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-#include "tf2/LinearMath/Scalar.h"
-//#include "tf2_eigen/tf2_eigen/tf2_eigen.hpp"
 
 namespace
 {
   constexpr auto DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST = "/arm_ik_twist_stamped"; // TODO: changeme
-  /// The inverse of the global orientation the kinematics origin frame wants to rotate to for a roll,pitch,yaw of 0,0,0
-  const auto ENDEFFECTOR_BASIS_INVERSE = tf2::Matrix3x3(tf2::Quaternion(-0.5, 0.5, -0.5, -0.5)).inverse();
   constexpr auto ENDEFFECTOR_KINEMATICS_FRAME = "endeffector_kinematics";
   constexpr auto KINEMATICS_ORIGIN_FRAME = "arm_kinematics_origin";
   constexpr auto TWISTMAPPER_TARGET_FRAME = "arm_twistmapper_target";
+
+  constexpr std::array<const char* const, 7> POSE_COMPONENTS = {
+    "x",
+    "y",
+    "z",
+    "qx",
+    "qy",
+    "qz",
+    "qw",
+  };
 } // namespace
 
 using std::placeholders::_1;
@@ -53,9 +57,9 @@ namespace nova_twistmapper
   InterfaceConfiguration NovaTwistmapper::command_interface_configuration() const
   {
     std::vector<std::string> conf_names;
-    for (const auto &joint_name : params_.joint_names)
+    for (const auto &component_name : POSE_COMPONENTS)
     {
-      conf_names.push_back(joint_to_command_interface_name(joint_name));
+      conf_names.push_back(pose_component_to_command_interface_name(component_name));
     }
 
     return {interface_configuration_type::INDIVIDUAL, conf_names};
@@ -68,7 +72,7 @@ namespace nova_twistmapper
     return {interface_configuration_type::INDIVIDUAL, conf_names};
   }
 
-  void NovaTwistmapper::update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period) {
+  void NovaTwistmapper::update_twistmapper_pose(const rclcpp::Time &time, const rclcpp::Duration &period) {
     std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
     received_twist_stamped_ptr.get(twist_stamped);
 
@@ -86,11 +90,6 @@ namespace nova_twistmapper
 
     // Create rotation matrix from twist.angular as XYZ euler
     auto rotation_matrix = tf2::Matrix3x3();
-    /*rotation_matrix.setRPY(
-      twist.angular.x * period.seconds(),
-      twist.angular.y * period.seconds(),
-      twist.angular.z * period.seconds());
-      */
     rotation_matrix.setRPY(twistmapper_pose_rpy_.x(), twistmapper_pose_rpy_.y(), twistmapper_pose_rpy_.z());
 
     const auto linear = tf2::Vector3(
@@ -103,25 +102,9 @@ namespace nova_twistmapper
     // TODO: If using tf like this, also have the twistmapper broadcast the target frame, so it can reference itself.
     twistmapper_pose_.setOrigin(linear + twistmapper_pose_.getOrigin());
     twistmapper_pose_.setBasis(rotation_matrix);
-
-    // Publish twistmapper pose to tf2
-    geometry_msgs::msg::TransformStamped transform_stamped;
-    transform_stamped.transform = toMsg(twistmapper_pose_);
-    transform_stamped.header.stamp = time;
-
-    // TODO: Parameterize
-    transform_stamped.child_frame_id = TWISTMAPPER_TARGET_FRAME;
-    transform_stamped.header.frame_id = KINEMATICS_ORIGIN_FRAME;
-
-    RCLCPP_INFO_ONCE(get_node()->get_logger(), "Broadcasting twistmapper pose as '%s', child of '%s'.",
-                     transform_stamped.child_frame_id.c_str(),
-                     transform_stamped.header.frame_id.c_str());
-
-    twistmapper_pose_tf_broadcaster_->sendTransform(transform_stamped);
   }
 
-  controller_interface::return_type NovaTwistmapper::update(
-      const rclcpp::Time &time, const rclcpp::Duration &period)
+  controller_interface::return_type NovaTwistmapper::update(const rclcpp::Time &time, const rclcpp::Duration &period)
   {
     auto logger = get_node()->get_logger();
     if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
@@ -135,25 +118,17 @@ namespace nova_twistmapper
       return controller_interface::return_type::OK;
     }
 
-    update_twistmapper(time, period);
+    if (!pose_handle.has_value())
+      return controller_interface::return_type::ERROR;
 
-    // TODO: Retrieve these values from the robot description, rather than specifying them directly
-    // TODO: Or even simpler, just put these in params!!!
-    constexpr std::array<double, 3> lengths = {0.5, 0.68332, 0.11073};
-
-    auto joint_angles = calculate_ik(twistmapper_pose_, lengths);
-
-    for (unsigned int i = 0; i < joint_angles.size(); i++)
-    {
-      auto& joint_handle = registered_joint_handles_[i];
-      joint_handle.command.get().set_value(joint_angles[i]);
-    }
+    update_twistmapper_pose(time, period);
+    publish_to_tf2(time);
+    pose_handle.value().set_value(twistmapper_pose_);
 
     return controller_interface::return_type::OK;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_configure(
-      const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_configure(const rclcpp_lifecycle::State&)
   {
     auto logger = get_node()->get_logger();
     RCLCPP_INFO(logger, "On configure");
@@ -162,10 +137,6 @@ namespace nova_twistmapper
     if (param_listener_->is_old(params_))
     {
       params_ = param_listener_->get_params();
-    }
-    if (params_.joint_names.empty())
-    {
-      return controller_interface::CallbackReturn::ERROR;
     }
 
     // TODO: maybe limit position so arm doesn't collide?
@@ -178,7 +149,6 @@ namespace nova_twistmapper
     tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_node()->get_clock());
     tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-    // TODO: insert correct subscriber here
     twist_stamped_sub = get_node()->create_subscription<geometry_msgs::msg::TwistStamped>(
       DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST,
       rclcpp::SystemDefaultsQoS(),
@@ -211,19 +181,22 @@ namespace nova_twistmapper
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_activate(
-      const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_activate(const rclcpp_lifecycle::State&)
   {
     RCLCPP_INFO(get_node()->get_logger(), "On activate");
-    const auto joints_result = configure_joints(params_.joint_names, registered_joint_handles_);
 
-    if (joints_result == controller_interface::CallbackReturn::ERROR)
-    {
-      RCLCPP_ERROR(
-          get_node()->get_logger(),
-          "Some joint interfaces are non existent");
-      return controller_interface::CallbackReturn::ERROR;
+    const auto prefix = params_.chained_controller_name.empty() ? ""
+      : params_.chained_controller_name + "/";
+
+    // Configure command interfaces for the pose
+    try {
+      pose_handle = PoseHandle::pose_handle_from_command_interfaces(command_interfaces_, prefix);
+    } catch (const std::runtime_error& e) {
+      RCLCPP_ERROR(get_node()->get_logger(), "%s. Do the given chainable controller name and interfaces exist?",
+                   e.what());
+      return CallbackReturn::FAILURE;
     }
+
     is_halted = false;
     subscriber_is_active_ = true;
 
@@ -245,13 +218,13 @@ namespace nova_twistmapper
       return controller_interface::CallbackReturn::FAILURE;
     }
 
-    // TODO: setup sub and pub
+    // TODO: Potentially initialise the command interface values
+
     RCLCPP_DEBUG(get_node()->get_logger(), "Subscriber and publisher are now active.");
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_deactivate(
-      const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_deactivate(const rclcpp_lifecycle::State&)
   {
     subscriber_is_active_ = false;
     if (!is_halted)
@@ -259,13 +232,12 @@ namespace nova_twistmapper
       halt();
       is_halted = true;
     }
-    registered_joint_handles_.clear();
+    // TODO: Clear PoseHandle
 
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_cleanup(
-      const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_cleanup(const rclcpp_lifecycle::State&)
   {
     if (!reset())
     {
@@ -275,7 +247,7 @@ namespace nova_twistmapper
     return controller_interface::CallbackReturn::SUCCESS;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_error(const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_error(const rclcpp_lifecycle::State&)
   {
     if (!reset())
     {
@@ -293,8 +265,7 @@ namespace nova_twistmapper
     return true;
   }
 
-  controller_interface::CallbackReturn NovaTwistmapper::on_shutdown(
-      const rclcpp_lifecycle::State &)
+  controller_interface::CallbackReturn NovaTwistmapper::on_shutdown(const rclcpp_lifecycle::State&)
   {
     return controller_interface::CallbackReturn::SUCCESS;
   }
@@ -314,128 +285,21 @@ namespace nova_twistmapper
     twist_stamped->twist.angular.z = 0;
   }
 
-  std::string NovaTwistmapper::joint_to_command_interface_name(const std::string& joint_name) const {
-    // If chained_controller_name is non-empty, prepend it plus "/"
-    // Example result: "nova_arm_controller/J1/position"
-    const auto prefix = params_.chained_controller_name.empty() ? "" : params_.chained_controller_name + "/";
-    return prefix + joint_name + "/" + hardware_interface::HW_IF_POSITION;
-  }
+  void NovaTwistmapper::publish_to_tf2(const rclcpp::Time &time) {
+    // Publish twistmapper pose to tf2
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    transform_stamped.transform = toMsg(twistmapper_pose_);
+    transform_stamped.header.stamp = time;
 
-  controller_interface::CallbackReturn NovaTwistmapper::configure_joints(
-      const std::vector<std::string> &joint_names,
-      std::vector<JointHandle> &registered_handles)
-  {
-    auto logger = get_node()->get_logger();
-    RCLCPP_INFO(logger, "Configure joints");
+    // TODO: Parameterize
+    transform_stamped.child_frame_id = TWISTMAPPER_TARGET_FRAME;
+    transform_stamped.header.frame_id = KINEMATICS_ORIGIN_FRAME;
 
-    if (joint_names.empty())
-    {
-      RCLCPP_ERROR(logger, "No joint names specified");
-      return controller_interface::CallbackReturn::ERROR;
-    }
+    RCLCPP_INFO_ONCE(get_node()->get_logger(), "Broadcasting twistmapper pose as '%s', child of '%s'.",
+                     transform_stamped.child_frame_id.c_str(),
+                     transform_stamped.header.frame_id.c_str());
 
-    // register handles
-    registered_handles.reserve(joint_names.size());
-    // TODO: pos/vel/etc limits --> Do we need these here if we are hooking into nova_arm_controller? - Bailey
-    for (const auto &joint_name : joint_names)
-    {
-      const auto command_interface_name = joint_to_command_interface_name(joint_name);
-
-      const auto command_handle = std::find_if(
-        command_interfaces_.begin(), command_interfaces_.end(),
-        [&joint_name, &logger, &command_interface_name](const auto &interface)
-        {
-          return interface.get_name() == command_interface_name;
-        });
-
-      if (command_handle == command_interfaces_.end())
-      {
-        RCLCPP_ERROR(logger, "Unable to obtain joint command handle '%s' for %s", command_interface_name.c_str(), joint_name.c_str());
-
-        RCLCPP_ERROR(logger, "command_interfaces_:");
-        for (const auto& command_interface : command_interfaces_) {
-          RCLCPP_ERROR(logger, "  > interface_name: %s", command_interface.get_interface_name().c_str());
-          RCLCPP_ERROR(logger, "    prefix_name: %s", command_interface.get_prefix_name().c_str());
-          RCLCPP_ERROR(logger, "    name: %s", command_interface.get_name().c_str());
-        }
-        return controller_interface::CallbackReturn::ERROR;
-      }
-
-      registered_handles.emplace_back(
-        JointHandle{joint_name, std::ref(*command_handle)});
-    }
-
-    return controller_interface::CallbackReturn::SUCCESS;
-  }
-
-  // See Keenan's IK notes
-  // TODO: remember to add something for the effector pose
-  std::array<double, 6> NovaTwistmapper::calculate_ik(tf2::Transform pose, std::array<double, 3> lengths)
-  {
-    auto origin = pose.getOrigin();
-    auto x = origin.getX();
-    auto y = origin.getY();
-    auto z = origin.getZ();
-
-    tf2::Matrix3x3 rotated_basis = pose.getBasis() * ENDEFFECTOR_BASIS_INVERSE;
-
-    double l1r = lengths[0];
-    double l2r = lengths[1];
-    double l3 = lengths[2];
-
-    Eigen::Matrix3d rxyz {
-      {rotated_basis[0][0], rotated_basis[0][1], rotated_basis[0][2]},
-      {rotated_basis[1][0], rotated_basis[1][1], rotated_basis[1][2]},
-      {rotated_basis[2][0], rotated_basis[2][1], rotated_basis[2][2]}
-    };  // rxyz orientation matrix
-
-    Eigen::Matrix4d t07r = Eigen::Matrix4d::Zero();
-    t07r.topLeftCorner<3,3>() = rxyz;
-
-    t07r(3, 3) = 1;
-    t07r(0, 3) = x;
-    t07r(1, 3) = y;
-    t07r(2, 3) = z;
-
-    Eigen::Matrix4d t67 { {1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, l3}, {0, 0, 0, 1} };
-    Eigen::Matrix4d t0_wrist = t07r * t67.inverse();
-
-    double wrist_x = t0_wrist(0, 3);
-    double wrist_y = t0_wrist(1, 3);
-    double wrist_z = t0_wrist(2, 3);
-
-    double j1 = atan2(wrist_y, wrist_x);
-    double l = sqrt(pow(wrist_x, 2) + pow(wrist_y, 2));
-    double j3a = acos((pow(l, 2) + pow(wrist_z, 2) - pow(l1r, 2) - pow(l2r, 2)) / (2 * l1r * l2r));
-    double j3b = -j3a; // expands to -acos((l^2+wrist_z^2-L1r^2-L2r^2)/(2*L1r*L2r)) as per keenan's notes
-    double j3ao = j3a + M_PI / 2;
-    double j3bo = j3b + M_PI / 2;
-
-    double k1a = l1r + l2r * cos(j3a);
-    double k2a = l2r * sin(j3a);
-    double k1b = l1r + l2r * cos(j3b);
-    double k2b = l2r * sin(j3b);
-
-    double j2a = atan2(wrist_z, l) - atan2(k2a, k1a);
-    double j2b = atan2(wrist_z, l) - atan2(k2b, k1b);
-    double j2ao = j2a - M_PI / 2;
-    double j2bo = j2b - M_PI / 2;
-
-    Eigen::Matrix4d t01 = sub_dh(0, 0, 0, j1);
-    Eigen::Matrix4d t12 = sub_dh(M_PI / 2, 0, 0, j2bo + M_PI / 2);
-    Eigen::Matrix4d t23 = sub_dh(0, l1r, 0, j3bo - M_PI / 2);
-    Eigen::Matrix4d t02 = t01 * t12;
-    Eigen::Matrix4d t03_wrist = t02 * t23;
-    Eigen::Matrix3d r03_wrist = t03_wrist.topLeftCorner<3, 3>(); // R03_wrist = T03_wrist(1:3,1:3); in matlab
-    Eigen::Matrix3d r07r = t07r.topLeftCorner<3, 3>(); // see above
-    Eigen::Matrix3d r37r = r03_wrist.inverse() * r07r;
-
-    double j4 = atan2(r37r(1, 2), r37r(0, 2));
-    double j5 = atan2(-r37r(2, 2), r37r(0, 2) / cos(j4));
-    double j6 = atan2(-r37r(2, 1) / cos(j5), r37r(2, 0) / cos(j5));
-
-    std::array<double, 6> new_joints = { -j1, -j2bo, -j3bo, -j4, -j5, -j6 };
-    return new_joints;
+    twistmapper_pose_tf_broadcaster_->sendTransform(transform_stamped);
   }
 } // namespace nova_twistmapper
 

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -1,0 +1,445 @@
+#include <memory>
+#include <queue>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "nova_twistmapper/nova_twistmapper.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "rclcpp/logging.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include "tf2/LinearMath/Scalar.h"
+//#include "tf2_eigen/tf2_eigen/tf2_eigen.hpp"
+
+namespace
+{
+  constexpr auto DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST = "/arm_ik_twist_stamped"; // TODO: changeme
+  /// The inverse of the global orientation the kinematics origin frame wants to rotate to for a roll,pitch,yaw of 0,0,0
+  const auto ENDEFFECTOR_BASIS_INVERSE = tf2::Matrix3x3(tf2::Quaternion(-0.5, 0.5, -0.5, -0.5)).inverse();
+  constexpr auto ENDEFFECTOR_KINEMATICS_FRAME = "endeffector_kinematics";
+  constexpr auto KINEMATICS_ORIGIN_FRAME = "arm_kinematics_origin";
+  constexpr auto TWISTMAPPER_TARGET_FRAME = "arm_twistmapper_target";
+} // namespace
+
+using std::placeholders::_1;
+
+namespace nova_twistmapper
+{
+  using namespace std::chrono_literals;
+  using controller_interface::interface_configuration_type;
+  using controller_interface::InterfaceConfiguration;
+  using lifecycle_msgs::msg::State;
+
+  NovaTwistmapper::NovaTwistmapper() : controller_interface::ControllerInterface() {}
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_init()
+  {
+    try
+    {
+      // Create the parameter listener and get the parameters
+      param_listener_ = std::make_shared<ParamListener>(get_node());
+      params_ = param_listener_->get_params();
+    }
+    catch (const std::exception &e)
+    {
+      fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  InterfaceConfiguration NovaTwistmapper::command_interface_configuration() const
+  {
+    std::vector<std::string> conf_names;
+    for (const auto &joint_name : params_.joint_names)
+    {
+      conf_names.push_back(joint_to_command_interface_name(joint_name));
+    }
+
+    return {interface_configuration_type::INDIVIDUAL, conf_names};
+  }
+
+  InterfaceConfiguration NovaTwistmapper::state_interface_configuration() const
+  {
+    std::vector<std::string> conf_names;
+
+    return {interface_configuration_type::INDIVIDUAL, conf_names};
+  }
+
+  void NovaTwistmapper::update_twistmapper(const rclcpp::Time &time, const rclcpp::Duration &period) {
+    std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
+    received_twist_stamped_ptr.get(twist_stamped);
+
+    if (twist_stamped == nullptr) {
+      RCLCPP_WARN(get_node()->get_logger(), "Haven't yet received a TwistStamped message to use for the twistmapper.");
+      return;
+    }
+
+    const auto& twist = twist_stamped->twist;
+
+    tf2::Vector3 tf2_twist_angular;
+    tf2::fromMsg(twist.angular, tf2_twist_angular);
+
+    twistmapper_pose_rpy_ = twistmapper_pose_rpy_ + tf2_twist_angular * period.seconds();
+
+    // Create rotation matrix from twist.angular as XYZ euler
+    auto rotation_matrix = tf2::Matrix3x3();
+    /*rotation_matrix.setRPY(
+      twist.angular.x * period.seconds(),
+      twist.angular.y * period.seconds(),
+      twist.angular.z * period.seconds());
+      */
+    rotation_matrix.setRPY(twistmapper_pose_rpy_.x(), twistmapper_pose_rpy_.y(), twistmapper_pose_rpy_.z());
+
+    const auto linear = tf2::Vector3(
+      twist.linear.x * period.seconds(),
+      twist.linear.y * period.seconds(),
+      twist.linear.z * period.seconds());
+
+    // TODO: Test this actually works as expected.
+    // TODO: Add a tf buffer and make use of the header.frame_id from the twist_stamped to allow IK to be done relative to anything. Then Teleop would just need to use the end effector frame by default
+    // TODO: If using tf like this, also have the twistmapper broadcast the target frame, so it can reference itself.
+    twistmapper_pose_.setOrigin(linear + twistmapper_pose_.getOrigin());
+    twistmapper_pose_.setBasis(rotation_matrix);
+
+    // Publish twistmapper pose to tf2
+    geometry_msgs::msg::TransformStamped transform_stamped;
+    transform_stamped.transform = toMsg(twistmapper_pose_);
+    transform_stamped.header.stamp = time;
+
+    // TODO: Parameterize
+    transform_stamped.child_frame_id = TWISTMAPPER_TARGET_FRAME;
+    transform_stamped.header.frame_id = KINEMATICS_ORIGIN_FRAME;
+
+    RCLCPP_INFO_ONCE(get_node()->get_logger(), "Broadcasting twistmapper pose as '%s', child of '%s'.",
+                     transform_stamped.child_frame_id.c_str(),
+                     transform_stamped.header.frame_id.c_str());
+
+    twistmapper_pose_tf_broadcaster_->sendTransform(transform_stamped);
+  }
+
+  controller_interface::return_type NovaTwistmapper::update(
+      const rclcpp::Time &time, const rclcpp::Duration &period)
+  {
+    auto logger = get_node()->get_logger();
+    if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
+    {
+      if (!is_halted)
+      {
+        halt();
+        is_halted = true;
+      }
+
+      return controller_interface::return_type::OK;
+    }
+
+    update_twistmapper(time, period);
+
+    // TODO: Retrieve these values from the robot description, rather than specifying them directly
+    // TODO: Or even simpler, just put these in params!!!
+    constexpr std::array<double, 3> lengths = {0.5, 0.68332, 0.11073};
+
+    auto joint_angles = calculate_ik(twistmapper_pose_, lengths);
+
+    for (unsigned int i = 0; i < joint_angles.size(); i++)
+    {
+      auto& joint_handle = registered_joint_handles_[i];
+      joint_handle.command.get().set_value(joint_angles[i]);
+    }
+
+    return controller_interface::return_type::OK;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_configure(
+      const rclcpp_lifecycle::State &)
+  {
+    auto logger = get_node()->get_logger();
+    RCLCPP_INFO(logger, "On configure");
+
+    // update parameters if they have changed
+    if (param_listener_->is_old(params_))
+    {
+      params_ = param_listener_->get_params();
+    }
+    if (params_.joint_names.empty())
+    {
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    // TODO: maybe limit position so arm doesn't collide?
+    if (!reset())
+    {
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    twistmapper_pose_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(tf2_ros::TransformBroadcaster(*get_node()));
+    tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_node()->get_clock());
+    tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+    // TODO: insert correct subscriber here
+    twist_stamped_sub = get_node()->create_subscription<geometry_msgs::msg::TwistStamped>(
+      DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST,
+      rclcpp::SystemDefaultsQoS(),
+      [this, logger](const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg) -> void
+      {
+        RCLCPP_INFO_ONCE(logger, "Twist message received.");
+
+        if (!subscriber_is_active_)
+        {
+          RCLCPP_WARN_ONCE(
+            logger, "Can't accept new commands. subscriber is inactive");
+          return;
+        }
+        if ((msg->header.stamp.sec == 0) && (msg->header.stamp.nanosec == 0))
+        {
+          RCLCPP_WARN_ONCE(
+            logger,
+            "Received message with zero timestamp, setting it to current "
+            "time, this message will only be shown once");
+          msg->header.stamp = get_node()->get_clock()->now();
+        }
+
+        received_twist_stamped_ptr.set(std::move(msg));
+      });
+    subscriber_is_active_ = true;
+
+    RCLCPP_INFO(logger, "Created twist stamped subscription");
+
+    previous_update_timestamp_ = get_node()->get_clock()->now();
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_activate(
+      const rclcpp_lifecycle::State &)
+  {
+    RCLCPP_INFO(get_node()->get_logger(), "On activate");
+    const auto joints_result = configure_joints(params_.joint_names, registered_joint_handles_);
+
+    if (joints_result == controller_interface::CallbackReturn::ERROR)
+    {
+      RCLCPP_ERROR(
+          get_node()->get_logger(),
+          "Some joint interfaces are non existent");
+      return controller_interface::CallbackReturn::ERROR;
+    }
+    is_halted = false;
+    subscriber_is_active_ = true;
+
+    try {
+      auto tf_transform = tf_buffer_->lookupTransform(
+        KINEMATICS_ORIGIN_FRAME, ENDEFFECTOR_KINEMATICS_FRAME, tf2::TimePointZero);
+      tf2::fromMsg(tf_transform.transform, twistmapper_pose_);
+
+      double roll, pitch, yaw;
+      twistmapper_pose_.getBasis().getRPY(roll, pitch, yaw);
+
+      twistmapper_pose_rpy_.setX(roll);
+      twistmapper_pose_rpy_.setY(pitch);
+      twistmapper_pose_rpy_.setZ(yaw);
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_INFO(
+        get_node()->get_logger(), "Could not transform %s to %s: %s",
+        ENDEFFECTOR_KINEMATICS_FRAME, KINEMATICS_ORIGIN_FRAME, ex.what());
+      return controller_interface::CallbackReturn::FAILURE;
+    }
+
+    // TODO: setup sub and pub
+    RCLCPP_DEBUG(get_node()->get_logger(), "Subscriber and publisher are now active.");
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_deactivate(
+      const rclcpp_lifecycle::State &)
+  {
+    subscriber_is_active_ = false;
+    if (!is_halted)
+    {
+      halt();
+      is_halted = true;
+    }
+    registered_joint_handles_.clear();
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_cleanup(
+      const rclcpp_lifecycle::State &)
+  {
+    if (!reset())
+    {
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_error(const rclcpp_lifecycle::State &)
+  {
+    if (!reset())
+    {
+      return controller_interface::CallbackReturn::ERROR;
+    }
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  bool NovaTwistmapper::reset()
+  {
+    // release the old queue
+    subscriber_is_active_ = false;
+
+    is_halted = false;
+    return true;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::on_shutdown(
+      const rclcpp_lifecycle::State &)
+  {
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  void NovaTwistmapper::halt()
+  {
+    // Set twistmapper velocities to 0
+    std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
+    received_twist_stamped_ptr.get(twist_stamped);
+
+    twist_stamped->twist.linear.x = 0;
+    twist_stamped->twist.linear.y = 0;
+    twist_stamped->twist.linear.z = 0;
+
+    twist_stamped->twist.angular.x = 0;
+    twist_stamped->twist.angular.y = 0;
+    twist_stamped->twist.angular.z = 0;
+  }
+
+  std::string NovaTwistmapper::joint_to_command_interface_name(const std::string& joint_name) const {
+    // If chained_controller_name is non-empty, prepend it plus "/"
+    // Example result: "nova_arm_controller/J1/position"
+    const auto prefix = params_.chained_controller_name.empty() ? "" : params_.chained_controller_name + "/";
+    return prefix + joint_name + "/" + hardware_interface::HW_IF_POSITION;
+  }
+
+  controller_interface::CallbackReturn NovaTwistmapper::configure_joints(
+      const std::vector<std::string> &joint_names,
+      std::vector<JointHandle> &registered_handles)
+  {
+    auto logger = get_node()->get_logger();
+    RCLCPP_INFO(logger, "Configure joints");
+
+    if (joint_names.empty())
+    {
+      RCLCPP_ERROR(logger, "No joint names specified");
+      return controller_interface::CallbackReturn::ERROR;
+    }
+
+    // register handles
+    registered_handles.reserve(joint_names.size());
+    // TODO: pos/vel/etc limits --> Do we need these here if we are hooking into nova_arm_controller? - Bailey
+    for (const auto &joint_name : joint_names)
+    {
+      const auto command_interface_name = joint_to_command_interface_name(joint_name);
+
+      const auto command_handle = std::find_if(
+        command_interfaces_.begin(), command_interfaces_.end(),
+        [&joint_name, &logger, &command_interface_name](const auto &interface)
+        {
+          return interface.get_name() == command_interface_name;
+        });
+
+      if (command_handle == command_interfaces_.end())
+      {
+        RCLCPP_ERROR(logger, "Unable to obtain joint command handle '%s' for %s", command_interface_name.c_str(), joint_name.c_str());
+
+        RCLCPP_ERROR(logger, "command_interfaces_:");
+        for (const auto& command_interface : command_interfaces_) {
+          RCLCPP_ERROR(logger, "  > interface_name: %s", command_interface.get_interface_name().c_str());
+          RCLCPP_ERROR(logger, "    prefix_name: %s", command_interface.get_prefix_name().c_str());
+          RCLCPP_ERROR(logger, "    name: %s", command_interface.get_name().c_str());
+        }
+        return controller_interface::CallbackReturn::ERROR;
+      }
+
+      registered_handles.emplace_back(
+        JointHandle{joint_name, std::ref(*command_handle)});
+    }
+
+    return controller_interface::CallbackReturn::SUCCESS;
+  }
+
+  // See Keenan's IK notes
+  // TODO: remember to add something for the effector pose
+  std::array<double, 6> NovaTwistmapper::calculate_ik(tf2::Transform pose, std::array<double, 3> lengths)
+  {
+    auto origin = pose.getOrigin();
+    auto x = origin.getX();
+    auto y = origin.getY();
+    auto z = origin.getZ();
+
+    tf2::Matrix3x3 rotated_basis = pose.getBasis() * ENDEFFECTOR_BASIS_INVERSE;
+
+    double l1r = lengths[0];
+    double l2r = lengths[1];
+    double l3 = lengths[2];
+
+    Eigen::Matrix3d rxyz {
+      {rotated_basis[0][0], rotated_basis[0][1], rotated_basis[0][2]},
+      {rotated_basis[1][0], rotated_basis[1][1], rotated_basis[1][2]},
+      {rotated_basis[2][0], rotated_basis[2][1], rotated_basis[2][2]}
+    };  // rxyz orientation matrix
+
+    Eigen::Matrix4d t07r = Eigen::Matrix4d::Zero();
+    t07r.topLeftCorner<3,3>() = rxyz;
+
+    t07r(3, 3) = 1;
+    t07r(0, 3) = x;
+    t07r(1, 3) = y;
+    t07r(2, 3) = z;
+
+    Eigen::Matrix4d t67 { {1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, l3}, {0, 0, 0, 1} };
+    Eigen::Matrix4d t0_wrist = t07r * t67.inverse();
+
+    double wrist_x = t0_wrist(0, 3);
+    double wrist_y = t0_wrist(1, 3);
+    double wrist_z = t0_wrist(2, 3);
+
+    double j1 = atan2(wrist_y, wrist_x);
+    double l = sqrt(pow(wrist_x, 2) + pow(wrist_y, 2));
+    double j3a = acos((pow(l, 2) + pow(wrist_z, 2) - pow(l1r, 2) - pow(l2r, 2)) / (2 * l1r * l2r));
+    double j3b = -j3a; // expands to -acos((l^2+wrist_z^2-L1r^2-L2r^2)/(2*L1r*L2r)) as per keenan's notes
+    double j3ao = j3a + M_PI / 2;
+    double j3bo = j3b + M_PI / 2;
+
+    double k1a = l1r + l2r * cos(j3a);
+    double k2a = l2r * sin(j3a);
+    double k1b = l1r + l2r * cos(j3b);
+    double k2b = l2r * sin(j3b);
+
+    double j2a = atan2(wrist_z, l) - atan2(k2a, k1a);
+    double j2b = atan2(wrist_z, l) - atan2(k2b, k1b);
+    double j2ao = j2a - M_PI / 2;
+    double j2bo = j2b - M_PI / 2;
+
+    Eigen::Matrix4d t01 = sub_dh(0, 0, 0, j1);
+    Eigen::Matrix4d t12 = sub_dh(M_PI / 2, 0, 0, j2bo + M_PI / 2);
+    Eigen::Matrix4d t23 = sub_dh(0, l1r, 0, j3bo - M_PI / 2);
+    Eigen::Matrix4d t02 = t01 * t12;
+    Eigen::Matrix4d t03_wrist = t02 * t23;
+    Eigen::Matrix3d r03_wrist = t03_wrist.topLeftCorner<3, 3>(); // R03_wrist = T03_wrist(1:3,1:3); in matlab
+    Eigen::Matrix3d r07r = t07r.topLeftCorner<3, 3>(); // see above
+    Eigen::Matrix3d r37r = r03_wrist.inverse() * r07r;
+
+    double j4 = atan2(r37r(1, 2), r37r(0, 2));
+    double j5 = atan2(-r37r(2, 2), r37r(0, 2) / cos(j4));
+    double j6 = atan2(-r37r(2, 1) / cos(j5), r37r(2, 0) / cos(j5));
+
+    std::array<double, 6> new_joints = { -j1, -j2bo, -j3bo, -j4, -j5, -j6 };
+    return new_joints;
+  }
+} // namespace nova_twistmapper
+
+#include "class_loader/register_macro.hpp"
+
+CLASS_LOADER_REGISTER_CLASS(
+    nova_twistmapper::NovaTwistmapper, controller_interface::ControllerInterface)

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -302,6 +302,13 @@ namespace nova_twistmapper
 
     twistmapper_pose_tf_broadcaster_->sendTransform(transform_stamped);
   }
+
+  std::string NovaTwistmapper::pose_component_to_command_interface_name(const std::string &component_name) const {
+    // If chained_controller_name is non-empty, prepend it plus "/"
+    // Example result: "nova_arm_controller/J1/position"
+    const auto prefix = params_.chained_controller_name.empty() ? "" : params_.chained_controller_name + "/";
+    return prefix + component_name;
+  }
 } // namespace nova_twistmapper
 
 #include "class_loader/register_macro.hpp"

--- a/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
+++ b/src/ros/rover/controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
@@ -1,0 +1,13 @@
+nova_twistmapper:
+  chained_controller_name: {
+    type: string,
+    default_value: "nova_ik_controller",
+    description: "The name of the chainable controller to capture reference interfaces from. Leave empty to use hardware interfaces."
+  }
+
+  # Twistmapper
+  twist_stamped_topic: {
+    type: string,
+    default_value: "/arm_ik_twist_stamped",
+    description: "The name of the topic to get teleop twist stamped messages from."
+  }

--- a/src/ros/rover/controllers/nova_twistmapper/twistmapper_plugin.xml
+++ b/src/ros/rover/controllers/nova_twistmapper/twistmapper_plugin.xml
@@ -1,0 +1,7 @@
+<library path="nova_twistmapper">
+  <class name="nova_twistmapper/NovaTwistmapper" type="nova_twistmapper::NovaTwistmapper" base_class_type="controller_interface::ControllerInterface">
+  <description>
+    Controller to convert twist messages to a virtual target end effector pose for the arm
+  </description>
+  </class>
+</library>

--- a/src/ros/rover/nix/packages/controllers/default.nix
+++ b/src/ros/rover/nix/packages/controllers/default.nix
@@ -8,4 +8,5 @@ with pkgs;
   nova-diff-drive-controller = callPackage ./nova-diff-drive-controller { };
   nova-arm-controller = callPackage ./nova-arm-controller { };
   nova-ik-controller = callPackage ./nova-ik-controller { };
+  nova-twistmapper = callPackage ./nova-twistmapper { };
 }

--- a/src/ros/rover/nix/packages/controllers/nova-twistmapper/default.nix
+++ b/src/ros/rover/nix/packages/controllers/nova-twistmapper/default.nix
@@ -1,0 +1,50 @@
+{ lib
+, buildRosPackage
+, ament-cmake
+, control-msgs
+, controller-interface
+, hardware-interface
+, pluginlib
+, rclcpp
+, rclcpp-lifecycle
+, std-srvs
+, generate-parameter-library
+, rcpputils
+, backward-ros
+, realtime-tools
+, tf2
+, tf2-msgs
+, geometry-msgs
+, tf2-geometry-msgs
+}:
+
+buildRosPackage {
+  name = "nova-twistmapper";
+  buildType = "ament_cmake";
+
+  src = builtins.path rec {
+    name = "nova_twistmapper-source";
+    path = ../../../../controllers/nova_twistmapper;
+    filter = lib.novaSourceFilter [ ] path;
+  };
+
+  nativeBuildInputs = [ ament-cmake ];
+
+  buildInputs = [
+    control-msgs
+    controller-interface
+    hardware-interface
+    pluginlib
+    rclcpp
+    rclcpp-lifecycle
+    std-srvs
+    generate-parameter-library
+    backward-ros
+    realtime-tools
+    tf2
+    tf2-msgs
+    geometry-msgs
+    tf2-geometry-msgs
+  ];
+}
+

--- a/src/ros/rover/teleop_arm_joy/config/ps5.config.yaml
+++ b/src/ros/rover/teleop_arm_joy/config/ps5.config.yaml
@@ -2,7 +2,7 @@ teleop_arm_joy_node:
   ros__parameters:
     twist:
       linear_max: 0.25
-      angular_max: 1.57079632679
+      angular_max: 0.785398163395
     joints:
       J1:
         max_speed: 0.785398163395
@@ -37,10 +37,11 @@ teleop_arm_joy_node:
 
       J4:
         device: "Gamepad"
-        id: 1
+        id: 3
+        invert: true
       J5:
         device: "Gamepad"
-        id: 3
+        id: 2
         invert: true
       J6:
         device: "Gamepad"
@@ -57,14 +58,14 @@ teleop_arm_joy_node:
 
       twist_x:
         device: "Gamepad"
-        button_id_negative: 11
-        button_id_positive: 12
-        invert: true
+        button_id_negative: 12
+        button_id_positive: 11
+        id: 1
       twist_y:
         device: "Gamepad"
-        button_id_negative: 13
-        button_id_positive: 14
-        invert: true
+        button_id_negative: 14
+        button_id_positive: 13
+        id: 0
       twist_z:
         device: "Gamepad"
         button_id_negative: 0
@@ -75,8 +76,12 @@ teleop_arm_joy_node:
         id: 2
       twist_pitch:
         device: "Gamepad"
+        id: 3
+        invert: true
       twist_roll:
         device: "Gamepad"
+        button_id_negative: 2
+        button_id_positive: 1
 
     buttons:
       twist_mode:

--- a/src/ros/rover/teleop_arm_joy/config/ps5.config.yaml
+++ b/src/ros/rover/teleop_arm_joy/config/ps5.config.yaml
@@ -2,21 +2,20 @@ teleop_arm_joy_node:
   ros__parameters:
     twist:
       linear_max: 0.25
-      angular_max: 1.0
-
+      angular_max: 1.57079632679
     joints:
       J1:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
       J2:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
       J3:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
       J4:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
       J5:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
       J6:
-        max_speed: 1.57079632679
+        max_speed: 0.785398163395
     device_names: ["Gamepad"]
     devices:
       Gamepad:
@@ -34,6 +33,7 @@ teleop_arm_joy_node:
         device: "Gamepad"
         button_id_negative: 0
         button_id_positive: 3
+        invert: true
 
       J4:
         device: "Gamepad"
@@ -54,23 +54,27 @@ teleop_arm_joy_node:
 #        device: "Gamepad"
 #        id: 4
 
+
       twist_x:
         device: "Gamepad"
-        id: 0
+        button_id_negative: 11
+        button_id_positive: 12
+        invert: true
       twist_y:
         device: "Gamepad"
-        id: 1
+        button_id_negative: 13
+        button_id_positive: 14
         invert: true
       twist_z:
         device: "Gamepad"
-        id: 3
+        button_id_negative: 0
+        button_id_positive: 3
 
       twist_yaw:
         device: "Gamepad"
         id: 2
       twist_pitch:
         device: "Gamepad"
-        id: 0
       twist_roll:
         device: "Gamepad"
 

--- a/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
+++ b/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
@@ -54,8 +54,7 @@ namespace teleop_arm_joy
    * @class TeleopArmJoy
    * @brief Class for handling joystick input and publishing arm commands.
    */
-  class TeleopArmJoy : public rclcpp::Node
-  {
+class TeleopArmJoy : public rclcpp::Node {
   public:
     /**
      * @brief Constructor for TeleopArmJoy.

--- a/src/ros/rover/teleop_arm_joy/src/parameters.yaml
+++ b/src/ros/rover/teleop_arm_joy/src/parameters.yaml
@@ -29,7 +29,8 @@ teleop_arm_joy:
       default_value:
         [
           "nova_arm_position_controller",
-          "nova_ik_controller"
+          "nova_ik_controller",
+          "nova_twistmapper",
         ]
       description: "Controllers to activate/deactivate for twist ik control"
 

--- a/src/ros/rover/teleop_arm_joy/src/parameters.yaml
+++ b/src/ros/rover/teleop_arm_joy/src/parameters.yaml
@@ -32,7 +32,7 @@ teleop_arm_joy:
           "nova_ik_controller",
           "nova_twistmapper",
         ]
-      description: "Controllers to activate/deactivate for twist ik control"
+      description: "Controllers to activate/deactivate for twist ik control. Given in order of activation, where controllers dependent on other controllers should succeed them in the order of this list."
 
   joint_space:
     controllers:
@@ -41,7 +41,7 @@ teleop_arm_joy:
         [
           "nova_arm_velocity_controller",
         ]
-      description: "Controllers to activate/deactivate for joint space control"
+      description: "Controllers to activate/deactivate for joint space control. Given in order of activation, where controllers dependent on other controllers should succeed them in the order of this list."
 
   device_names:
     type: string_array

--- a/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
+++ b/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
@@ -340,7 +340,14 @@ void TeleopArmJoy::switchController(const ControlMode requested_control_mode)
               prettyPrintMode(control_mode).c_str(),
               prettyPrintMode(requested_control_mode).c_str());
 
-  vector<std::string> deactivate_controllers = modeToControllers(control_mode);
+  // The order of deactivation needs to be opposite to the activation order. This is the reverse to the final order.
+  vector<std::string> deactivate_controllers_reversed = modeToControllers(control_mode);
+  // Reverse the given order of controllers so they deactivate correctly; in order.
+  vector<std::string> deactivate_controllers(deactivate_controllers_reversed.size());
+  std::reverse_copy(deactivate_controllers_reversed.begin(), deactivate_controllers_reversed.end(),
+                    deactivate_controllers.begin());
+
+  // Given order of activated controllers is already correct
   vector<std::string> activate_controllers = modeToControllers(requested_control_mode);
 
   if (!switch_controller_client->service_is_ready()) {


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

I have made the IK controller yet another chainable controller. This allows us to swap out the source of the input target pose.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Add nova_twistmapper, encapsulating the logic for the twistmapper previously in nova_ik_controller
- Make nova_ik_controller chainable
- Changed launch configs to include the new chain
- Fixed bugs in teleop_arm_joy with enabling/disabling controller chains

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

after `ws-build`ing

```sh
./result/bin/ros2 launch auto_bringup mock.launch.py arm:=true
```

```sh
./result/bin/ros2 run joy joy_node
```

```sh
./result/bin/ros2 run teleop_arm_joy teleop_arm_joy_node --ros-args --params-file /home/nova/nova/src/ros/rover/teleop_arm_joy/config/ps5.config.yaml
```

```sh
./result/bin/rviz2
```

In rviz, add a RobotModel with /robot_description as the topic. Press the unlock button, and move around

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
