### PR TITLE
Remove use_local_mesh param and add param to disable auto mount for urdf

### DIFF
--- a/src/ros/rover/auto_bringup/launch/control.launch.py
+++ b/src/ros/rover/auto_bringup/launch/control.launch.py
@@ -68,7 +68,7 @@ def launch_setup(context, *args, **kwargs):
                 ),
                 IncludeLaunchDescription(
                     PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'urdf.launch.py'])),
-                    launch_arguments={'model': model, 'gazebo': gazebo, 'angle': angle, 'use_local_mesh': use_local_mesh}.items(),
+                    launch_arguments={'model': model, 'gazebo': gazebo, 'angle': angle}.items(),
                 )],
         ),
     ]
@@ -103,11 +103,6 @@ def generate_launch_description():
             name='model', 
             default_value=PathJoinSubstitution([rover_description_dir, 'banksia', 'urdf', 'rover.urdf.xacro']),
             description='Absolute path to robot urdf file',
-        ),
-        DeclareLaunchArgument(
-            name='use_local_mesh',
-            default_value='False',
-            description='Use local mesh paths instead of nix store paths',
         ),
     ]
 

--- a/src/ros/rover/auto_bringup/launch/gazebo.launch.py
+++ b/src/ros/rover/auto_bringup/launch/gazebo.launch.py
@@ -63,7 +63,7 @@ def launch_setup(context, *args, **kwargs):
         ),
         IncludeLaunchDescription(
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'urdf.launch.py'])),
-            launch_arguments={'model': model, 'gazebo': 'true', 'robot_name': robot_name, 'angle': angle}.items(),
+            launch_arguments={'model': model, 'gazebo': 'true', 'robot_name': robot_name, 'angle': angle, 'camera': camera}.items(),
         ),
         IncludeLaunchDescription(
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([ros_gz_sim_dir, 'launch', 'gz_sim.launch.py'])),
@@ -108,7 +108,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             name='camera',
             default_value='True',
-            description='',
+            description='Whether to spawn auto mount on the rover.',
         ),
         DeclareLaunchArgument(
             name='gz_params',

--- a/src/ros/rover/auto_bringup/launch/urdf.launch.py
+++ b/src/ros/rover/auto_bringup/launch/urdf.launch.py
@@ -26,14 +26,14 @@ def launch_setup(context, *args, **kwargs):
     gazebo = LaunchConfiguration('gazebo').perform(context)
     model = LaunchConfiguration('model').perform(context)
     robot_name = LaunchConfiguration('robot_name').perform(context)
-    use_local_mesh = LaunchConfiguration('use_local_mesh').perform(context)
+    camera = LaunchConfiguration('camera').perform(context)
 
     return [
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
             parameters=[{'robot_description': 
-                ParameterValue(Command(['xacro ', model, ' ', 'gazebo:=', gazebo, ' ', 'robot_name:=', robot_name, ' ', 'angle:=', angle, ' ', 'use_local_mesh:=', use_local_mesh]), value_type=str)
+                ParameterValue(Command(['xacro ', model, ' ', 'gazebo:=', gazebo, ' ', 'robot_name:=', robot_name, ' ', 'angle:=', angle, ' ', 'auto_camera:=', camera]), value_type=str)
             }]
         )
     ]
@@ -64,9 +64,9 @@ def generate_launch_description():
             description='name of the robot',
         ),
         DeclareLaunchArgument(
-            name='use_local_mesh',
-            default_value='False',
-            description='Use local mesh paths instead of nix store paths',
+            name='camera',
+            default_value='True',
+            description='Whether to spawn auto mount on the rover.',
         ),
     ]
 

--- a/src/ros/rover/rover_description/auto_mount/urdf/auto_camera.xacro
+++ b/src/ros/rover/rover_description/auto_mount/urdf/auto_camera.xacro
@@ -13,7 +13,7 @@ which is how it gets added to the gazebo sim. Edited by: Victor Bartlinski, Kabi
       <visual>
           <origin xyz="0.138856 0.281 0.00511278" rpy="3.14159 -0.00348764 3.3577e-34" />
           <geometry>
-              <mesh filename="${mesh_path}/auto_mount/meshes/clam.stl" />
+              <mesh filename="file://$(find rover_description)/auto_mount/meshes/clam.stl" />
           </geometry>
           <material name="clam_material">
               <color rgba="0.866667 0.0745098 0.32549 1.0" />
