### PR TITLE
Onshape to Robot update + Pybullet removal

### DIFF
--- a/nixfiles/modules/home/macros/urdf-tool.nix
+++ b/nixfiles/modules/home/macros/urdf-tool.nix
@@ -1,33 +1,42 @@
 { pkgs ? import <nixpkgs> { } }:
 
 let
-  # Define onshape-to-robot build
-  onshapeToRobot = pkgs.python3Packages.buildPythonApplication rec {
+  python = pkgs.python312Full;
+  py = python.pkgs;
+
+  # Rebuild pymeshlab in your environment to ensure same numpy
+  pyEnv = pkgs.python312.override {
+    packageOverrides = self: super: {
+      pymeshlab = super.pymeshlab.overrideAttrs (old: {
+        propagatedBuildInputs = (old.propagatedBuildInputs or []) ++ [ self.numpy ];
+      });
+    };
+  };
+  pyPkgs = pyEnv.pkgs;
+
+  onshapeToRobot = pyPkgs.buildPythonPackage rec {
     pname = "onshape-to-robot";
-    version = "1.2.1";
+    version = "1.5.7";
 
     src = pkgs.fetchFromGitHub {
-      owner = "V01DBREAKER";
+      owner = "Rhoban";
       repo = pname;
-      rev = "03419bd1a20f901ff6325e467e07d43b502436bb";
-      hash = "sha256-/KguWFqhmLyqnDDLX96RFxrSeLvb9Wjkpbhy+7IZlbs=";
+      rev = "1c6e662fe6233b452dfc0de1632a40086ba1b8f7";
+      hash = "sha256-f/ho5NSNm7nfJVsF6xczobc9puny3/EtS/Idsl6Sjus=";
     };
 
-    buildInputs = with pkgs.python3Packages; [
+    propagatedBuildInputs = with pyPkgs; [
       numpy
-      pybullet
       requests
       commentjson
       colorama
       numpy-stl
       transforms3d
-      pymeshlab
       python-dotenv
+      pymeshlab
     ];
 
-    nativeBuildInputs = [
-      pkgs.pkg-config
-    ];
+    nativeBuildInputs = [ pkgs.pkg-config ];
 
     postPatch = ''
       substituteInPlace onshape_to_robot/edit_shape.py \
@@ -36,22 +45,13 @@ let
     '';
 
     meta = with pkgs.lib; {
-      description = "A Python library to convert Onshape assemblies into URDF or SDF robots";
+      description = "Convert Onshape assemblies into URDF or SDF robots";
       homepage = "https://github.com/Rhoban/onshape-to-robot";
       license = licenses.mit;
     };
   };
 
-  # Check if the Onshape API keys file exists before importing it
-  onshapeKeys = if builtins.pathExists "/etc/nixos/onshape_key/onshape-keys.nix" then
-    import /etc/nixos/onshape_key/onshape-keys.nix
-  else
-    {
-      ACCESS_KEY = "";
-      SECRET_KEY = "";
-    };  # If the file does not exist, use set with empty values to avoid errors
-
-  urdf-modifier = pkgs.python3Packages.buildPythonApplication rec {
+  urdfModifier = pyPkgs.buildPythonApplication rec {
     pname = "urdf-modifier";
     version = "1.0";
 
@@ -62,48 +62,47 @@ let
       hash = "sha256-OtwYxlHKxruVxJmosMbvT//FM5gPV+75MCG1zKyEuuE=";
     };
 
-    buildInputs = with pkgs.python3Packages; [
-      pymeshlab
-    ];
+    propagatedBuildInputs = [ pyPkgs.pymeshlab ];
 
     meta = with pkgs.lib; {
-      description = "A Python script used to modify generated URDFs and recalculate inertias.";
+      description = "Modify generated URDFs and recalculate inertias.";
       homepage = "https://github.com/V01DBREAKER/urdf-modifier";
       license = licenses.mit;
     };
   };
 
+  onshapeKeys = if builtins.pathExists "/etc/nixos/onshape_key/onshape-keys.nix" then
+    import /etc/nixos/onshape_key/onshape-keys.nix
+  else
+    {
+      ACCESS_KEY = "";
+      SECRET_KEY = "";
+    };
+
 in
 pkgs.mkShell {
-  buildInputs = [
+  packages = [
     pkgs.openscad
     onshapeToRobot
-    urdf-modifier
-    pkgs.python3Packages.numpy
-    pkgs.python3Packages.pybullet
-    pkgs.python3Packages.requests
-    pkgs.python3Packages.commentjson
-    pkgs.python3Packages.colorama
-    pkgs.python3Packages.numpy-stl
-    pkgs.python3Packages.transforms3d
-    pkgs.python3Packages.pymeshlab
-    pkgs.python3Packages.python-dotenv
+    urdfModifier
+    pyPkgs.pymeshlab
   ];
 
-  # Set up PYTHONPATH to include all dependencies
   shellHook = ''
-    export PATH=${onshapeToRobot}/bin:$PATH
-    export PATH=${urdf-modifier}/bin:$PATH
-    export PYTHONPATH=${pkgs.python3Packages.python.sitePackages}:${pkgs.python3Packages."numpy-stl"}/lib/python3.12/site-packages:$PYTHONPATH
+    export PATH=${onshapeToRobot}/bin:${urdfModifier}/bin:$PATH
+    export PYTHONPATH=${onshapeToRobot}/${python.sitePackages}:$PYTHONPATH
     export ONSHAPE_API=https://cad.onshape.com
-    # Check if Onshape API keys are defined, and warn if not
-    if [ -z "${onshapeKeys.ACCESS_KEY}" ] || [ -z "${onshapeKeys.SECRET_KEY}" ]; then
-      echo -e "\033[1;31mWARNING: Onshape API keys (ACCESS_KEY, SECRET_KEY) are not defined in /etc/nixos/onshapeAPI/onshape-keys.nix. Please configure them before using the Onshape API.\033[0m"
+
+    ACCESS_KEY="${onshapeKeys.ACCESS_KEY}"
+    SECRET_KEY="${onshapeKeys.SECRET_KEY}"
+
+    if [ -z "$ACCESS_KEY" ] || [ -z "$SECRET_KEY" ]; then
+      echo -e "\033[1;31mWARNING: Onshape API keys not defined in /etc/nixos/onshape_key/onshape-keys.nix\033[0m"
     else
-      export ONSHAPE_ACCESS_KEY=${onshapeKeys.ACCESS_KEY}
-      export ONSHAPE_SECRET_KEY=${onshapeKeys.SECRET_KEY}
+      export ONSHAPE_ACCESS_KEY="$ACCESS_KEY"
+      export ONSHAPE_SECRET_KEY="$SECRET_KEY"
     fi
 
-    echo "OpenSCAD and Onshape-to-Robot are ready to use."
+    echo "✔ OpenSCAD and Onshape-to-Robot are ready with Python ${python.version} 🐍"
   '';
 }


### PR DESCRIPTION
Updated onshape to robot to v1.5.7.

Also removed pybullet. This will completely disable the ability to run `onshape-to-robot-bullet` for testing models (We don't really use this, or have a real need for it) as GCC14 has a lot of issues with it now?

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

Run urdf-tool.


<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
