### PR TITLE
Feat/auto typing switch

### DIFF
--- a/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
+++ b/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
@@ -1,7 +1,7 @@
 /**
  * @file teleop_arm_joy.hpp
  * @brief Header file for the TeleopArmJoy class, which handles joystick input for teleoperation of the robotic arm.
- * Last Edited by Bailey
+ * Last Edited by Abby
  */
 #ifndef TELEOP_ARM_JOY_HPP
 #define TELEOP_ARM_JOY_HPP
@@ -26,7 +26,8 @@ namespace teleop_arm_joy
   enum class ControlMode
   {
     FK,
-    IK
+    IK,
+	AutoTyping
   };
 
   inline std::string prettyPrintMode(const ControlMode mode)
@@ -37,6 +38,9 @@ namespace teleop_arm_joy
       return "FK";
     case ControlMode::IK:
       return "IK";
+	case ControlMode::AutoTyping:
+	  return "Autonomous Typing";
+	  break;
     default:
       return "Unknown Mode";
     }
@@ -90,6 +94,11 @@ class TeleopArmJoy : public rclcpp::Node {
     void sendTwistCommand();
 
     /**
+     * @brief Sends a task space typing command for the arm based on ???.
+     */
+    void sendAutoTypingCommand();
+    
+	/**
      * @brief Sends a halt command to stop the rover.
      * Called when locked.
      */

--- a/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
+++ b/src/ros/rover/teleop_arm_joy/include/teleop_arm_joy/teleop_arm_joy.hpp
@@ -11,6 +11,7 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nova_interfaces/msg/arm_fk_velocity_targets.hpp>
 #include <controller_manager_msgs/srv/switch_controller.hpp>
+#include "std_srvs/srv/trigger.hpp"
 
 #include "teleop_arm_joy_parameters.hpp"
 #include "JoyDevice.hpp"
@@ -27,7 +28,6 @@ namespace teleop_arm_joy
   {
     FK,
     IK,
-	AutoTyping
   };
 
   inline std::string prettyPrintMode(const ControlMode mode)
@@ -38,9 +38,6 @@ namespace teleop_arm_joy
       return "FK";
     case ControlMode::IK:
       return "IK";
-	case ControlMode::AutoTyping:
-	  return "Autonomous Typing";
-	  break;
     default:
       return "Unknown Mode";
     }
@@ -68,6 +65,11 @@ class TeleopArmJoy : public rclcpp::Node {
 
     void initializeParams();
 
+    /**
+     * @brief Toggles autonomous typing state.
+     */
+	void toggleTyping(const std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
   private:
     void onDeviceUpdated(string& device_name);
 
@@ -93,11 +95,6 @@ class TeleopArmJoy : public rclcpp::Node {
      */
     void sendTwistCommand();
 
-    /**
-     * @brief Sends a task space typing command for the arm based on ???.
-     */
-    void sendAutoTypingCommand();
-    
 	/**
      * @brief Sends a halt command to stop the rover.
      * Called when locked.
@@ -117,12 +114,16 @@ class TeleopArmJoy : public rclcpp::Node {
      */
     void switchController(ControlMode requested_control_mode);
 
+	bool setTypingState();
+
     // Member variables
     // rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub;
     rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_client;
     rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr fk_client;
     rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr ik_client;
-    std::shared_ptr<ParamListener> param_listener_;
+  	rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr service;
+
+	std::shared_ptr<ParamListener> param_listener_;
 
     rclcpp::Publisher<nova_interfaces::msg::ArmFkVelocityTargets>::SharedPtr fk_velocity_pub;
     rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr ik_twist_pub;
@@ -136,7 +137,8 @@ class TeleopArmJoy : public rclcpp::Node {
     State previous_state;
 
     ControlMode control_mode = ControlMode::FK;
-    double speed; // Linear Speed Multiplier that can be incremented
+    bool typing_active;
+	double speed; // Linear Speed Multiplier that can be incremented
   };
 
 } // namespace teleop_arm_joy

--- a/src/ros/rover/teleop_arm_joy/package.xml
+++ b/src/ros/rover/teleop_arm_joy/package.xml
@@ -20,6 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>core</depend>
   <depend>nova_interfaces</depend>
+  <depend>std_srvs</depend>
 
   <exec_depend>joy</exec_depend>
 

--- a/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
+++ b/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
@@ -13,6 +13,7 @@ namespace
   constexpr auto BUTTON_DEBOUNCE_INTERVAL = std::chrono::milliseconds(50);
   constexpr auto DEFAULT_FK_VELOCITY_TOPIC = "/arm_fk_velocity_target";
   constexpr auto DEFAULT_IK_TWIST_TOPIC = "/arm_ik_twist_stamped";
+  constexpr auto DEFAULT_AUTO_TYPING_TOPIC = "/test";
 }
 
 using std::placeholders::_1;
@@ -32,11 +33,14 @@ TeleopArmJoy::TeleopArmJoy(const rclcpp::NodeOptions &options)
   ik_twist_pub = this->create_publisher<geometry_msgs::msg::TwistStamped>(
     DEFAULT_IK_TWIST_TOPIC, 50);
 
+  // TODO: create publisher for auto typing topic
+
   // Create service clients
   switch_controller_client = this->create_client<controller_manager_msgs::srv::SwitchController>("/controller_manager/switch_controller");
   // TODO: Make good for actual controller implementations
   fk_client = this->create_client<rcl_interfaces::srv::SetParameters>("/nova_arm_controller/set_parameters");
   ik_client = this->create_client<rcl_interfaces::srv::SetParameters>("/strafe_controller/set_parameters");
+  // TODO: create client for auto typing topic
 
   control_mode = ControlMode::FK;
 
@@ -188,6 +192,8 @@ void TeleopArmJoy::updateState() {
   // TODO: put speed into state
   handleSpeedChange();
 
+  // TODO: rework this
+  //
   setControlMode(buttons["twist_mode"]->value() ? ControlMode::IK : ControlMode::FK);
 }
 
@@ -206,6 +212,9 @@ void TeleopArmJoy::setControlMode(const ControlMode new_control_mode) {
   else if (new_control_mode == ControlMode::IK) {
     RCLCPP_INFO(get_logger(), "Switched to IK control.");
   }
+  else if (new_control_mode == ControlMode::AutoTyping) {
+    RCLCPP_INFO(get_logger(), "Switched to autonomous typing.");
+  }
 }
 
 void TeleopArmJoy::sendArmCommand()
@@ -218,6 +227,9 @@ void TeleopArmJoy::sendArmCommand()
   }
   else if (control_mode == ControlMode::IK) {
     sendTwistCommand();
+  }
+  else if (control_mode == ControlMode::AutoTyping) {
+    sendAutoTypingCommand();
   }
 }
 