@@ -61,7 +61,7 @@ which is how it gets added to the gazebo sim. Edited by: Victor Bartlinski, Kabi
       <visual>
           <origin xyz="0.081 0.000713936 -0.025" rpy="4.93038e-32 6.86401e-31 -3.70732e-33" />
           <geometry>
-              <mesh filename="${mesh_path}/auto_mount/meshes/mount.stl" />
+              <mesh filename="file://$(find rover_description)/auto_mount/meshes/mount.stl" />
           </geometry>
           <material name="mount_material">
               <color rgba="0.866667 0.0745098 0.32549 1.0" />
@@ -85,7 +85,7 @@ which is how it gets added to the gazebo sim. Edited by: Victor Bartlinski, Kabi
       <visual>
           <origin xyz="-0.075 5.55112e-17 0.06" rpy="-1.5708 -1.5708 0" />
           <geometry>
-              <mesh filename="${mesh_path}/auto_mount/meshes/camera_holder.stl" />
+              <mesh filename="file://$(find rover_description)/auto_mount/meshes/camera_holder.stl" />
           </geometry>
           <material name="camera_holder_front_material">
               <color rgba="0.866667 0.0745098 0.32549 1.0" />
@@ -116,7 +116,7 @@ which is how it gets added to the gazebo sim. Edited by: Victor Bartlinski, Kabi
       <visual>
           <origin xyz="-0.075 0 0.06" rpy="1.5708 1.5708 0" />
           <geometry>
-              <mesh filename="${mesh_path}/auto_mount/meshes/camera_holder.stl" />
+              <mesh filename="file://$(find rover_description)/auto_mount/meshes/camera_holder.stl" />
           </geometry>
           <material name="camera_holder_back_material">
               <color rgba="0.866667 0.0745098 0.32549 1.0" />

--- a/src/ros/rover/rover_description/banksia/urdf/rover.urdf.xacro
+++ b/src/ros/rover/rover_description/banksia/urdf/rover.urdf.xacro
@@ -14,7 +14,6 @@
     <xacro:arg name="auto_camera" default="true"/>
     <xacro:arg name="robot_name" default="Banksia"/>
     <xacro:arg name="angle" default="0"/>
-    <xacro:arg name="use_local_mesh" default="false"/>
 
     <!-- Robot properties-->
     <gazebo>
@@ -22,12 +21,6 @@
     </gazebo>
 
     <!-- Variables -->
-    <xacro:if value="$(arg use_local_mesh)">
-        <xacro:property name="mesh_path" value="file://home/nova/nova/src/ros/rover/rover_description" />
-    </xacro:if>
-    <xacro:unless value="$(arg use_local_mesh)">
-        <xacro:property name="mesh_path" value="file://$(find rover_description)" />
-    </xacro:unless>
     <xacro:property name="angle" value="$(arg angle)" />
 
     <!-- Generated URDF -->
@@ -43,7 +36,7 @@
         <visual>
             <origin xyz="0 0 0" rpy="3.26128e-16 -1.01395e-15 1.5708" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/chassis.stl" />
+                <mesh filename="file://$(find rover_description)/banksia/meshes/chassis.stl" />
             </geometry>
             <material name="chassis_material">
                 <color rgba="0.866667 0.0745098 0.32549 1.0" />
