### PR TITLE
Init arm controller position command interfaces on activation

### DIFF
--- a/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
+++ b/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller.cpp
@@ -315,6 +315,14 @@ controller_interface::CallbackReturn NovaArmController::on_activate(
     reference_interfaces_.begin(), reference_interfaces_.end(),
     std::numeric_limits<double>::quiet_NaN());
 
+
+  if (params_.use_position_control) {
+    // Set all joint command interfaces to be the current state interface values
+    for (auto& joint : registered_joint_handles_) {
+      joint.command.get().set_value(joint.state_pos.get().get_value());
+    }
+  }
+
   // TODO: setup sub and pub
   //RCLCPP_DEBUG(get_node()->get_logger(), "Subscriber and publisher are now active.");
   return controller_interface::CallbackReturn::SUCCESS;

--- a/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller_parameter.yaml
+++ b/src/ros/rover/controllers/nova_arm_controller/src/nova_arm_controller_parameter.yaml
@@ -37,11 +37,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 1.57,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -1.57,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -49,7 +49,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -57,7 +57,7 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }
     J2:
       has_position_limits: {
@@ -66,11 +66,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 1,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -1.57,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -78,7 +78,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -86,7 +86,7 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }
     J3:
       has_position_limits: {
@@ -95,11 +95,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 1.57,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -1,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -107,7 +107,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -115,7 +115,7 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }
     J4:
       has_position_limits: {
@@ -124,11 +124,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 1.57,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -1.57,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -136,7 +136,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -144,7 +144,7 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }
     J5:
       has_position_limits: {
@@ -153,11 +153,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 0.78,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -0.78,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -165,7 +165,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -173,7 +173,7 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }
     J6:
       has_position_limits: {
@@ -182,11 +182,11 @@ nova_arm_controller:
       }
       max_position: {
         type: double,
-        default_value: 1.57,
+        default_value: 1.57079632679,
       }
       min_position: {
         type: double,
-        default_value: -1.57,
+        default_value: -1.57079632679,
       }
       has_velocity_limits: {
         type: bool,
@@ -194,7 +194,7 @@ nova_arm_controller:
       }
       max_velocity: {
         type: double,
-        default_value: 0.4,
+        default_value: 1.57079632679,
       }
       has_acceleration_limits: {
         type: bool,
@@ -202,5 +202,5 @@ nova_arm_controller:
       }
       max_acceleration: {
         type: double,
-        default_value: 0.3,
+        default_value: 15.7079632679,
       }


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Initializes the arm controller position command interfaces on activation to be equal to the state interface values.

This should hopefully fix the jumping seen when switching between IK and joint space on the sim.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Make limits on arm more lenient
- Init arm controller position command interfaces on activation

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