@@ -283,6 +295,14 @@ void TeleopArmJoy::sendTwistCommand() {
   ik_twist_pub->publish(std::move(msg));
 }
 
+void TeleopArmJoy::sendAutoTypingCommand()
+{
+  // TODO: fill this out
+  auto msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
+
+  msg->header.stamp = this->now();
+}
+
 void TeleopArmJoy::sendHaltCommand()
 {
   // Send all zeroes for joint space
@@ -312,6 +332,8 @@ void TeleopArmJoy::sendHaltCommand()
   ik_msg->twist.angular = angular;
 
   ik_twist_pub->publish(std::move(ik_msg));
+
+  //TODO: halt auto typing command
 }
 
 void TeleopArmJoy::handleSpeedChange() {
@@ -325,6 +347,8 @@ std::vector<std::string> TeleopArmJoy::modeToControllers(const ControlMode mode)
       return params_.joint_space.controllers;
     case ControlMode::IK:
       return params_.twist.controllers;
+	case ControlMode::AutoTyping:
+	  return params_.auto.controllers;
     default:
       RCLCPP_WARN(get_logger(), "Unknown control type given to modeToControllers. Returning no controllers.");
       return {};

--- a/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
+++ b/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
@@ -192,9 +192,23 @@ void TeleopArmJoy::updateState() {
   // TODO: put speed into state
   handleSpeedChange();
 
-  // TODO: rework this
-  //
-  setControlMode(buttons["twist_mode"]->value() ? ControlMode::IK : ControlMode::FK);
+  // rotate control mode
+  if (buttons["twist_mode"]->down())
+  {
+	switch(control_mode)
+	{
+		case ControlMode::FK:
+			setControlMode(ControlMode::IK);
+			break;
+		case ControlMode::IK:
+			setControlMode(ControlMode::AutoTyping);
+			break;
+		case ControlMode::AutoTyping:
+			setControlMode(ControlMode::FK);
+			break;
+	}
+  }
+  //setControlMode(buttons["twist_mode"]->value() ? ControlMode::IK : ControlMode::FK);
 }
 
 void TeleopArmJoy::setControlMode(const ControlMode new_control_mode) {

--- a/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
+++ b/src/ros/rover/teleop_arm_joy/src/teleop_arm_joy.cpp
@@ -1,7 +1,7 @@
 /**
  * @file teleop_arm_joy.cpp
  * @brief Teleop Arm Joy node to translate Joy messages from /joy to commands for the arm.
- * Edited by Bailey
+ * Edited by Abby
  */
 
 #include "teleop_arm_joy/teleop_arm_joy.hpp"
@@ -17,6 +17,7 @@ namespace
 }
 
 using std::placeholders::_1;
+using std::placeholders::_2;
 
 namespace teleop_arm_joy
 {
@@ -33,16 +34,17 @@ TeleopArmJoy::TeleopArmJoy(const rclcpp::NodeOptions &options)
   ik_twist_pub = this->create_publisher<geometry_msgs::msg::TwistStamped>(
     DEFAULT_IK_TWIST_TOPIC, 50);
 
-  // TODO: create publisher for auto typing topic
-
   // Create service clients
   switch_controller_client = this->create_client<controller_manager_msgs::srv::SwitchController>("/controller_manager/switch_controller");
   // TODO: Make good for actual controller implementations
   fk_client = this->create_client<rcl_interfaces::srv::SetParameters>("/nova_arm_controller/set_parameters");
   ik_client = this->create_client<rcl_interfaces::srv::SetParameters>("/strafe_controller/set_parameters");
-  // TODO: create client for auto typing topic
-
+  
+  service = this->create_service<std_srvs::srv::Trigger>("/teleop_arm_joy/toggle_typing", 
+		  std::bind(&teleop_arm_joy::TeleopArmJoy::toggleTyping, this, _1, _2));
+  
   control_mode = ControlMode::FK;
+  typing_active = false;
 
   devices = std::vector<shared_ptr<JoyDevice>>();
   speed = 0;
@@ -192,23 +194,10 @@ void TeleopArmJoy::updateState() {
   // TODO: put speed into state
   handleSpeedChange();
 
-  // rotate control mode
-  if (buttons["twist_mode"]->down())
+  if (!typing_active)
   {
-	switch(control_mode)
-	{
-		case ControlMode::FK:
-			setControlMode(ControlMode::IK);
-			break;
-		case ControlMode::IK:
-			setControlMode(ControlMode::AutoTyping);
-			break;
-		case ControlMode::AutoTyping:
-			setControlMode(ControlMode::FK);
-			break;
-	}
+  	setControlMode(buttons["twist_mode"]->value() ? ControlMode::IK : ControlMode::FK);
   }
-  //setControlMode(buttons["twist_mode"]->value() ? ControlMode::IK : ControlMode::FK);
 }
 
 void TeleopArmJoy::setControlMode(const ControlMode new_control_mode) {
@@ -226,9 +215,6 @@ void TeleopArmJoy::setControlMode(const ControlMode new_control_mode) {
   else if (new_control_mode == ControlMode::IK) {
     RCLCPP_INFO(get_logger(), "Switched to IK control.");
   }
-  else if (new_control_mode == ControlMode::AutoTyping) {
-    RCLCPP_INFO(get_logger(), "Switched to autonomous typing.");
-  }
 }
 
 void TeleopArmJoy::sendArmCommand()
@@ -241,9 +227,6 @@ void TeleopArmJoy::sendArmCommand()
   }
   else if (control_mode == ControlMode::IK) {
     sendTwistCommand();
-  }
-  else if (control_mode == ControlMode::AutoTyping) {
-    sendAutoTypingCommand();
   }
 }
 
@@ -309,14 +292,6 @@ void TeleopArmJoy::sendTwistCommand() {
   ik_twist_pub->publish(std::move(msg));
 }
 
-void TeleopArmJoy::sendAutoTypingCommand()
-{
-  // TODO: fill this out
-  auto msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
-
-  msg->header.stamp = this->now();
-}
-
 void TeleopArmJoy::sendHaltCommand()
 {
   // Send all zeroes for joint space
@@ -361,8 +336,6 @@ std::vector<std::string> TeleopArmJoy::modeToControllers(const ControlMode mode)
       return params_.joint_space.controllers;
     case ControlMode::IK:
       return params_.twist.controllers;
-	case ControlMode::AutoTyping:
-	  return params_.auto.controllers;
     default:
       RCLCPP_WARN(get_logger(), "Unknown control type given to modeToControllers. Returning no controllers.");
       return {};
@@ -401,6 +374,36 @@ void TeleopArmJoy::switchController(const ControlMode requested_control_mode)
 
   auto future = switch_controller_client->async_send_request(request);
   control_mode = requested_control_mode;
+}
+
+bool TeleopArmJoy::setTypingState()
+{
+  if (!typing_active)
+  {
+  	// TODO: error checking!! right now this assumes that the control mode switch always goes through
+  	setControlMode(ControlMode::IK);
+  }
+
+  typing_active = !typing_active;
+  
+  return true;
+}
+
+void TeleopArmJoy::toggleTyping(const std::shared_ptr<std_srvs::srv::Trigger::Request> request, std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Received request to toggle typing state.");
+
+  bool res = setTypingState();
+  if (!res) {
+	response->success = false;
+    response->message = "Could not switch to typing mode.";
+  }
+  else {
+  	response->success = true;
+	response->message = typing_active ? "Switched to typing mode." : "Switched to FK/IK mode.";
+  }
+
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Sending back response...");
 }
 
 }


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

This PR adds a service call `/teleop_arm_joy/toggle_typing` to teleop_arm_joy, which allows it to switch from its normal FK/IK mode to a modified IK for typing used by Auto.

Relevant issue: #449 

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->
 - Modify teleop_arm_joy to add a service call for autonomous typing
 
## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->
- New service call: `/teleop_arm_joy/toggle_typing`


## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

- Run teleop_arm_joy and controller_manager
- Run `ros2 service call /teleop_arm_joy/toggle_typing std_srvs/srv/Trigger`

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

Our arm:
<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
![image](https://github.com/user-attachments/assets/82ceef38-a54b-4700-8030-3b73a6ca8f12)