### PR TITLE
Keyboard Localiser working IRL with GUI overlay

### DIFF
--- a/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
@@ -7,6 +7,10 @@ This service manages a GStreamer pipeline to
 stream video footage from ros Image topics over WebRTC.
 Consult the repository README for complete setup
 instructions.
+This node can only be run when the camera stack is not being run
+    e.g for gazebo sim only
+
+There is also gstreamer pipeline classes at the end.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODE: camera_streamer
 TOPICS: None
@@ -54,6 +58,9 @@ from sensor_msgs.msg import Image
 
 
 class CameraStreamerService(Node):
+    """
+    This node is 
+    """
     class CameraConfiguration():
         def __init__(self, serial: str, topic: str):
             self.serial = serial
@@ -204,13 +211,12 @@ class CameraStreamerService(Node):
 
 
 class RosCameraBin:
+    """
+    This gstreamer pipeline takes in a ros image topic and outputs a webrtc stream
+    **Cannot** be used with camera_streamer_service.py
+    """
     bin: Gst.Bin
-
-    _source: Gst.Element
-    _queue: Gst.Element
-    _decoder: Gst.Element
-    _video_converter: Gst.Element
-    _sink: Gst.Element
+    # rosimagesrc ! capsfilter ! decoder ! videoconvert ! webrtcsink
 
     def __init__(self, serial: str, topic: str):
         self.bin = Gst.Bin.new(f"camera-{serial}-bin")
@@ -251,6 +257,10 @@ class RosCameraBin:
         return gst_structure_to_dict(self._sink.props.stats)
 
 class CameraSplitROSWebRTCBin:
+    """
+    This gstreamer pipeline takes in a camera device in v4l2 and outputs both a webrtc stream and ros image topic
+    Used with camera_streamer_service.py
+    """
     bin: Gst.Bin
     # v4l2src ! capsfilter ! decoder ! videoconvert ! tee \
     # \ tee ! webrtcsink

--- a/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
@@ -250,6 +250,114 @@ class RosCameraBin:
     def webrtc_stats(self) -> dict[str, object]:
         return gst_structure_to_dict(self._sink.props.stats)
 
+class CameraSplitROSWebRTCBin:
+    bin: Gst.Bin
+    # v4l2src ! capsfilter ! decoder ! videoconvert ! tee \
+    # \ tee ! webrtcsink
+    # \ tee ! rosimagesink
+    def __init__(
+        self,
+        serial: str,
+        device_node: str,
+        mime: str = "video/x-raw",
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+        framerate: Optional[int] = None,
+        do_fec: bool = True,
+        do_retransmission: bool = True,
+        show_clock: bool = True,
+        extra_meta: Optional[dict[str, object]] = None,
+    ):
+        ros_topic = extra_meta['ros_topic']
+        self.bin = Gst.Bin.new(f"camera-{serial}-bin")
+
+        # Create and configure the elements.
+
+        # # Web sink branch
+        self._websink = Gst.ElementFactory.make("webrtcsink", "websink")
+        # ## WebRTC settings
+        self._websink.props.congestion_control = "gcc"
+        self._websink.props.do_fec = do_fec
+        self._websink.props.do_retransmission = do_retransmission
+        self._websink.props.stun_server = None
+        # ## Metadata
+        self._websink.props.meta = dict_to_gst_structure(
+            "meta",
+            {"serial": serial, **(extra_meta if extra_meta is not None else {})},
+        )
+        self.bin.add(self._websink)
+
+        # # Clock overlay
+        if show_clock:
+            self._clock_overlay = Gst.ElementFactory.make(
+                "clockoverlay", "clockoverlay"
+            )
+            self.bin.add(self._clock_overlay)
+            self._clock_overlay.link(self._websink)
+        else:
+            self._clock_overlay = None
+
+        self._queue2 = Gst.ElementFactory.make("queue", "q2")
+        self.bin.add(self._queue2)
+        self._queue2.link(
+            self._clock_overlay if self._clock_overlay is not None else self._websink
+        )
+
+        # # Ros Sink branch
+        self._rossink = Gst.ElementFactory.make("rosimagesink", "rossink")
+        self._rossink.set_property("ros-topic", ros_topic)
+        self.bin.add(self._rossink)
+
+        self._queue1 = Gst.ElementFactory.make("queue", "q1")
+        self.bin.add(self._queue1)
+        self._queue1.link(self._rossink)
+
+        # # Tee split
+        self._tee = Gst.ElementFactory.make("tee", "tee")
+        self.bin.add(self._tee)
+        self._tee.link(self._queue2)
+        self._tee.link(self._queue1)
+
+        # # Converter
+        self._video_converter = Gst.ElementFactory.make("videoconvert", "converter")
+        self.bin.add(self._video_converter)
+        self._video_converter.link(self._tee)
+
+        # # Decoder
+        self._decoder = Gst.ElementFactory.make("decodebin", "decoder")
+        self._decoder.connect(
+            "pad-added",
+            lambda element, pad: pad.link(self._video_converter.get_static_pad("sink")),
+        )
+        self.bin.add(self._decoder)
+
+        # # Capability filter
+        caps = Gst.Caps.new_empty()
+        caps_structure = Gst.Structure.new_empty(mime)
+        if width is not None:
+            caps_structure.set_value("width", width)
+        if height is not None:
+            caps_structure.set_value("height", height)
+        if framerate is not None:
+            caps_structure.set_value("framerate", Gst.Fraction(framerate, 1))
+        caps.append_structure(caps_structure)
+
+        self._caps_filter = Gst.ElementFactory.make("capsfilter", "capsfilter")
+        self._caps_filter.props.caps = caps
+        self.bin.add(self._caps_filter)
+        self._caps_filter.link(self._decoder)
+
+        # # Source
+        self._source = Gst.ElementFactory.make("v4l2src", "source")
+        self._source.props.device = device_node
+        self.bin.add(self._source)
+        self._source.link(self._caps_filter)
+
+    @property
+    def webrtc_stats(self) -> dict[str, object]:
+        return gst_structure_to_dict(self._sink.props.stats)
+
+
 
 def main(args=None):
     rclpy.init(args=args)