@@ -61,7 +54,7 @@
         <visual>
             <origin xyz="-1.3078806732583218725e-20 8.6736173798840354721e-19 -0.021000000000000518252" rpy="-3.141592653589793116 6.2280032059897877693e-19 -4.1232880706353110482e-18" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/left_leg.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/left_leg.stl"/>
             </geometry>
             <material name="left_leg_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -133,7 +126,7 @@
         <visual>
             <origin xyz="-0.12415341931613717297 2.2204460492503130808e-16 -0.1250000000000002498" rpy="-1.570796326794896558 -0.13351607992219349796 -5.9804098682663148249e-17" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/fl_ankle.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/fl_ankle.stl"/>
             </geometry>
             <material name="fl_ankle_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -193,7 +186,7 @@
         <visual>
             <origin xyz="5.5511151231257827021e-17 0 5.963111948670274387e-18" rpy="7.279848939407052303e-17 1.0638440422271473935e-16 -6.3914183266779029169e-20" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/fl_wheel.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/fl_wheel.stl"/>
             </geometry>
             <material name="fl_wheel_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -217,7 +210,7 @@
         <visual>
             <origin xyz="-0.12415341931613714521 2.2204460492503130808e-16 -0.1250000000000002498" rpy="-1.570796326794896558 -0.13351607992219349796 -7.1088909477657821376e-17" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/bl_ankle.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/bl_ankle.stl"/>
             </geometry>
             <material name="bl_ankle_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -277,7 +270,7 @@
         <visual>
             <origin xyz="0 1.1102230246251565404e-16 1.7780915628762272718e-17" rpy="4.6040217445536182725e-17 1.0513492286565858337e-16 2.3412503191653332746e-19" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/bl_wheel.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/bl_wheel.stl"/>
             </geometry>
             <material name="bl_wheel_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -301,7 +294,7 @@
         <visual>
             <origin xyz="-7.9461177221465168975e-19 -7.2858385990954703269e-20 -0.020999999999999519051" rpy="3.141592653589793116 3.7838655819744092421e-17 -5.8406613147999892266e-19" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/right_leg.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/right_leg.stl"/>
             </geometry>
             <material name="right_leg_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -373,7 +366,7 @@
         <visual>
             <origin xyz="0.12415341931613695092 -2.2204460492503130808e-16 -0.12500000000000027756" rpy="-1.57079632679489678 0.13351607992219352572 9.9507186100571649487e-18" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/fr_ankle.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/fr_ankle.stl"/>
             </geometry>
             <material name="fr_ankle_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -433,7 +426,7 @@
         <visual>
             <origin xyz="5.5511151231257827021e-17 -1.1102230246251565404e-16 -3.0791341698588325926e-17" rpy="-3.6194812825998444115e-17 1.0511409763610977507e-16 -2.2325341479697011877e-19" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/fr_wheel.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/fr_wheel.stl"/>
             </geometry>
             <material name="fr_wheel_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -457,7 +450,7 @@
         <visual>
             <origin xyz="0.12415341931613720072 -2.2204460492503130808e-16 -0.12500000000000027756" rpy="-1.57079632679489678 0.13351607992219349796 -6.7670245197813334123e-17" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/br_ankle.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/br_ankle.stl"/>
             </geometry>
             <material name="br_ankle_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -517,7 +510,7 @@
         <visual>
             <origin xyz="5.5511151231257827021e-17 0 5.8763757748714340323e-17" rpy="1.4537948349788456791e-16 1.0501738044156386319e-16 -7.6074648532850333807e-21" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/br_wheel.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/br_wheel.stl"/>
             </geometry>
             <material name="br_wheel_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -541,7 +534,7 @@
         <visual>
             <origin xyz="4.9770590769729886024e-14 -0.00015426611885745872277 -0.010000000000000730527" rpy="1.570796326794896558 -3.0512890594788867116e-34 0" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/diffbar.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/diffbar.stl"/>
             </geometry>
             <material name="diffbar_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -571,7 +564,7 @@
         <visual>
             <origin xyz="-2.7755575615628913511e-15 -0.057750000000000162315 3.3306690738754696213e-16" rpy="1.5707963267948350516 -1.5127867282353739675 -3.1415926535897926719" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/left_difflink.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/left_difflink.stl"/>
             </geometry>
             <material name="left_difflink_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>
@@ -596,7 +589,7 @@
         <visual>
             <origin xyz="6.2172489379008766264e-15 -0.057749999999999454547 -2.4424906541753443889e-15" rpy="1.5707963267948286123 1.512786629442331332 3.141592653589793116" />
             <geometry>
-                <mesh filename="${mesh_path}/banksia/meshes/right_difflink.stl"/>
+                <mesh filename="file://$(find rover_description)/banksia/meshes/right_difflink.stl"/>
             </geometry>
             <material name="right_difflink_material">
                 <color rgba="0.86666666666666669627 0.074509803921568626417 0.32549019607843138191 1.0"/>


### PR DESCRIPTION
These were implemented in the gui-joy branch but while i fix that branch lets merge this into master.
This PR will remove the local_mesh stuff which doesn't do anything and was originally added by me without testing at ARCh.

The param to disable the cameras in gazebo will allow us to quickly launch a sim that can be used for showcasing the rover in sim. Since the auto mount cameras slow down the sim from 90% irl speed to 12% irl speed on most laptops.

Terry please check that these changes work and don't break anything.
(They shouldn't as they've already been tested extensively on gui-joy)

`ros2 launch auto_bringup gazebo.launch.py camera:=False` to test without auto mount in sim