### PR TITLE
Banksia Arm MoveIt2 Kinematics Plugin

### DIFF
--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -43,6 +43,7 @@
 , nova-arm-controller ? throw "nova-arm-controller is needed, but not available!"
 , nova-ik-controller ? throw "nova-ik-controller is needed, but not available!"
 , nova-twistmapper ? throw "nova-twistmapper is needed, but not available!"
+, nova-banksia-kinematics-plugin ? throw "nova-banksia-kinematics-plugin is needed, but not available!"
 
   # Configuration options
   ## Include graphical applications in the workspace.
@@ -88,7 +89,8 @@
       reolink
       nova-arm-controller
       nova-ik-controller
-      nova-twistmapper;
+      nova-twistmapper
+      nova-banksia-kinematics-plugin;
   }
 
   ## Extra packages to add to the workspace.

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/CMakeLists.txt
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.16)
+project(banksia_kinematics_plugin LANGUAGES CXX)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  geometry_msgs
+  pluginlib
+  rclcpp
+  rcpputils
+  tf2
+  tf2_msgs
+  tf2_geometry_msgs
+  Eigen3
+  tf2_eigen
+  moveit_core
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(backward_ros REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+include_directories(
+	${EIGEN3_INCLUDE_DIRS}
+)
+
+add_library(banksia_kinematics_plugin SHARED
+  src/banksia_kinematics_plugin.cpp
+)
+target_compile_features(banksia_kinematics_plugin PUBLIC cxx_std_17)
+target_include_directories(banksia_kinematics_plugin PUBLIC
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/banksia_kinematics_plugin>
+)
+ament_target_dependencies(banksia_kinematics_plugin PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(banksia_kinematics_plugin PRIVATE "BANKSIA_KINEMATICS_PLUGIN_BUILDING_DLL")
+pluginlib_export_plugin_description_file(kinematics_base banksia_kinematics_plugin.xml)
+
+install(DIRECTORY
+  #launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/banksia_kinematics_plugin
+)
+install(TARGETS banksia_kinematics_plugin
+  EXPORT export_banksia_kinematics_plugin
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+ament_export_targets(export_banksia_kinematics_plugin HAS_LIBRARY_TARGET)
+
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/banksia_kinematics_plugin.xml
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/banksia_kinematics_plugin.xml
@@ -1,0 +1,8 @@
+<library path="banksia_kinematics_plugin">
+  <class name="banksia_kinematics_plugin/BanksiaKinematicsPlugin" type="banksia_kinematics_plugin::BanksiaKinematicsPlugin"
+         base_class_type="kinematics::KinematicsBase">
+  <description>
+    The kinematics plugin for banksia's arm special IK
+  </description>
+  </class>
+</library>

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/include/banksia_kinematics_plugin/banksia_kinematics_plugin.hpp
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/include/banksia_kinematics_plugin/banksia_kinematics_plugin.hpp
@@ -1,0 +1,124 @@
+#ifndef BANKSIA_KINEMATICS_PLUGIN__BANKSIA_KINEMATICS_PLUGIN_HPP_
+#define BANKSIA_KINEMATICS_PLUGIN__BANKSIA_KINEMATICS_PLUGIN_HPP_
+
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "visibility_control.h"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/node.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+#include "tf2/LinearMath/Scalar.h"
+#include <Eigen/Dense>
+#include <tf2/LinearMath/Transform.h>
+#include <moveit/kinematics_base/kinematics_base.h>
+
+namespace banksia_kinematics_plugin
+{
+class BanksiaKinematicsPlugin : public kinematics::KinematicsBase
+{
+  bool initialize(
+    const rclcpp::Node::SharedPtr &node,
+    const moveit::core::RobotModel &robot_model,
+    const std::string &group_name,
+    const std::string &base_frame,
+    const std::vector<std::string> &tip_frames,
+    double search_discretization) override;
+
+  bool getPositionIK(
+    const geometry_msgs::msg::Pose &ik_pose,
+    const std::vector<double> &ik_seed_state,
+    std::vector<double> &solution,
+    moveit_msgs::msg::MoveItErrorCodes &error_code,
+    const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
+
+  bool searchPositionIK(
+    const geometry_msgs::msg::Pose &ik_pose,
+    const std::vector<double> &ik_seed_state,
+    double timeout,
+    std::vector<double> &solution,
+    moveit_msgs::msg::MoveItErrorCodes &error_code,
+    const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
+
+  bool searchPositionIK(
+    const std::vector<geometry_msgs::msg::Pose> &ik_poses,
+    const std::vector<double> &ik_seed_state,
+    double timeout,
+    const std::vector<double> &consistency_limits,
+    std::vector<double> &solution,
+    const kinematics::KinematicsBase::IKCallbackFn &solution_callback,
+    const kinematics::KinematicsBase::IKCostFn &cost_function,
+    moveit_msgs::msg::MoveItErrorCodes &error_code,
+    const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions(),
+    const moveit::core::RobotState *context_state = nullptr) const override;
+
+  bool searchPositionIK(
+    const geometry_msgs::msg::Pose &ik_pose,
+    const std::vector<double> &ik_seed_state,
+    double timeout,
+    std::vector<double> &solution,
+    const IKCallbackFn &solution_callback,
+    moveit_msgs::msg::MoveItErrorCodes &error_code,
+    const kinematics::KinematicsQueryOptions &options = kinematics::KinematicsQueryOptions()) const override;
+
+  bool searchPositionIK(
+    const geometry_msgs::msg::Pose& ik_pose,
+    const std::vector<double>& ik_seed_state,
+    double timeout,
+    const std::vector<double>& consistency_limits,
+    std::vector<double>& solution,
+    moveit_msgs::msg::MoveItErrorCodes& error_code,
+    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  bool searchPositionIK(
+    const geometry_msgs::msg::Pose& ik_pose,
+    const std::vector<double>& ik_seed_state,
+    double timeout,
+    const std::vector<double>& consistency_limits,
+    std::vector<double>& solution,
+    const IKCallbackFn& solution_callback,
+    moveit_msgs::msg::MoveItErrorCodes& error_code,
+    const kinematics::KinematicsQueryOptions& options = kinematics::KinematicsQueryOptions()) const override;
+
+  bool getPositionFK(
+    const std::vector<std::string> &link_names,
+    const std::vector<double> &joint_angles,
+    std::vector<geometry_msgs::msg::Pose> &poses) const override;
+
+  const std::vector<std::string> &getJointNames() const override;
+
+  const std::vector<std::string> &getLinkNames() const override;
+
+private:
+  /// @brief Calculates the IK given a frame, pose and set of lengths.
+  /// @brief See Keenan's IK notes.
+  /// @param frame is ???
+  /// @param pose is a struct combining a position (x,y,z) and a quaternion (x,y,z,w).
+  /// @param Lengths are [fill this].
+  /// @returns an array of joint angles in joint space for each of J1 through J6, through joints.
+  std::array<double, 6> calculate_ik(tf2::Transform pose, std::array<double, 3> lengths) const;
+
+  // substitutes values into our DH table.
+  // see: https://www.notion.so/Inverse-Kinematics-ddfe35179c1f4959850bd28b2195be8a
+  // equivalent line: DHs = [cos(the) -sin(the) 0 a; sin(the)*cos(alp) cos(the)*cos(alp) -sin(alp) -sin(alp)*d; sin(the)*sin(alp) cos(the)*sin(alp) cos(alp) cos(alp)*d; 0 0 0 1];
+  Eigen::Matrix4d sub_dh(double alp, double a, double d, double the) const
+  {
+    return Eigen::Matrix4d {
+      { cos(the), 			-sin(the), 			0, 			a },
+      { sin(the)*cos(alp),	cos(the)*cos(alp), 	-sin(alp), 	-sin(alp)*d },
+      { sin(the)*sin(alp),	cos(the)*sin(alp),	cos(alp),	cos(alp)*d },
+      { 0,					0,					0,			1 }
+    };
+  }
+
+  std::vector<std::string> joint_names_;
+  std::vector<std::string> link_names_;
+  std::array<double, 3> link_lengths_;  // L1, L2, L3
+
+};
+} // namespace banksia_kinematics_plugin
+#endif // BANKSIA_KINEMATICS_PLUGIN__BANKSIA_KINEMATICS_PLUGIN_HPP_

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/include/banksia_kinematics_plugin/visibility_control.h
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/include/banksia_kinematics_plugin/visibility_control.h
@@ -1,0 +1,35 @@
+#ifndef BANKSIA_KINEMATICS_PLUGIN__VISIBILITY_CONTROL_H_
+#define BANKSIA_KINEMATICS_PLUGIN__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define BANKSIA_KINEMATICS_PLUGIN_EXPORT __attribute__((dllexport))
+#define BANKSIA_KINEMATICS_PLUGIN_IMPORT __attribute__((dllimport))
+#else
+#define BANKSIA_KINEMATICS_PLUGIN_EXPORT __declspec(dllexport)
+#define BANKSIA_KINEMATICS_PLUGIN_IMPORT __declspec(dllimport)
+#endif
+#ifdef BANKSIA_KINEMATICS_PLUGIN_BUILDING_DLL
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC BANKSIA_KINEMATICS_PLUGIN_EXPORT
+#else
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC BANKSIA_KINEMATICS_PLUGIN_IMPORT
+#endif
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC_TYPE BANKSIA_KINEMATICS_PLUGIN_PUBLIC
+#define BANKSIA_KINEMATICS_PLUGIN_LOCAL
+#else
+#define BANKSIA_KINEMATICS_PLUGIN_EXPORT __attribute__((visibility("default")))
+#define BANKSIA_KINEMATICS_PLUGIN_IMPORT
+#if __GNUC__ >= 4
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC __attribute__((visibility("default")))
+#define BANKSIA_KINEMATICS_PLUGIN_LOCAL __attribute__((visibility("hidden")))
+#else
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC
+#define BANKSIA_KINEMATICS_PLUGIN_LOCAL
+#endif
+#define BANKSIA_KINEMATICS_PLUGIN_PUBLIC_TYPE
+#endif
+
+#endif // BANKSIA_KINEMATICS_PLUGIN__VISIBILITY_CONTROL_H_

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/package.xml
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>banksia_kinematics_plugin</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="novaroverteam@monash.edu">nova</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+	
+  <depend>eigen</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <moveit_core plugin="${prefix}/banksia_kinematics_plugin.xml"/>
+  </export>
+</package>

--- a/src/ros/rover/controllers/banksia_kinematics_plugin/src/banksia_kinematics_plugin.cpp
+++ b/src/ros/rover/controllers/banksia_kinematics_plugin/src/banksia_kinematics_plugin.cpp
@@ -1,0 +1,229 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "banksia_kinematics_plugin/banksia_kinematics_plugin.hpp"
+#include "rclcpp/logging.hpp"
+#include "tf2/LinearMath/Scalar.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp"
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+namespace
+{
+  /// The inverse of the global orientation the kinematics origin frame wants to rotate to for a roll,pitch,yaw of 0,0,0
+  // To find this value, set the rotation quat to 0,0,0,1. Ensure both the arm kinematics origin and endeffector
+  // kinematics frames have the z axis up and x axis facing drive forward when in the zero position. Run rviz, and enter
+  // IK mode from the zero position. Enter the rotation of the endeffector_kinematics frame after this.
+  const auto ENDEFFECTOR_BASIS_INVERSE = tf2::Matrix3x3(tf2::Quaternion(0.5, -0.5, 0.5, 0.5)).inverse();
+} // namespace
+
+namespace banksia_kinematics_plugin
+{
+  bool BanksiaKinematicsPlugin::initialize(const rclcpp::Node::SharedPtr &node,
+                                           const moveit::core::RobotModel &robot_model,
+                                           const std::string &group_name,
+                                           const std::string &base_frame,
+                                           const std::vector<std::string> &tip_frames,
+                                           double search_discretization) {
+
+    setValues(robot_model.getName(), group_name, base_frame, tip_frames, search_discretization);
+
+    joint_names_ = robot_model.getJointModelGroup(group_name)->getActiveJointModelNames();
+    link_names_ = robot_model.getJointModelGroup(group_name)->getLinkModelNames();
+
+    // TODO: Calculate from the given RobotModel
+    link_lengths_ = {0.5, 0.41799975417, 0.417};
+
+    return true;
+  }
+
+  // See Keenan's IK notes
+  // TODO: remember to add something for the effector pose
+  std::array<double, 6> BanksiaKinematicsPlugin::calculate_ik(tf2::Transform pose, std::array<double, 3> lengths) const {
+    auto origin = pose.getOrigin();
+    auto x = origin.getX();
+    auto y = origin.getY();
+    auto z = origin.getZ();
+
+    tf2::Matrix3x3 rotated_basis = pose.getBasis() * ENDEFFECTOR_BASIS_INVERSE;
+
+    double l1r = lengths[0];
+    double l2r = lengths[1];
+    double l3 = lengths[2];
+
+    Eigen::Matrix3d rxyz {
+      {rotated_basis[0][0], rotated_basis[0][1], rotated_basis[0][2]},
+      {rotated_basis[1][0], rotated_basis[1][1], rotated_basis[1][2]},
+      {rotated_basis[2][0], rotated_basis[2][1], rotated_basis[2][2]}
+    };  // rxyz orientation matrix
+
+    Eigen::Matrix4d t07r = Eigen::Matrix4d::Zero();
+    t07r.topLeftCorner<3,3>() = rxyz;
+
+    t07r(3, 3) = 1;
+    t07r(0, 3) = x;
+    t07r(1, 3) = y;
+    t07r(2, 3) = z;
+
+    Eigen::Matrix4d t67 { {1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, l3}, {0, 0, 0, 1} };
+    Eigen::Matrix4d t0_wrist = t07r * t67.inverse();
+
+    double wrist_x = t0_wrist(0, 3);
+    double wrist_y = t0_wrist(1, 3);
+    double wrist_z = t0_wrist(2, 3);
+
+    double j1 = atan2(wrist_y, wrist_x);
+    double l = sqrt(pow(wrist_x, 2) + pow(wrist_y, 2));
+    double j3a = acos((pow(l, 2) + pow(wrist_z, 2) - pow(l1r, 2) - pow(l2r, 2)) / (2 * l1r * l2r));
+    double j3b = -j3a; // expands to -acos((l^2+wrist_z^2-L1r^2-L2r^2)/(2*L1r*L2r)) as per keenan's notes
+    double j3ao = j3a + M_PI / 2;
+    double j3bo = j3b + M_PI / 2;
+
+    double k1a = l1r + l2r * cos(j3a);
+    double k2a = l2r * sin(j3a);
+    double k1b = l1r + l2r * cos(j3b);
+    double k2b = l2r * sin(j3b);
+
+    double j2a = atan2(wrist_z, l) - atan2(k2a, k1a);
+    double j2b = atan2(wrist_z, l) - atan2(k2b, k1b);
+    double j2ao = j2a - M_PI / 2;
+    double j2bo = j2b - M_PI / 2;
+
+    Eigen::Matrix4d t01 = sub_dh(0, 0, 0, j1);
+    Eigen::Matrix4d t12 = sub_dh(M_PI / 2, 0, 0, j2bo + M_PI / 2);
+    Eigen::Matrix4d t23 = sub_dh(0, l1r, 0, j3bo - M_PI / 2);
+    Eigen::Matrix4d t02 = t01 * t12;
+    Eigen::Matrix4d t03_wrist = t02 * t23;
+    Eigen::Matrix3d r03_wrist = t03_wrist.topLeftCorner<3, 3>(); // R03_wrist = T03_wrist(1:3,1:3); in matlab
+    Eigen::Matrix3d r07r = t07r.topLeftCorner<3, 3>(); // see above
+    Eigen::Matrix3d r37r = r03_wrist.inverse() * r07r;
+
+    double j4 = atan2(r37r(1, 2), r37r(0, 2));
+    double j5 = atan2(-r37r(2, 2), r37r(0, 2) / cos(j4));
+    double j6 = atan2(-r37r(2, 1) / cos(j5), r37r(2, 0) / cos(j5));
+
+    std::array<double, 6> new_joints = { j1, j2bo, j3bo, -j4, j5, j6 };
+    return new_joints;
+  }
+
+  bool BanksiaKinematicsPlugin::getPositionIK(const geometry_msgs::msg::Pose &ik_pose,
+                                              const std::vector<double> &ik_seed_state,
+                                              std::vector<double> &solution,
+                                              moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                              const kinematics::KinematicsQueryOptions &options) const {
+    tf2::Transform tf_pose;
+    tf2::fromMsg(ik_pose, tf_pose);
+
+    auto joints = calculate_ik(tf_pose, link_lengths_);
+    solution.assign(joints.begin(), joints.end());
+    error_code.val = moveit_msgs::msg::MoveItErrorCodes::SUCCESS;
+    return true;
+  }
+
+  bool BanksiaKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
+                                                 const std::vector<double> &ik_seed_state, double timeout,
+                                                 std::vector<double> &solution,
+                                                 moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                                 const kinematics::KinematicsQueryOptions &options) const {
+    // TODO: Actually include a timeout
+    return getPositionIK(ik_pose, ik_seed_state, solution, error_code, options);
+  }
+
+  bool BanksiaKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
+                                                 const std::vector<double> &ik_seed_state,
+                                                 double timeout,
+                                                 std::vector<double> &solution,
+                                                 const kinematics::KinematicsBase::IKCallbackFn &solution_callback,
+                                                 moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                                 const kinematics::KinematicsQueryOptions &options) const {
+    auto solution_found = searchPositionIK(ik_pose, ik_seed_state, timeout, solution, error_code, options);
+    solution_callback(ik_pose, solution, error_code);
+    return solution_found;
+  }
+
+  bool BanksiaKinematicsPlugin::getPositionFK(const std::vector<std::string> &link_names,
+                                              const std::vector<double> &joint_angles,
+                                              std::vector<geometry_msgs::msg::Pose> &poses) const {
+    // TODO: Actually solve FK
+    poses.clear();
+
+    if (!robot_model_)
+    {
+      // RCLCPP_ERROR(LOGGER, "Robot model is not initialized.");
+      return false;
+    }
+
+    const moveit::core::JointModelGroup* joint_model_group =
+      robot_model_->getJointModelGroup(group_name_);
+    if (!joint_model_group)
+    {
+      // RCLCPP_ERROR(LOGGER, "Joint model group '%s' not found.", group_name_.c_str());
+      return false;
+    }
+
+    moveit::core::RobotState robot_state(robot_model_);
+    robot_state.setToDefaultValues();  // optional: ensure known base state
+    robot_state.setJointGroupPositions(joint_model_group, joint_angles);
+    robot_state.update();
+
+    auto base_transform_inverse = robot_state.getFrameTransform(base_frame_).inverse();
+
+    poses.reserve(link_names.size());
+    for (const auto& link_name : link_names)
+    {
+      const Eigen::Isometry3d& tf = base_transform_inverse * robot_state.getGlobalLinkTransform(link_name);
+      geometry_msgs::msg::Pose pose = tf2::toMsg(tf);
+      poses.push_back(pose);
+    }
+
+    return true;
+  }
+
+  const std::vector<std::string> &BanksiaKinematicsPlugin::getJointNames() const {
+    return joint_names_;
+  }
+
+  const std::vector<std::string> &BanksiaKinematicsPlugin::getLinkNames() const {
+    return link_names_;
+  }
+
+  bool BanksiaKinematicsPlugin::searchPositionIK(const std::vector<geometry_msgs::msg::Pose> &ik_poses,
+                                                 const std::vector<double> &ik_seed_state, double timeout,
+                                                 const std::vector<double> &consistency_limits,
+                                                 std::vector<double> &solution,
+                                                 const kinematics::KinematicsBase::IKCallbackFn &solution_callback,
+                                                 const kinematics::KinematicsBase::IKCostFn &cost_function,
+                                                 moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                                 const kinematics::KinematicsQueryOptions &options,
+                                                 const moveit::core::RobotState *context_state) const {
+    // TODO: Implement
+    return false;
+  }
+
+  bool BanksiaKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
+                                                 const std::vector<double> &ik_seed_state, double timeout,
+                                                 const std::vector<double> &consistency_limits,
+                                                 std::vector<double> &solution,
+                                                 moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                                 const kinematics::KinematicsQueryOptions &options) const {
+    // TODO: Implement
+    return false;
+  }
+
+  bool BanksiaKinematicsPlugin::searchPositionIK(const geometry_msgs::msg::Pose &ik_pose,
+                                                 const std::vector<double> &ik_seed_state, double timeout,
+                                                 const std::vector<double> &consistency_limits,
+                                                 std::vector<double> &solution,
+                                                 const kinematics::KinematicsBase::IKCallbackFn &solution_callback,
+                                                 moveit_msgs::msg::MoveItErrorCodes &error_code,
+                                                 const kinematics::KinematicsQueryOptions &options) const {
+    // TODO: Implement
+    return false;
+  }
+} // namespace banksia_kinematics_plugin
+
+#include "class_loader/register_macro.hpp"
+
+CLASS_LOADER_REGISTER_CLASS(banksia_kinematics_plugin::BanksiaKinematicsPlugin, kinematics::KinematicsBase);

--- a/src/ros/rover/nix/packages/controllers/default.nix
+++ b/src/ros/rover/nix/packages/controllers/default.nix
@@ -9,4 +9,5 @@ with pkgs;
   nova-arm-controller = callPackage ./nova-arm-controller { };
   nova-ik-controller = callPackage ./nova-ik-controller { };
   nova-twistmapper = callPackage ./nova-twistmapper { };
+  nova-banksia-kinematics-plugin = callPackage ./nova-banksia-kinematics-plugin { };
 }

--- a/src/ros/rover/nix/packages/controllers/nova-banksia-kinematics-plugin/default.nix
+++ b/src/ros/rover/nix/packages/controllers/nova-banksia-kinematics-plugin/default.nix
@@ -3,7 +3,6 @@
 , ament-cmake
 , pluginlib
 , rclcpp
-, rclcpp-lifecycle
 , rcpputils
 , backward-ros
 , tf2
@@ -30,7 +29,6 @@ buildRosPackage {
   buildInputs = [
     pluginlib
     rclcpp
-    rclcpp-lifecycle
     backward-ros
     tf2
     tf2-msgs

--- a/src/ros/rover/nix/packages/controllers/nova-banksia-kinematics-plugin/default.nix
+++ b/src/ros/rover/nix/packages/controllers/nova-banksia-kinematics-plugin/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, buildRosPackage
+, ament-cmake
+, pluginlib
+, rclcpp
+, rclcpp-lifecycle
+, rcpputils
+, backward-ros
+, tf2
+, tf2-msgs
+, geometry-msgs
+, tf2-geometry-msgs
+, eigen
+, tf2-eigen
+, moveit-core
+}:
+
+buildRosPackage {
+  name = "nova-banksia-kinematics-plugin";
+  buildType = "ament_cmake";
+
+  src = builtins.path rec {
+    name = "banksia_kinematics_plugin-source";
+    path = ../../../../controllers/banksia_kinematics_plugin;
+    filter = lib.novaSourceFilter [ ] path;
+  };
+
+  nativeBuildInputs = [ ament-cmake ];
+
+  buildInputs = [
+    pluginlib
+    rclcpp
+    rclcpp-lifecycle
+    backward-ros
+    tf2
+    tf2-msgs
+    geometry-msgs
+    tf2-geometry-msgs
+    eigen
+    tf2-eigen
+    moveit-core
+  ];
+}


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

I implemented `kinematics::KinematicsBase` with Keenan's IK solution to move our IK logic into a reusable piece of code inside of the twistmapper. This will hopefully be the first step to making the IK controller redundant.


We need to make the control system modular, so that future robotic arm payloads with different IK solutions can be supported.  
To do this, we can load the kinematics used in twistmapper as a plugin with the `kinematics::KinematicsBase` type.

This is the same plugin used by MoveIt2, promoting compatibility with MoveIt2.

Note, some member functions remain unimplemented, or with temporary implementations. This likely means it won't work perfectly with MoveIt2 currently.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Add the `banksia_kinematics_plugin` package, exporting `banksia_kinematics_plugin::BanksiaKinematicsPlugin : public kinematics::KinematicsBase`

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

Not yet testable, as we don't have anything to consume the plugin.

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->