### PR TITLE
Stream OAK cameras to GUI

### DIFF
--- a/src/ros/cameras2/cameras2/launch/ros_topic_streamer.launch.py
+++ b/src/ros/cameras2/cameras2/launch/ros_topic_streamer.launch.py
@@ -4,12 +4,14 @@ from launch import LaunchDescription, Substitution, SomeSubstitutionsType
 from launch.actions import DeclareLaunchArgument, ExecuteProcess
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch.utilities import normalize_to_list_of_substitutions
+from launch.conditions import IfCondition
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     params = LaunchConfiguration("params")
+    signalling = LaunchConfiguration("signalling")
 
     return LaunchDescription(
         [
@@ -18,7 +20,13 @@ def generate_launch_description():
                 default_value=PathJoinSubstitution([FindPackageShare("cameras2"), "params", "ros_streamer.yaml"]),
                 description="The path to the ros_streaming param file",
             ),
+            DeclareLaunchArgument(
+                "signalling",
+                default_value='False',
+                description="If to launch the gst-webrtc-signalling-server",
+            ),
             ExecuteProcess(
+                condition=IfCondition(signalling),
                 cmd=["gst-webrtc-signalling-server"],
                 additional_env={
                     "WEBRTCSINK_SIGNALLING_SERVER_LOG": "warn",

--- a/src/ros/cameras2/cameras2/params/ros_streamer.yaml
+++ b/src/ros/cameras2/cameras2/params/ros_streamer.yaml
@@ -3,9 +3,9 @@ ros_streamer:
     # Note the node doesn't currently work with depth cameras (needs some conversion in gstreamer pipeline)
     cameras: oak-rgb bootie-rgb
     oak-rgb:
-      topic: /oak/rgb/image_raw
+      topic: /oak/rgb/gui
       serial: oak-rgb
     bootie-rgb:
-      topic: /bootie/rgb/image_raw
+      topic: /bootie/rgb/gui
       serial: bootie-rgb
     

--- a/src/ros/cameras2/nix/packages/cameras2/patches/launch-patch-ros-streamer.patch
+++ b/src/ros/cameras2/nix/packages/cameras2/patches/launch-patch-ros-streamer.patch
@@ -2,11 +2,12 @@ diff --git a/launch/ros_topic_streamer.launch.py b/launch/ros_topic_streamer.lau
 index a891b64..19df154 100644
 --- a/launch/ros_topic_streamer.launch.py
 +++ b/launch/ros_topic_streamer.launch.py
-@@ -10,5 +10,5 @@ def generate_launch_description():
+@@ -27,7 +27,7 @@
+             ),
              ExecuteProcess(
+                 condition=IfCondition(signalling),
 -                cmd=["gst-webrtc-signalling-server"],
 +                cmd=["@gst_plugins_rs@/bin/gst-webrtc-signalling-server"],
                  additional_env={
-                      @bas-h@
                      "WEBRTCSINK_SIGNALLING_SERVER_LOG": "warn",
                  },

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraPageConstants.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraPageConstants.tsx
@@ -50,6 +50,9 @@ export enum CameraSerials {
   URC_SCIENCE_PAYLOAD_DOWN = "science_payload_down",
   URC_ACTIVATED_NODES = "activated_nodes",
   URC_SCIENCE_AUGER_DEPTH_SENSORS = "science_auger_depth_sensors",
+
+  AUTO_OAK = "oak-rgb",
+  AUTO_BOOTIE = "bootie-rgb",
 }
 
 export const allCams = [];
@@ -182,7 +185,7 @@ export const autonomous_views: CameraView[] = [
 
 export const urc_autonomous_views: CameraView[] = [
   {
-    cameraSerials: [...mastCams, ...driveCams],
+    cameraSerials: [...mastCams, ...driveCams, CameraSerials.AUTO_OAK, CameraSerials.AUTO_BOOTIE],
     viewTitle: "All Cams",
   },
   {

--- a/src/ros/rover/auto_bringup/launch/oak-gui.launch.py
+++ b/src/ros/rover/auto_bringup/launch/oak-gui.launch.py
@@ -42,7 +42,7 @@ def launch_setup(context, *args, **kwargs):
                 ('/out','/oak/rgb/gui')], # ros camera topic for gui
         ),
         Node(
-            condition=IfCondition(front),
+            condition=IfCondition(back),
             package='image_transport',
             executable='republish',
             parameters=[{

--- a/src/ros/rover/auto_bringup/launch/oak-gui.launch.py
+++ b/src/ros/rover/auto_bringup/launch/oak-gui.launch.py
@@ -1,0 +1,85 @@
+'''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Execute this code in the base station to get 
+    oak cameras to GUI.
+Run camera.launch.py before running this launch!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NODES:
+  - image_republishers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE: 	auto_bringup
+CREATION:	13/11/2024
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.conditions import IfCondition, UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, AndSubstitution, NotSubstitution
+from launch_ros.actions import  Node, ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+from launch_ros.substitutions import FindPackageShare
+
+def launch_setup(context, *args, **kwargs):
+    auto_bringup_dir = FindPackageShare('auto_bringup')
+    cameras2_dir = FindPackageShare("cameras2")
+    back = LaunchConfiguration('back')
+    front = LaunchConfiguration('front')
+    signalling = LaunchConfiguration('signalling') # set to true is cameras2 is not running alongside
+
+    return [
+        Node(
+            condition=IfCondition(front),
+            package='image_transport',
+            executable='republish',
+            parameters=[{
+                'in_transport':'compressed', 
+                'out_transport':'raw'}],
+            remappings=[
+                ('/in/compressed','/oak/rgb/image_raw/compressed'),
+                ('/out','/oak/rgb/gui')], # ros camera topic for gui
+        ),
+        Node(
+            condition=IfCondition(front),
+            package='image_transport',
+            executable='republish',
+            parameters=[{
+                'in_transport':'compressed', 
+                'out_transport':   'raw'}],
+            remappings=[
+                 ('/in/compressed','/bootie/rgb/image_raw/compressed'),
+                 ('/out','/bootie/rgb/gui')], # ros camera topic for gui
+        ),
+        IncludeLaunchDescription(
+            launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([cameras2_dir, 'ros_topic_streamer.launch.py'])),
+            launch_arguments={'signalling': signalling}.items(),
+        ),
+    ]
+
+
+def generate_launch_description():
+    auto_bringup_dir = FindPackageShare('auto_bringup')
+
+    declared_arguments = [
+        DeclareLaunchArgument(
+            name='back',
+            default_value='True',
+            description='',
+        ),
+        DeclareLaunchArgument(
+            name='front',
+            default_value='True',
+            description='',
+        ),
+        DeclareLaunchArgument(
+            name='signalling',
+            default_value='False',
+            description='',
+        ),
+    ]
+
+    return LaunchDescription(
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/src/ros/rover/nix/packages/auto-bringup/default.nix
+++ b/src/ros/rover/nix/packages/auto-bringup/default.nix
@@ -16,6 +16,7 @@
   pluginlib,
   robot-localization,
   image-view,
+  image-transport,
   navigation2,
   depthai-ros,
   rtabmap-ros,
@@ -27,6 +28,7 @@
   nova-gazebo,
   nova-auto-interfaces,
   nova-bt-navigators,
+  nova-cameras2,
   rviz-imu-plugin,
   rviz-satellite, 
   imu-transformer,
@@ -67,6 +69,7 @@ buildRosPackage rec {
       pluginlib
       robot-localization
       image-view
+      image-transport
       navigation2
       depthai-ros
       rtabmap-ros
@@ -78,6 +81,7 @@ buildRosPackage rec {
       nova-gazebo
       nova-auto-interfaces
       nova-bt-navigators
+      nova-cameras2
       rviz-imu-plugin
       rviz-satellite
       nova-pivot-drive-controller


### PR DESCRIPTION
This PR creates a launch file which launches nodes to convert the Oak and Bootie camera's compressed topics to raw images. This topic is then used by the new ros topic to webrtc node to allow it to be displayed on GUI.

`ros2 launch auto_bringup oak-gui.launch.py` to run with cameras2 running
`ros2 launch auto_bringup oak-gui.launch.py signalling:=True` to run when cameras2 is not running 
- Launches gst-webrtc-signalling-server which is normally run by cameras2

To test, run GUI, rosbridge and auto_bringup/camera.launch.py with the physical oak cameras attached.
- Has params to disable front and back. e.g front:=False

During comp, use the first launch style and run this on base station NOT ORIN.

Since it uses compressed image topics, this should not flood the network with raw image data!