--- a/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_ros_streamer.py
@@ -58,9 +58,6 @@ from sensor_msgs.msg import Image
 
 
 class CameraStreamerService(Node):
-    """
-    This node is 
-    """
     class CameraConfiguration():
         def __init__(self, serial: str, topic: str):
             self.serial = serial

--- a/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
@@ -46,8 +46,7 @@ class CameraStreamerService(Node):
     ACTIONS: None
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     PACKAGE: 	cameras2
-    AUTHOR(S):	Joshua Leivenzon
-    EDITED BY:  Anthony Lew
+    AUTHOR(S):	Joshua Leivenzon, Anthony Lew
     CREATION:	25/02/2023
     EDITED:		7/05/2025
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
@@ -322,7 +322,7 @@ class CameraStreamerService(Node):
         # Choose the gstreamer bin to use
         # If a ros topic is present, use the split ros topic and webrtc pipeline
         # TODO: Make this more robust and able to support any sort of pipeline in a plugin style system able to be specified in param file
-        cam_bin_init = CameraWebRTCBin if camera_configuration.meta['ros_topic'] is None else CameraSplitROSWebRTCBin
+        cam_bin_init = CameraSplitROSWebRTCBin  if 'ros_topic' in camera_configuration.meta else CameraWebRTCBin
         camera_bin = cam_bin_init(
             serial,
             device_node,

--- a/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
@@ -23,6 +23,7 @@ from camera_msgs.msg import Cameras
 from camera_msgs.srv import CameraOperation, GetCameraStreamStats, GetIPList
 
 from cameras2.camera_webrtc_bin import CameraWebRTCBin
+from cameras2.camera_ros_streamer import CameraSplitROSWebRTCBin
 
 
 class CameraStreamerService(Node):
@@ -317,7 +318,9 @@ class CameraStreamerService(Node):
 
     def _create_camera_bin(self, serial: str, device_node: str) -> CameraWebRTCBin:
         camera_configuration = self._camera_configurations.get(serial, self._default_camera_configuration)
-        camera_bin = CameraWebRTCBin(
+        self.get_logger().info(f"{camera_configuration.meta}")
+        cam_bin_init = CameraWebRTCBin if camera_configuration.meta['ros_topic'] is None else CameraSplitROSWebRTCBin
+        camera_bin = cam_bin_init(
             serial,
             device_node,
             mime=camera_configuration.mime,

--- a/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
+++ b/src/ros/cameras2/cameras2/cameras2/camera_streamer_service.py
@@ -47,8 +47,9 @@ class CameraStreamerService(Node):
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     PACKAGE: 	cameras2
     AUTHOR(S):	Joshua Leivenzon
+    EDITED BY:  Anthony Lew
     CREATION:	25/02/2023
-    EDITED:		25/02/2023
+    EDITED:		7/05/2025
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     """
 
@@ -318,7 +319,9 @@ class CameraStreamerService(Node):
 
     def _create_camera_bin(self, serial: str, device_node: str) -> CameraWebRTCBin:
         camera_configuration = self._camera_configurations.get(serial, self._default_camera_configuration)
-        self.get_logger().info(f"{camera_configuration.meta}")
+        # Choose the gstreamer bin to use
+        # If a ros topic is present, use the split ros topic and webrtc pipeline
+        # TODO: Make this more robust and able to support any sort of pipeline in a plugin style system able to be specified in param file
         cam_bin_init = CameraWebRTCBin if camera_configuration.meta['ros_topic'] is None else CameraSplitROSWebRTCBin
         camera_bin = cam_bin_init(
             serial,

--- a/src/ros/cameras2/cameras2/params/config.yaml
+++ b/src/ros/cameras2/cameras2/params/config.yaml
@@ -91,3 +91,7 @@ camera_streamer:
         meta:
           uiProps:
             name: Arm - Side
+      arm_end_periscope:
+        meta:
+          # used for auto typing 2025
+          ros_topic: "/arm/periscope"

--- a/src/ros/cameras2/nix/packages/cameras2/default.nix
+++ b/src/ros/cameras2/nix/packages/cameras2/default.nix
@@ -78,9 +78,10 @@ buildRosPackage {
 
   #export GST_PLUGIN_PATH="${gst-bridge}/lib:$GST_PLUGIN_PATH"
   preFixup = ''
-    wrapGApp "$out/lib/cameras2/camera_streamer_service"
-
     export GST_PLUGIN_PATH="${gst-bridge}/lib:$GST_PLUGIN_PATH"
+
+    wrapGApp "$out/lib/cameras2/camera_streamer_service"\
+      --prefix GST_PLUGIN_PATH : "${gst-bridge}/lib"
     wrapGApp "$out/lib/cameras2/camera_ros_streamer"\
       --prefix GST_PLUGIN_PATH : "${gst-bridge}/lib"
   '';

--- a/src/ros/nova-gui/nova-gui/src/components/AutoTyping/AutoTypingKeyEntryWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/AutoTyping/AutoTypingKeyEntryWidget.tsx
@@ -1,10 +1,10 @@
 import {Button, Input, CardProps} from "@nextui-org/react";
-//import {useBifrost} from "../../redux/actions/bifrost/useBifrostAction.ts";
-//import {useSelector} from "react-redux";
-//import {RootState} from "../../redux/RootState.ts";
-//import {RosService} from "../../ros/services/rosService.ts";
+import {useBifrost} from "../../redux/actions/bifrost/useBifrostAction.ts";
+import {useSelector} from "react-redux";
+import {RootState} from "../../redux/RootState.ts";
+import {RosService} from "../../ros/services/rosService.ts";
 import { Square, Power } from "react-feather";
-//import {AlignTransformValues} from "./AutoTypingConstants.tsx";
+import {AlignTransformValues} from "./AutoTypingConstants.tsx";
 
 interface IAutoTypingKeyEntryWidgetProps extends CardProps {
 }
@@ -15,17 +15,17 @@ interface IAutoTypingKeyEntryWidgetProps extends CardProps {
  * @constructor
  */
 const AutoTypingKeyEntryWidget: React.FC<IAutoTypingKeyEntryWidgetProps> = () => {
-  //const keyboardTransform = useSelector(
-  //    (state: RootState) => state.keyboardData
-  //);
+  const keyboardTransform = useSelector(
+      (state: RootState) => state.keyboardTFTrigger
+  );
 
-  //const bifrost = useBifrost({ service: RosService.KEYBOARD_TF_TOGGLE });
-  //const toggleKeyboardState = () => bifrost.callServiceToRedux({value:keyboardTransform.success ? AlignTransformValues.STOP : AlignTransformValues.START});
+  const bifrost = useBifrost({ service: RosService.KEYBOARD_TF_TOGGLE });
+  const toggleKeyboardState = () => bifrost.callServiceToRedux({value:keyboardTransform.success ? AlignTransformValues.STOP : AlignTransformValues.START});
 
   return (
     <div className="flex flex-row justify-between gap-5">
       <Button className="w-1/3 text-h1 h-12" color="primary" 
-        onPress={()=>{}}> {/** Change on press to start/stop auto typing via ros */}
+        onPress={toggleKeyboardState}> {/** Change on press to start/stop auto typing via ros */}
         {false ? "STOP TYPING" : "START TYPING"}
         {false ? <Square size="15" fill="white"/> : <Power size="15"/>}
       </Button>

--- a/src/ros/nova-gui/nova-gui/src/components/AutoTyping/AutoTypingTransformWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/AutoTyping/AutoTypingTransformWidget.tsx
@@ -16,7 +16,7 @@ interface IAutoTypingTransformWidgetProps extends CardProps {
  */
 const AutoTypingTransformWidget: React.FC<IAutoTypingTransformWidgetProps> = () => {
   const keyboardTransform = useSelector(
-      (state: RootState) => state.keyboardData
+      (state: RootState) => state.keyboardTFTrigger
     );
 
   const bifrost = useBifrost({ service: RosService.KEYBOARD_TF_TOGGLE });

--- a/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
@@ -1,50 +1,49 @@
 import {BaseCameraComponentProps} from "../CameraComponent.tsx";
-import {FC, useState} from "react";
+import {FC, useState, useEffect} from "react";
 import OverlayedCameraComponent from "./OverlayedCameraComponent.tsx";
 import {StreamingState} from "../hooks/useCameraStream.ts";
 import {RosTopic} from "../../../ros/topics/rosTopic.ts";
+import { RootState } from "../../../redux/RootState";
+import { useSelector } from "react-redux";
 import {useBifrost} from "../../../redux/actions/bifrost/useBifrostAction.ts";
 
-const CAMERA_WIDTH = 640
-const CAMERA_HEIGHT = 480
-
-// dummy points
-const overlayPoints = [
-  { x: 100, y: 100 },
-  { x: 600, y: 100 },
-  { x: 600, y: 200 },
-  { x: 100, y: 200 }
-];
 
 export const KeyboardOverlayedCameraComponent: FC<BaseCameraComponentProps> = (props) => {
   const [showOverlay, setShowOverlay] = useState<boolean>(false)
-  const polygonPoints = overlayPoints.map(p => `${p.x},${p.y}`).join(" ");
 
-  const bifrost = useBifrost({ topic: RosTopic.NIR_DATA });
-  const takeReading = (led: number) => bifrost.callService({led: led});
+  const bifrost = useBifrost({ topic: RosTopic.KEYBOARD_DATA });
+  const keyboardPoints = useSelector((state: RootState) => state.keyboardDataStore.points);
+  const camera_width = useSelector((state: RootState) => state.keyboardDataStore.width);
+  const camera_height = useSelector((state: RootState) => state.keyboardDataStore.height);
+  const polygonPoints = keyboardPoints.reduce<string[]>((acc, val, idx, arr) => {
+    if (idx % 2 === 0) acc.push(`${val},${arr[idx + 1]}`);
+    return acc;
+  }, []).join(" ");
 
   useEffect(() => {
     bifrost.syncWithTopic();
   }, [bifrost]);
 
+  const overlayBody = (
+    <svg 
+      className="absolute top-0 left-0 w-full h-full pointer-events-none"
+      viewBox={`0 0 ${camera_width} ${camera_height}`}
+      preserveAspectRatio="none"
+    >
+      <polygon
+        points={polygonPoints}
+        fill="none"
+        stroke="red"
+        strokeWidth="2"
+      />
+    </svg>
+  )
+
   return (
     <OverlayedCameraComponent
       onStreamingStateChange={(s) => setShowOverlay(s === StreamingState.STOPPED)}
       {...props}
-      overlay={showOverlay ? (
-        <svg 
-          className="absolute top-0 left-0 w-full h-full pointer-events-none"
-          viewBox={`0 0 ${CAMERA_WIDTH} ${CAMERA_HEIGHT}`}
-          preserveAspectRatio="none"
-        >
-          <polygon
-            points={polygonPoints}
-            fill="none"
-            stroke="red"
-            strokeWidth="2"
-          />
-        </svg>
-      ) : <div/>}
+      overlay={showOverlay ? overlayBody : <div/>}
     />
   )
 }

--- a/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
@@ -1,0 +1,52 @@
+import {BaseCameraComponentProps} from "../CameraComponent.tsx";
+import {FC, useState} from "react";
+import OverlayedCameraComponent from "./OverlayedCameraComponent.tsx";
+import {StreamingState} from "../hooks/useCameraStream.ts";
+import {RosTopic} from "../../../ros/topics/rosTopic.ts";
+import {useBifrost} from "../../../redux/actions/bifrost/useBifrostAction.ts";
+
+const CAMERA_WIDTH = 640
+const CAMERA_HEIGHT = 480
+
+// dummy points
+const overlayPoints = [
+  { x: 100, y: 100 },
+  { x: 600, y: 100 },
+  { x: 600, y: 200 },
+  { x: 100, y: 200 }
+];
+
+export const KeyboardOverlayedCameraComponent: FC<BaseCameraComponentProps> = (props) => {
+  const [showOverlay, setShowOverlay] = useState<boolean>(false)
+  const polygonPoints = overlayPoints.map(p => `${p.x},${p.y}`).join(" ");
+
+  const bifrost = useBifrost({ topic: RosTopic.NIR_DATA });
+  const takeReading = (led: number) => bifrost.callService({led: led});
+
+  useEffect(() => {
+    bifrost.syncWithTopic();
+  }, [bifrost]);
+
+  return (
+    <OverlayedCameraComponent
+      onStreamingStateChange={(s) => setShowOverlay(s === StreamingState.STOPPED)}
+      {...props}
+      overlay={showOverlay ? (
+        <svg 
+          className="absolute top-0 left-0 w-full h-full pointer-events-none"
+          viewBox={`0 0 ${CAMERA_WIDTH} ${CAMERA_HEIGHT}`}
+          preserveAspectRatio="none"
+        >
+          <polygon
+            points={polygonPoints}
+            fill="none"
+            stroke="red"
+            strokeWidth="2"
+          />
+        </svg>
+      ) : <div/>}
+    />
+  )
+}
+
+export default KeyboardOverlayedCameraComponent;

--- a/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx
@@ -12,36 +12,39 @@ export const KeyboardOverlayedCameraComponent: FC<BaseCameraComponentProps> = (p
   const [showOverlay, setShowOverlay] = useState<boolean>(false)
 
   const bifrost = useBifrost({ topic: RosTopic.KEYBOARD_DATA });
-  const keyboardPoints = useSelector((state: RootState) => state.keyboardDataStore.points);
-  const camera_width = useSelector((state: RootState) => state.keyboardDataStore.width);
-  const camera_height = useSelector((state: RootState) => state.keyboardDataStore.height);
-  const polygonPoints = keyboardPoints.reduce<string[]>((acc, val, idx, arr) => {
-    if (idx % 2 === 0) acc.push(`${val},${arr[idx + 1]}`);
-    return acc;
-  }, []).join(" ");
-
   useEffect(() => {
     bifrost.syncWithTopic();
   }, [bifrost]);
 
+  const keyboardPoints = useSelector((state: RootState) => state.keyboardDataStore.points);
+  const camera_width = useSelector((state: RootState) => state.keyboardDataStore.width);
+  const camera_height = useSelector((state: RootState) => state.keyboardDataStore.height);
+  const polygonPoints = keyboardPoints.reduce<string[]>((acc:string[], val:number, idx:number, arr:number[]) => {
+    if (idx % 2 === 0) acc.push(`${val},${arr[idx + 1]}`);
+    return acc;
+  }, []).join(" ");
+
   const overlayBody = (
-    <svg 
-      className="absolute top-0 left-0 w-full h-full pointer-events-none"
-      viewBox={`0 0 ${camera_width} ${camera_height}`}
-      preserveAspectRatio="none"
-    >
-      <polygon
-        points={polygonPoints}
-        fill="none"
-        stroke="red"
-        strokeWidth="2"
-      />
-    </svg>
+    <div>
+      <svg 
+        className="absolute top-0 left-0 w-full h-full pointer-events-none"
+        viewBox={`0 0 ${camera_width} ${camera_height}`}
+        preserveAspectRatio="none"
+      >
+        <polygon
+          points={polygonPoints}
+          fill="none"
+          stroke="red"
+          strokeWidth="2"
+        />
+      </svg>
+      <div className="self-center grow h-0.5 bg-black"/> 
+    </div>
   )
 
   return (
     <OverlayedCameraComponent
-      onStreamingStateChange={(s) => setShowOverlay(s === StreamingState.STOPPED)}
+      onStreamingStateChange={(s) => setShowOverlay(s === StreamingState.STREAMING)}
       {...props}
       overlay={showOverlay ? overlayBody : <div/>}
     />

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -97,10 +97,18 @@ export const reduxStores = {
       data: "",
     }
   ),
-  keyboardData: createBifrostStore(
+  keyboardTFTrigger: createBifrostStore(
     { service: RosService.KEYBOARD_TF_TOGGLE },
     {
       success: false,
+    }
+  ),
+  keyboardDataStore: createBifrostStore(
+    { topic: RosTopic.KEYBOARD_DATA },
+    {
+      points: [0, 0, 0, 0, 0, 0, 0, 0],
+      width: 640,
+      height: 480,
     }
   ),
 

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -25,7 +25,7 @@ import {
   IRosNovaInterfacesBmeSensor,
   IRosSensorMsgsBatteryState,
   IRosArmInterfacesStringTriggerResponse,
-  IRosArmMsgsKeyboardPoints,
+  IRosArmInterfacesKeyboardPoints,
 } from "../ros/rosTypes";
 
 import { BifrostStatus } from "./models/bifrost/BifrostTypes";
@@ -52,7 +52,7 @@ export interface RootState {
   armTelemetryStore: IRosCmdInterfacesCmDsFeedback;
   rfidDataStore: IRosStdMsgsString;
   keyboardTFTrigger: IRosArmInterfacesStringTriggerResponse;
-  keyboardDataStore: IRosArmMsgsKeyboardPoints;
+  keyboardDataStore: IRosArmInterfacesKeyboardPoints;
 
   // Camera Stores
   camerasStore: IRosCameraMsgsCameras;

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -25,6 +25,7 @@ import {
   IRosNovaInterfacesBmeSensor,
   IRosSensorMsgsBatteryState,
   IRosArmInterfacesStringTriggerResponse,
+  IRosArmMsgsKeyboardPoints,
 } from "../ros/rosTypes";
 
 import { BifrostStatus } from "./models/bifrost/BifrostTypes";
@@ -50,7 +51,8 @@ export interface RootState {
   // Arm Stores
   armTelemetryStore: IRosCmdInterfacesCmDsFeedback;
   rfidDataStore: IRosStdMsgsString;
-  keyboardData: IRosArmInterfacesStringTriggerResponse;
+  keyboardTFTrigger: IRosArmInterfacesStringTriggerResponse;
+  keyboardDataStore: IRosArmMsgsKeyboardPoints;
 
   // Camera Stores
   camerasStore: IRosCameraMsgsCameras;

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
@@ -19,6 +19,7 @@ export enum RosTopic {
   // Arm related topics
   ARM_TELEMETRY = "/cmds/cmd_feedback",
   RFID_DATA = "/electronics/rfid/data",
+  KEYBOARD_DATA = "/arm/keyboard/points",
 
   // Camera Related topics
   CAMERAS = "/camera_directory/cameras",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
@@ -19,6 +19,7 @@ export const rosTopicMessages = {
   // Arm Related
   [RosTopic.ARM_TELEMETRY]: "cmd_interfaces/msg/CMDsFeedback",
   [RosTopic.RFID_DATA]: "std_msgs/msg/String",
+  [RosTopic.KEYBOARD_DATA]: "arm_interfaces/msg/KeyboardPoints",
 
   // Cameras Related
   [RosTopic.CAMERAS]: "camera_msgs/msg/Cameras",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
@@ -18,12 +18,13 @@ import {
   IRosSensorMsgsCompressedImage,
   IRosNovaInterfacesBmeSensor,
   IRosSensorMsgsBatteryState,
+  IRosArmInterfacesKeyboardPoints,
 } from "../rosTypes";
 import { RosTopic } from "./rosTopic";
 
 /**
  * This Interface exists to link Individual topics to The Messages.
- * These Messages are defined as Interfaces on `rosTypes.ts`. This is not to be confused with
+ * These Messages are defined as InterKeybofaces on `rosTypes.ts`. This is not to be confused with
  * `rosMessages.ts`
  *
  * An Example is Given below to link the Topic RosTopics.DEMO_TOPIC to IRosDemoMessage
@@ -39,6 +40,7 @@ export interface RosTopicInterfaces {
   // Arm Related
   [RosTopic.ARM_TELEMETRY]: IRosCmdInterfacesCmDsFeedback;
   [RosTopic.RFID_DATA]: IRosStdMsgsString;
+  [RosTopic.KEYBOARD_DATA]: IRosArmInterfacesKeyboardPoints;
 
   // Cameras Related
   [RosTopic.CAMERAS]: IRosCameraMsgsCameras;

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/SerialMappedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/SerialMappedCameraComponent.tsx
@@ -2,6 +2,7 @@ import {FC, memo, useMemo} from "react";
 import {BaseCameraComponentProps, CameraComponent} from "../../../components/CameraComponent/CameraComponent.tsx";
 import {CameraSerials} from "./CameraPageConstants.tsx";
 import BarOverlayedCameraComponent from "../../../components/CameraComponent/special/BarOverlayedCameraComponent.tsx";
+//import KeyboardOverlayedCameraComponent from "../../../components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx";
 import {
   GimbalOverlayedCameraComponent
 } from "../../../components/CameraComponent/special/GimbalOverlayedCameraComponent.tsx";

--- a/src/ros/nova-gui/nova-gui/src/views/urc/URCAutoTypingView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/urc/URCAutoTypingView.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import AutoTypingTransformWidget from "../../components/AutoTyping/AutoTypingTransformWidget.tsx";
 import AutoTypingKeyEntryWidget from "../../components/AutoTyping/AutoTypingKeyEntryWidget.tsx";
 import SerialMappedCameraComponent from "../shared/CamerasPage/SerialMappedCameraComponent.tsx";
 import KeyboardOverlayedCameraComponent from "../../components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx";
 import ArmTypingWidget from "../../components/ArmWidget/ArmTypingWidget.tsx";
 import {CameraSerials} from "../shared/CamerasPage/CameraPageConstants.tsx";
+import { useCameraStreamer } from "../../components/CameraComponent/hooks/useCameraStreamer";
 
 
 const URCAutoTypingView: React.FC = () => {
+  useCameraStreamer();
   return <div className="grid m-3 gap-3">
     <div className="grid grid-cols-2 gap-3 h-2/3">
       <div className="grid grid-col gap-3">
         <KeyboardOverlayedCameraComponent cameraSerial={CameraSerials.ARM_END_PERISCOPE}/>
-        <AutoTypingTransformWidget/>
         <AutoTypingKeyEntryWidget/>
       </div>
       <div className="grid grid-cols-2 gap-3">

--- a/src/ros/nova-gui/nova-gui/src/views/urc/URCAutoTypingView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/urc/URCAutoTypingView.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import AutoTypingTransformWidget from "../../components/AutoTyping/AutoTypingTransformWidget.tsx";
 import AutoTypingKeyEntryWidget from "../../components/AutoTyping/AutoTypingKeyEntryWidget.tsx";
 import SerialMappedCameraComponent from "../shared/CamerasPage/SerialMappedCameraComponent.tsx";
+import KeyboardOverlayedCameraComponent from "../../components/CameraComponent/special/KeyboardOverlayedCameraComponent.tsx";
 import ArmTypingWidget from "../../components/ArmWidget/ArmTypingWidget.tsx";
 import {CameraSerials} from "../shared/CamerasPage/CameraPageConstants.tsx";
 
@@ -10,7 +11,7 @@ const URCAutoTypingView: React.FC = () => {
   return <div className="grid m-3 gap-3">
     <div className="grid grid-cols-2 gap-3 h-2/3">
       <div className="grid grid-col gap-3">
-        <SerialMappedCameraComponent cameraSerial={CameraSerials.ARM_END_PERISCOPE}/>
+        <KeyboardOverlayedCameraComponent cameraSerial={CameraSerials.ARM_END_PERISCOPE}/>
         <AutoTypingTransformWidget/>
         <AutoTypingKeyEntryWidget/>
       </div>

--- a/src/ros/rover/arm/arm/arm/keyboard_localiser.py
+++ b/src/ros/rover/arm/arm/arm/keyboard_localiser.py
@@ -257,14 +257,20 @@ class KeyboardLocaliser(Node):
         mask_blip = cv2.morphologyEx(mask_pruned, cv2.MORPH_OPEN, kern_blip, iterations=1)
         
         # Get largest contour's hull
+        approx = None
         contours, _ = cv2.findContours(mask_blip, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        hull = cv2.convexHull(max(contours, key=cv2.contourArea))
-        # simplify contour polygon using algorithm (0.02 *cv2 arcLength is 2% of perimeter)
-        approx = cv2.approxPolyDP(hull, 0.02 * cv2.arcLength(hull, True), True)
-        # Extract and reshape points to 2D array
-        corners = approx.reshape(4, 2)
+        if contours:
+            hull = cv2.convexHull(max(contours, key=cv2.contourArea))
+            # simplify contour polygon using algorithm (0.02 *cv2 arcLength is 2% of perimeter)
+            approx = cv2.approxPolyDP(hull, 0.02 * cv2.arcLength(hull, True), True)
+
         # Sort the points in order: top-left, top-right, bottom-right, bottom-left
-        def sort_corners(pts) -> np.ndarray:
+        def sort_corners(approx) -> np.ndarray:
+            if approx is None or len(approx) != 4:
+                return None
+            # Extract and reshape points to 2D array
+            pts = approx.reshape(4, 2)
+
             sorted_pts = np.zeros((4, 2), dtype="float32")
             s = pts.sum(axis=1)
             diff = np.diff(pts, axis=1)
@@ -274,14 +280,15 @@ class KeyboardLocaliser(Node):
             sorted_pts[3] = pts[np.argmax(diff)]    # bottom-left
             return sorted_pts
 
-        image_points = sort_corners(corners)
+        image_points = sort_corners(approx)
         self.pub_debug_image(image, image_points)
         return image_points
     
     def pub_debug_image(self, img, points) -> None:
         # Draw each point
-        for point in points:
-           cv2.circle(img, (int(point[0]), int(point[1])), radius=5, color=(0, 255, 0), thickness=-1)
+        if points is not None:
+            for point in points:
+                cv2.circle(img, (int(point[0]), int(point[1])), radius=5, color=(0, 255, 0), thickness=-1)
 
         # Convert OpenCV image -> ROS Image
         output_msg = CvBridge().cv2_to_imgmsg(img, encoding="bgr8")

--- a/src/ros/rover/arm/arm/arm/keyboard_localiser.py
+++ b/src/ros/rover/arm/arm/arm/keyboard_localiser.py
@@ -93,7 +93,8 @@ class KeyboardLocaliser(Node):
         self.node_is_auto = self.declare_parameter('using_auto', True).get_parameter_value().bool_value
         # Do we publish the debug image or keyboard points to GUI
         self.do_debug = self.declare_parameter('debug_image', True).get_parameter_value().bool_value
-        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10) if self.do_debug else self.create_publisher(KeyboardPoints, POINT_TOPIC, 10)
+        self.point_pub = self.create_publisher(KeyboardPoints, POINT_TOPIC, 10)
+        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10) if self.do_debug else None
 
         # key position initalisation
         self.keyboard_frame = self.declare_parameter('keyboard_frame', 'keyboard_frame').get_parameter_value().string_value
@@ -215,10 +216,10 @@ class KeyboardLocaliser(Node):
 
     def publish_analysis_tf(self) -> None:
         '''Publish the transform of the keyboard through the solvePnP method'''
-        if self.view is None or not self.node_is_auto or not self.is_aligned:
+        if self.view is None or not self.node_is_auto:
             return
         transform = self.estimate_pose()
-        if transform is None:
+        if transform is None or self.is_aligned:
             return None
         self.transform_broadcaster.sendTransform(transform)
 
@@ -286,17 +287,17 @@ class KeyboardLocaliser(Node):
         return image_points
     
     def pub_debug_image(self, img, points) -> None:
-        if not self.do_debug:
-            # Publish points instead
-            kb_msg = KeyboardPoints()
-            kb_msg.points = [i for point in points for i in point]
-            kb_msg.width, kb_msg.height = self.camera_resolution
-            self.debug_pub.publish(kb_msg)
-            return
-        # Draw each point
+        # Publish points and draw each point
         if points is not None:
+            kb_msg = KeyboardPoints()
+            kb_msg.points = [int(i) for point in points for i in point]
+            kb_msg.width, kb_msg.height = self.camera_resolution
+            self.point_pub.publish(kb_msg)
             for point in points:
                 cv2.circle(img, (int(point[0]), int(point[1])), radius=5, color=(0, 255, 0), thickness=-1)
+
+        if not self.do_debug:
+            return
 
         # Convert OpenCV image -> ROS Image
         output_msg = CvBridge().cv2_to_imgmsg(img, encoding="bgr8")

--- a/src/ros/rover/arm/arm/arm/keyboard_localiser.py
+++ b/src/ros/rover/arm/arm/arm/keyboard_localiser.py
@@ -91,15 +91,13 @@ class KeyboardLocaliser(Node):
         self.node_is_auto = self.declare_parameter('using_auto', True).get_parameter_value().bool_value
         # Do we publish the debug image?
         self.do_debug = self.declare_parameter('debug_image', True).get_parameter_value().bool_value
-        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10)
+        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10) if self.do_debug else None
 
         # key position initalisation
         self.keyboard_frame = self.declare_parameter('keyboard_frame', 'keyboard_frame').get_parameter_value().string_value
         self.base_frame = self.declare_parameter('base_frame', 'base_link').get_parameter_value().string_value
         self.key_srv = self.create_service(KeyPosition, KEY_SERVICE_NAME, self.get_key_position_callback)
         self.key_map = KEY_MAP
-        
-        THRESHOLD_CONTOUR_AREA = (30000, 80000) # expected pixel area bounds of rectangle in image
 
         # manual keyboard alignment initalisation
         self.aligned_keyboard_position = self.declare_parameter('aligned_keyboard_position', DEFAULT_POSITION).get_parameter_value().double_array_value
@@ -285,6 +283,8 @@ class KeyboardLocaliser(Node):
         return image_points
     
     def pub_debug_image(self, img, points) -> None:
+        if not self.do_debug:
+            return
         # Draw each point
         if points is not None:
             for point in points:

--- a/src/ros/rover/arm/arm/arm/keyboard_localiser.py
+++ b/src/ros/rover/arm/arm/arm/keyboard_localiser.py
@@ -25,6 +25,7 @@ TODO:
 
 from geometry_msgs.msg import PointStamped, TransformStamped
 from arm_interfaces.srv import KeyPosition, StringTrigger
+from arm_interfaces.msg import KeyboardPoints
 from sensor_msgs.msg import Image
 
 import rclpy
@@ -80,7 +81,8 @@ In separate terminal:
 KEY_SERVICE_NAME = '/arm/keyboard/get_key_position'
 KEYBOARD_TF_SERVICE_NAME = '/arm/keyboard/transform_toggle'
 IMAGE_TOPIC = '/arm/periscope'
-DEBUG_TOPIC = '/keyboard_debug'
+DEBUG_TOPIC = '/arm/keyboard/image'
+POINT_TOPIC = '/arm/keyboard/points'
 
 
 class KeyboardLocaliser(Node):
@@ -89,9 +91,9 @@ class KeyboardLocaliser(Node):
 
         # Choose whether to use auto transform or manual align transform
         self.node_is_auto = self.declare_parameter('using_auto', True).get_parameter_value().bool_value
-        # Do we publish the debug image?
+        # Do we publish the debug image or keyboard points to GUI
         self.do_debug = self.declare_parameter('debug_image', True).get_parameter_value().bool_value
-        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10) if self.do_debug else None
+        self.debug_pub = self.create_publisher(Image, DEBUG_TOPIC, 10) if self.do_debug else self.create_publisher(KeyboardPoints, POINT_TOPIC, 10)
 
         # key position initalisation
         self.keyboard_frame = self.declare_parameter('keyboard_frame', 'keyboard_frame').get_parameter_value().string_value
@@ -118,6 +120,7 @@ class KeyboardLocaliser(Node):
         ], dtype=np.float32)
         dist_arr = self.declare_parameter('distortion_matrix', [0.0,0.0,0.0,0.0,0.0]).get_parameter_value().double_array_value
         self.dist_coeffs = np.array(dist_arr)
+        self.camera_resolution = width, height
 
         # keyboard pose analysis initalisation
         self.camera_frame = self.declare_parameter('camera_frame', 'arm_end_periscope_optical').get_parameter_value().string_value
@@ -284,6 +287,11 @@ class KeyboardLocaliser(Node):
     
     def pub_debug_image(self, img, points) -> None:
         if not self.do_debug:
+            # Publish points instead
+            kb_msg = KeyboardPoints()
+            kb_msg.points = [i for point in points for i in point]
+            kb_msg.width, kb_msg.height = self.camera_resolution
+            self.debug_pub.publish(kb_msg)
             return
         # Draw each point
         if points is not None:

--- a/src/ros/rover/arm/arm/arm/keyboard_localiser.py
+++ b/src/ros/rover/arm/arm/arm/keyboard_localiser.py
@@ -132,6 +132,10 @@ class KeyboardLocaliser(Node):
             [-KEYBOARD[1]/2, KEYBOARD[0]/2, 0]      # bottom-left
         ], dtype=np.float32)
 
+        # OpenCV filter params
+        self.dark_threshold = self.declare_parameter('dark_threshold', 120).get_parameter_value().integer_value
+        self.kernel_size = self.declare_parameter('kernel_size', 100).get_parameter_value().integer_value
+
         # tf2 initalisation
         self.tf_buffer = Buffer()
         self.tf_listener = TransformListener(self.tf_buffer, self)
@@ -236,21 +240,20 @@ class KeyboardLocaliser(Node):
         image = self.msg_to_mat(self.get_logger(), self.view, 'bgr8')
 
         # Get filtered mask
-        # TODO, parameterise threshold 120 and kernal 100
         hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
         h, s, v = cv2.split(hsv)
 
         # filter for dark colours (black keyboard)
-        _, mask = cv2.threshold(v, 120, 255, cv2.THRESH_BINARY_INV)
+        _, mask = cv2.threshold(v, self.dark_threshold, 255, cv2.THRESH_BINARY_INV)
 
         # close small gaps in mask
         kernel_close = cv2.getStructuringElement(cv2.MORPH_RECT, (5,5))
         mask_closed = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel_close, iterations=2)
 
         # filter out irregular blobs
-        kern_neck = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 100))
+        kern_neck = cv2.getStructuringElement(cv2.MORPH_RECT, (3, self.kernel_size))
         mask_pruned = cv2.morphologyEx(mask_closed, cv2.MORPH_OPEN, kern_neck, iterations=1)
-        kern_blip = cv2.getStructuringElement(cv2.MORPH_RECT, (100, 3))
+        kern_blip = cv2.getStructuringElement(cv2.MORPH_RECT, (self.kernel_size, 3))
         mask_blip = cv2.morphologyEx(mask_pruned, cv2.MORPH_OPEN, kern_blip, iterations=1)
         
         # Get largest contour's hull

--- a/src/ros/rover/arm/arm_interfaces/CMakeLists.txt
+++ b/src/ros/rover/arm/arm_interfaces/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(geometry_msgs)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/KeyboardLocaliser.msg"
   "msg/ArmControlScheme.msg"
   "msg/EndEffectorInput.msg"
 

--- a/src/ros/rover/arm/arm_interfaces/CMakeLists.txt
+++ b/src/ros/rover/arm/arm_interfaces/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(geometry_msgs)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
-  "msg/KeyboardLocaliser.msg"
+  "msg/KeyboardPoints.msg"
   "msg/ArmControlScheme.msg"
   "msg/EndEffectorInput.msg"
 

--- a/src/ros/rover/arm/arm_interfaces/msg/KeyboardPoints.msg
+++ b/src/ros/rover/arm/arm_interfaces/msg/KeyboardPoints.msg
@@ -1,0 +1,7 @@
+# Array of 8 values containing pixel points of keyboard corners:
+# [x1,y1, x2,y2, x3,y3, x4,y4] (i'm lazy)
+int32[] points
+
+# camera resolution 
+int32 width
+int32 height

--- a/src/ros/rover/nova_bringup/params/arm.yaml
+++ b/src/ros/rover/nova_bringup/params/arm.yaml
@@ -21,6 +21,10 @@ keyboard_localiser:
     image_height: 480 #720
     distortion_matrix: [0.59680899,-2.13821558,-0.01071933,0.0900803,4.94332294]
 
+    # OpenCV filter params
+    dark_threshold: 120 # 0-255
+    kernel_size: 100
+
     # (auto) keyboard pose analysis initalisation
     camera_frame: arm_end_periscope_optical
 


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description
Keyboard localiser detects the model keyboard and publishes a transform.
It also publishes points used on the GUI to create a visible overlay.

Importantly cameras2 is modified to have the pipeline also publish a ros image topic if the camera serial is given a ros_topic parameter. See config.yaml in `cameras2/cameras2/params`.
This is the main deciding factor on if this should be merged!
<!--- Elaborate on your Wonderful Work! --->

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Steps to Test
Terminal 1: Run GUI and navigate to `urc/auto-typing`
Terminal 2: `rosbridge`
Terminal 3: `ros2 run arm keyboard_localiser.py --ros-args --params-file /home/nova/nova/src/ros/rover/nova_bringup/params/arm.yaml`
Terminal 3: `ros2 launch cameras2 camera_server_launch.py`
<!--- How does someone test your awesome work? Add as Much Detail as Possible --->
<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes
![image](https://github.com/user-attachments/assets/6964bd3d-c841-4526-be4a-f405ad4472ae)
<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
