### PR TITLE
fix: nova_twistmapper 

### DIFF
--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -35,6 +35,13 @@ def launch_setup(context, *args, **kwargs):
     use_mock_hardware = LaunchConfiguration('use_mock_hardware')
     robot_name = LaunchConfiguration('robot_name')
 
+    show_colours_additional_env = {
+        # Show colors in the terminal output
+        'RCUTILS_COLORIZED_OUTPUT': '1',
+        # (Optional!) omit time from the logs
+        'RCUTILS_CONSOLE_OUTPUT_FORMAT': '[{severity}] [{name}] {message}',
+    }
+
     return [
         GroupAction(
             condition=IfCondition(PythonExpression([arm, " or ", old_arm])),
@@ -42,12 +49,14 @@ def launch_setup(context, *args, **kwargs):
                 Node(
                     package='controller_manager',
                     executable='spawner',
-                    arguments=['nova_arm_velocity_controller', '--inactive'] #, '--inactive']
+                    arguments=['nova_arm_velocity_controller', '--inactive'],
+                    additional_env=show_colours_additional_env,
                 ),
                 Node(
                     package='controller_manager',
                     executable='spawner',
                     arguments=['nova_arm_position_controller', 'nova_twistmapper', '--inactive'],
+                    additional_env=show_colours_additional_env,
                 ),
             ]
         ),
@@ -56,7 +65,8 @@ def launch_setup(context, *args, **kwargs):
             executable='robot_state_publisher',
             parameters=[{'robot_description':
                              ParameterValue(Command(['xacro ', model, ' ', 'gazebo:=', gazebo, ' ', 'robot_name:=', robot_name, ' ', 'arm:=', arm, ' ', 'old_arm:=', old_arm, ' ', 'use_mock_hardware:=', use_mock_hardware, ' ', 'auto_camera:=false']), value_type=str)
-                         }]
+                         }],
+            additional_env=show_colours_additional_env,
         ),
         GroupAction(
             condition=UnlessCondition(gazebo),
@@ -65,12 +75,14 @@ def launch_setup(context, *args, **kwargs):
                     package='controller_manager',
                     executable='spawner',
                     arguments=['joint_state_broadcaster'],
+                    additional_env=show_colours_additional_env,
                 ),
                 Node(
                     package='controller_manager',
                     executable='ros2_control_node',
                     parameters=[controllers],
                     remappings=[('/controller_manager/robot_description', '/robot_description'), ('/joint_states', '/arm/joint_states')],
+                    additional_env=show_colours_additional_env,
                 ),
                 # IncludeLaunchDescription(
                 #     PythonLaunchDescriptionSource(PathJoinSubstitution([arm_bringup_dir, 'launch', 'urdf.launch.py'])),
@@ -88,7 +100,7 @@ def generate_launch_description():
     declared_arguments = [   
         DeclareLaunchArgument(
             name='controllers',
-            default_value=PathJoinSubstitution([arm_bringup_dir, 'params', 'controllers.yaml']),
+            default_value=PathJoinSubstitution([arm_bringup_dir, 'params', 'new.controllers.yaml']),
             description='Absolute path to controller params file',
         ),
         DeclareLaunchArgument(
@@ -108,12 +120,12 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='arm',
-            default_value='False',
+            default_value='True',
             description='whether to launch arm',
         ),
         DeclareLaunchArgument(
             name='old_arm',
-            default_value='True',
+            default_value='False',
             description='whether to launch the old arm (on new armware)',
         ),
         DeclareLaunchArgument(
@@ -125,11 +137,6 @@ def generate_launch_description():
             name='robot_name',
             default_value='Banksia',
             description='name of the robot',
-        ),
-        DeclareLaunchArgument(
-            name='arm',
-            default_value='True',
-            description='whether to launch arm',
         ),
     ]
 

--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -34,6 +34,8 @@ def launch_setup(context, *args, **kwargs):
     old_arm = LaunchConfiguration('old_arm').perform(context)
     use_mock_hardware = LaunchConfiguration('use_mock_hardware')
     robot_name = LaunchConfiguration('robot_name')
+    urdf = LaunchConfiguration('urdf')
+    rviz = LaunchConfiguration('rviz').perform(context)
 
     show_colours_additional_env = {
         # Show colors in the terminal output
@@ -84,10 +86,11 @@ def launch_setup(context, *args, **kwargs):
                     remappings=[('/controller_manager/robot_description', '/robot_description'), ('/joint_states', '/arm/joint_states')],
                     additional_env=show_colours_additional_env,
                 ),
-                # IncludeLaunchDescription(
-                #     PythonLaunchDescriptionSource(PathJoinSubstitution([arm_bringup_dir, 'launch', 'urdf.launch.py'])),
-                #     launch_arguments={'model': model, 'gazebo': gazebo, 'use_mock_hardware': use_mock_hardware, 'arm': arm, 'old_arm': old_arm}.items(),
-                # )
+                IncludeLaunchDescription(
+                    PythonLaunchDescriptionSource(PathJoinSubstitution([arm_bringup_dir, 'launch', 'urdf.launch.py'])),
+                    launch_arguments={'model': model, 'gazebo': gazebo, 'use_mock_hardware': use_mock_hardware, 'arm': arm, 'old_arm': old_arm, 'rviz': rviz}.items(),
+                    condition=IfCondition(urdf),
+                )
             ],
         ),
     ]
@@ -137,6 +140,16 @@ def generate_launch_description():
             name='robot_name',
             default_value='Banksia',
             description='name of the robot',
+        ),
+        DeclareLaunchArgument(
+            name='urdf',
+            default_value='True',
+            description='whether to run urdf.launch.py to publish values to /tf (needed for rviz to work)',
+        ),
+        DeclareLaunchArgument(
+            name='rviz',
+            default_value='False',
+            description='whether to run rviz2 to visualize the robot (urdf must also be True).',
         ),
     ]
 

--- a/src/ros/rover/arm/arm_bringup/launch/mock.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/mock.launch.py
@@ -64,7 +64,7 @@ def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
             name='controllers',
-            default_value=PathJoinSubstitution([arm_bringup_dir, 'params', 'controllers.yaml']),
+            default_value=PathJoinSubstitution([arm_bringup_dir, 'params', 'new.controllers.yaml']),
             description='Absolute path to controllers params file',
         ),
         DeclareLaunchArgument(
@@ -94,12 +94,12 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='arm',
-            default_value='false',
+            default_value='True',
             description='whether to launch arm',
         ),
         DeclareLaunchArgument(
             name='old_arm',
-            default_value='True',
+            default_value='False',
             description='whether to launch the old arm (on new armware)',
         ),
         DeclareLaunchArgument(name='x', default_value='11.2123871', description='x_pose'),

--- a/src/ros/rover/arm/arm_bringup/launch/urdf.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/urdf.launch.py
@@ -20,14 +20,20 @@ from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitut
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
+from launch.conditions import IfCondition
 
 def launch_setup(context, *args, **kwargs):
+    arm_bringup_dir = FindPackageShare('arm_bringup')
+
     gazebo = LaunchConfiguration('gazebo').perform(context)
     model = LaunchConfiguration('model').perform(context)
     robot_name = LaunchConfiguration('robot_name').perform(context)
     arm = LaunchConfiguration('arm').perform(context)
     old_arm = LaunchConfiguration('old_arm').perform(context)
     use_mock_hardware = LaunchConfiguration('use_mock_hardware').perform(context)
+    rviz = LaunchConfiguration('rviz')
+
+    fixed_frame = 'base_link'
 
     return [
         Node(
@@ -47,7 +53,16 @@ def launch_setup(context, *args, **kwargs):
             parameters=[{
                 'source_list': ['/arm/joint_states']
             }]
-        )
+        ),
+
+        Node(
+            package='rviz2',
+            namespace='',
+            executable='rviz2',
+            name='rviz2',
+            arguments=['-d', [PathJoinSubstitution([arm_bringup_dir, 'rviz', 'arm.rviz'])], '-f', fixed_frame],
+            condition=IfCondition(rviz),
+        ),
     ]
 
 
@@ -84,6 +99,11 @@ def generate_launch_description():
             name='use_mock_hardware',
             default_value='false',
             description='whether to use mock hardware for hardware interfaces',
+        ),
+        DeclareLaunchArgument(
+            name='rviz',
+            default_value='false',
+            description='whether to launch rviz',
         ),
     ]
 

--- a/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
+++ b/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
@@ -1,3 +1,5 @@
+# Controllers for the new arm
+
 controller_manager:
   ros__parameters:
     update_rate: 20
@@ -39,12 +41,12 @@ controller_manager:
 nova_arm_velocity_controller:
   ros__parameters:
     joint_names:
-      - arm_j1
-      - arm_j2
-      - arm_j3
-      - arm_j4
-      - arm_j5
-      - arm_j6
+      - J1
+      - J2
+      - J3
+      - J4
+      - J5
+      - J6
     use_position_control: false
     use_collision_limits: false
     use_limits: false
@@ -52,12 +54,12 @@ nova_arm_velocity_controller:
 nova_arm_position_controller:
   ros__parameters:
     joint_names:
-      - arm_j1
-      - arm_j2
-      - arm_j3
-      - arm_j4
-      - arm_j5
-      - arm_j6
+      - J1
+      - J2
+      - J3
+      - J4
+      - J5
+      - J6
     use_position_control: true
     use_collision_limits: false
     use_limits: false
@@ -66,16 +68,16 @@ nova_twistmapper:
   ros__parameters:
     chained_controller_name: "nova_arm_position_controller"
     joint_names:
-      - arm_j1
-      - arm_j2
-      - arm_j3
-      - arm_j4
-      - arm_j5
-      - arm_j6
-    kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
-    # kinematics_solver: "banksia_kinematics_plugin/BanksiaKinematicsPlugin"
+      - J1
+      - J2
+      - J3
+      - J4
+      - J5
+      - J6
+#    kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
+    kinematics_solver: "banksia_kinematics_plugin/BanksiaKinematicsPlugin"
     kinematics_solver_timeout: 0.02
-    kinematics_base_frame: "arm_link"
+    kinematics_base_frame: "arm_kinematics_origin"
     kinematics_endeffector_frame: "endeffector_kinematics"
 
 nova_path_planner:
@@ -89,17 +91,10 @@ nova_path_planner:
       - J4
       - J5
       - J6
-    #      - arm_j1
-    #      - arm_j2
-    #      - arm_j3
-    #      - arm_j4
-    #      - arm_j5
-    #      - arm_j6
-#    kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
     kinematics_solver: "banksia_kinematics_plugin/BanksiaKinematicsPlugin"
     kinematics_solver_timeout: 1.0
     kinematics_base_frame: "arm_kinematics_origin"
-    add_allowed_collisions_to_srdf: true
+#    add_allowed_collisions_to_srdf: true
     add_chain_to_srdf: false
     kinematics_endeffector_frame: "endeffector_kinematics"
 
@@ -124,28 +119,28 @@ joint_state_broadcaster:
     interfaces:
        ["position", "velocity"]
 
-    joints:
-      ["blp", "brp", "flp", "frp",
-      "blw", "brw", "flw", "frw",
-      "J1", "J2", "J3", "J4", "J5", "J6"]
+    joints: ["J1", "J2", "J3", "J4", "J5", "J6"]
+#      ["blp", "brp", "flp", "frp",
+#      "blw", "brw", "flw", "frw",
+#      "J1", "J2", "J3", "J4", "J5", "J6"]
     #       "arm_j1", "asm_j2", "arm_j3", "arm_j4", "arm_j5", "arm_j6"]
 
-    extra_joints:
-      ["chassis_to_left_leg",
-       "chassis_to_right_leg",
-        "chassis_to_diffbar",
-        "tl_ball_roll",
-        "tl_ball_pitch",
-        "tl_ball_yaw",
-        "tr_ball_roll",
-        "tr_ball_pitch",
-        "tr_ball_yaw",
-        "bl_ball_roll",
-        "bl_ball_pitch",
-        "bl_ball_yaw",
-        "br_ball_roll",
-        "br_ball_pitch",
-        "br_ball_yaw"]
+    extra_joints: []
+#      ["chassis_to_left_leg",
+#       "chassis_to_right_leg",
+#        "chassis_to_diffbar",
+#        "tl_ball_roll",
+#        "tl_ball_pitch",
+#        "tl_ball_yaw",
+#        "tr_ball_roll",
+#        "tr_ball_pitch",
+#        "tr_ball_yaw",
+#        "bl_ball_roll",
+#        "bl_ball_pitch",
+#        "bl_ball_yaw",
+#        "br_ball_roll",
+#        "br_ball_pitch",
+#        "br_ball_yaw"]
     use_local_topics: false
     
 pivot_drive_controller:

--- a/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
+++ b/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
@@ -2,7 +2,7 @@
 
 controller_manager:
   ros__parameters:
-    update_rate: 20
+    update_rate: 60
     use_sim_time: false
 
     nova_arm_velocity_controller:
@@ -48,8 +48,8 @@ nova_arm_velocity_controller:
       - J5
       - J6
     use_position_control: false
-    use_collision_limits: false
-    use_limits: false
+    use_collision_limits: true
+    use_limits: true
 
 nova_arm_position_controller:
   ros__parameters:
@@ -61,8 +61,8 @@ nova_arm_position_controller:
       - J5
       - J6
     use_position_control: true
-    use_collision_limits: false
-    use_limits: false
+    use_collision_limits: true
+    use_limits: true
 
 nova_twistmapper:
   ros__parameters:
@@ -125,7 +125,7 @@ joint_state_broadcaster:
 #      "J1", "J2", "J3", "J4", "J5", "J6"]
     #       "arm_j1", "asm_j2", "arm_j3", "arm_j4", "arm_j5", "arm_j6"]
 
-    extra_joints: []
+#    extra_joints: []
 #      ["chassis_to_left_leg",
 #       "chassis_to_right_leg",
 #        "chassis_to_diffbar",

--- a/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
+++ b/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
@@ -2,7 +2,7 @@
 
 controller_manager:
   ros__parameters:
-    update_rate: 60
+    update_rate: 20
     use_sim_time: false
 
     nova_arm_velocity_controller:
@@ -74,11 +74,13 @@ nova_twistmapper:
       - J4
       - J5
       - J6
-#    kinematics_solver: "kdl_kinematics_plugin/KDLKinematicsPlugin"
     kinematics_solver: "banksia_kinematics_plugin/BanksiaKinematicsPlugin"
     kinematics_solver_timeout: 0.02
     kinematics_base_frame: "arm_kinematics_origin"
     kinematics_endeffector_frame: "endeffector_kinematics"
+    add_chain_to_srdf: false
+    add_allowed_collisions_to_srdf: false
+    publish_debug_frames: false
 
 nova_path_planner:
   ros__parameters:
@@ -94,25 +96,9 @@ nova_path_planner:
     kinematics_solver: "banksia_kinematics_plugin/BanksiaKinematicsPlugin"
     kinematics_solver_timeout: 1.0
     kinematics_base_frame: "arm_kinematics_origin"
-#    add_allowed_collisions_to_srdf: true
-    add_chain_to_srdf: false
     kinematics_endeffector_frame: "endeffector_kinematics"
-
-wheel_velocity_controller:
-  ros__parameters:
-    joints:
-      - flw
-      - blw
-      - brw
-      - frw
-
-pivot_position_controller:
-  ros__parameters:
-    joints:
-      - flp
-      - blp
-      - brp
-      - frp
+    add_chain_to_srdf: false
+    add_allowed_collisions_to_srdf: false
 
 joint_state_broadcaster:
   ros__parameters:
@@ -120,27 +106,6 @@ joint_state_broadcaster:
        ["position", "velocity"]
 
     joints: ["J1", "J2", "J3", "J4", "J5", "J6"]
-#      ["blp", "brp", "flp", "frp",
-#      "blw", "brw", "flw", "frw",
-#      "J1", "J2", "J3", "J4", "J5", "J6"]
-    #       "arm_j1", "asm_j2", "arm_j3", "arm_j4", "arm_j5", "arm_j6"]
-
-#    extra_joints: []
-#      ["chassis_to_left_leg",
-#       "chassis_to_right_leg",
-#        "chassis_to_diffbar",
-#        "tl_ball_roll",
-#        "tl_ball_pitch",
-#        "tl_ball_yaw",
-#        "tr_ball_roll",
-#        "tr_ball_pitch",
-#        "tr_ball_yaw",
-#        "bl_ball_roll",
-#        "bl_ball_pitch",
-#        "bl_ball_yaw",
-#        "br_ball_roll",
-#        "br_ball_pitch",
-#        "br_ball_yaw"]
     use_local_topics: false
     
 pivot_drive_controller:

--- a/src/ros/rover/arm/arm_bringup/params/old.controllers.yaml
+++ b/src/ros/rover/arm/arm_bringup/params/old.controllers.yaml
@@ -1,3 +1,5 @@
+# Controllers for the old arm
+
 controller_manager:
   ros__parameters:
     update_rate: 20

--- a/src/ros/rover/arm/arm_bringup/rviz/arm.rviz
+++ b/src/ros/rover/arm/arm_bringup/rviz/arm.rviz
@@ -1,0 +1,595 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1
+        - /RobotModel1
+      Splitter Ratio: 0.40316206216812134
+    Tree Height: 1099
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        actuator:
+          Value: true
+        arm_base_to_j1:
+          Value: true
+        arm_end_finger_optical:
+          Value: true
+        arm_end_periscope_optical:
+          Value: true
+        arm_end_side_optical:
+          Value: true
+        arm_end_top_optical:
+          Value: true
+        arm_j2_to_j3:
+          Value: true
+        arm_j3_to_j4:
+          Value: true
+        arm_j4_to_j4_base:
+          Value: true
+        arm_j4_to_j5:
+          Value: true
+        arm_j5_to_j6:
+          Value: true
+        arm_j6_to_ee:
+          Value: true
+        arm_kinematics_origin:
+          Value: true
+        arm_link:
+          Value: true
+        armmount:
+          Value: true
+        base_link:
+          Value: true
+        bl_ankle:
+          Value: true
+        bl_ball_link_x:
+          Value: true
+        bl_ball_link_y:
+          Value: true
+        bl_wheel:
+          Value: true
+        br_ankle:
+          Value: true
+        br_ball_link_x:
+          Value: true
+        br_ball_link_y:
+          Value: true
+        br_wheel:
+          Value: true
+        chassis:
+          Value: true
+        diffbar:
+          Value: true
+        eebase:
+          Value: true
+        endeffector_kinematics:
+          Value: true
+        fl_ankle:
+          Value: true
+        fl_wheel:
+          Value: true
+        fr_ankle:
+          Value: true
+        fr_wheel:
+          Value: true
+        gearbox:
+          Value: true
+        gps:
+          Value: true
+        j5:
+          Value: true
+        j6:
+          Value: true
+        l1:
+          Value: true
+        l1a_tp_j2_mimic:
+          Value: true
+        l1prime:
+          Value: true
+        l1prime_mimic:
+          Value: true
+        l2:
+          Value: true
+        l2cam:
+          Value: true
+        l2cam_mimic:
+          Value: true
+        l2prime:
+          Value: true
+        left_diffend_dummy:
+          Value: true
+        left_difflink:
+          Value: true
+        left_leg:
+          Value: true
+        leftfinger:
+          Value: true
+        linkagedrive:
+          Value: true
+        right_diffend_dummy:
+          Value: true
+        right_difflink:
+          Value: true
+        right_leg:
+          Value: true
+        rightfinger:
+          Value: true
+        tl_ball_link_x:
+          Value: true
+        tl_ball_link_y:
+          Value: true
+        tr_ball_link_x:
+          Value: true
+        tr_ball_link_y:
+          Value: true
+      Marker Scale: 0.25
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        base_link:
+          chassis:
+            arm_link:
+              arm_base_to_j1:
+                arm_j2_to_j3:
+                  arm_j3_to_j4:
+                    arm_j4_to_j4_base:
+                      arm_j4_to_j5:
+                        arm_j5_to_j6:
+                          arm_j6_to_ee:
+                            {}
+              armmount:
+                arm_kinematics_origin:
+                  {}
+                gearbox:
+                  linkagedrive:
+                    l1:
+                      l1a_tp_j2_mimic:
+                        l2:
+                          j5:
+                            j6:
+                              eebase:
+                                arm_end_periscope_optical:
+                                  {}
+                                arm_end_top_optical:
+                                  {}
+                                endeffector_kinematics:
+                                  {}
+                                leftfinger:
+                                  actuator:
+                                    {}
+                                  arm_end_finger_optical:
+                                    {}
+                                rightfinger:
+                                  arm_end_side_optical:
+                                    {}
+                    l2prime:
+                      l1prime_mimic:
+                        l1prime:
+                          l2cam_mimic:
+                            l2cam:
+                              {}
+            diffbar:
+              tl_ball_link_x:
+                tl_ball_link_y:
+                  left_difflink:
+                    bl_ball_link_x:
+                      bl_ball_link_y:
+                        left_diffend_dummy:
+                          {}
+              tr_ball_link_x:
+                tr_ball_link_y:
+                  right_difflink:
+                    br_ball_link_x:
+                      br_ball_link_y:
+                        right_diffend_dummy:
+                          {}
+            left_leg:
+              bl_ankle:
+                bl_wheel:
+                  {}
+              fl_ankle:
+                fl_wheel:
+                  {}
+            right_leg:
+              br_ankle:
+                br_wheel:
+                  {}
+              fr_ankle:
+                fr_wheel:
+                  {}
+          gps:
+            {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        actuator:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        arm_end_finger_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        arm_end_periscope_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        arm_end_side_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        arm_end_top_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        arm_kinematics_origin:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        armmount:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        bl_ankle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bl_ball_link_x:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        bl_ball_link_y:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        bl_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_ankle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        br_ball_link_x:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        br_ball_link_y:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        br_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        chassis:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        diffbar:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        eebase:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        endeffector_kinematics:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        fl_ankle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fl_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_ankle:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        fr_wheel:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        gearbox:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        gps:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        j5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        j6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l1a_tp_j2_mimic:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l1prime:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l1prime_mimic:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l2cam:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        l2cam_mimic:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        l2prime:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_diffend_dummy:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        left_difflink:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        leftfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        linkagedrive:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_diffend_dummy:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        right_difflink:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_leg:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        rightfinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        tl_ball_link_x:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tl_ball_link_y:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tr_ball_link_x:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        tr_ball_link_y:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 2.7581729888916016
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.5026679635047913
+        Y: -0.339214026927948
+        Z: 0.6845558285713196
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.17039933800697327
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.6809667348861694
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 1403
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001da000004d9fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005d00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f000004d9000000cc00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000004d9fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003f000004d9000000a900fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000009b00000003efc0100000002fb0000000800540069006d00650100000000000009b0000002de00fffffffb0000000800540069006d00650100000000000004500000000000000000000006bb000004d900000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 2480
+  X: 80
+  Y: 0

--- a/src/ros/rover/arm/arm_control_modes/joint_space_control_mode/src/joint_space_control_mode.cpp
+++ b/src/ros/rover/arm/arm_control_modes/joint_space_control_mode/src/joint_space_control_mode.cpp
@@ -49,49 +49,40 @@ CallbackReturn JointSpaceControlMode::on_configure(const State &)
     return CallbackReturn::ERROR;
   }
 
+
   // Get params for every joint
-  bool has_params = true;
-  int i = 0;
-  do {
-    const std::string i_str = std::to_string(i);
-    std::string prefix = "joints." + i_str + ".";
-    std::string name;
-
-    if (const bool has_name = get_node()->get_parameter<std::string>(prefix + "name", name); !has_name) {
-      has_params = i == 0;
-      i++;
-      continue;
-    }
-
-    double scale = 0.0;
-    std::string input_name;
-
-    get_node()->get_parameter_or<double>(prefix + "scale", scale, 0.0);
-    get_node()->get_parameter_or<std::string>(prefix + "input_name", input_name, "j" + i_str);
-
-    joints_.emplace_back(JointHandle{
-      name,
-      nullptr,
-      scale
-    });
-    input_names_.push_back(input_name);
-
-    i++;
-  } while (has_params);
 
   return CallbackReturn::SUCCESS;
 }
 
 void JointSpaceControlMode::on_configure_inputs(Inputs inputs)
 {
+  const auto logger = get_node()->get_logger();
+
   // TODO: Implement a remapping functionality to avoid boilerplate parameters for names, like input source remapping
   speed_ = inputs.axes[params_.input_names.speed];
 
-  for (size_t i = 0; i < input_names_.size(); ++i) {
-    const auto & input_name = input_names_[i];
-    auto & joint = joints_[i];
+  joints_.clear();
+  input_names_.clear();
 
-    joint.axis = inputs.axes[input_name];
+  RCLCPP_DEBUG(logger, "Getting joint inputs");
+  for (auto & [name, joint_params] : params_.joints.joint_definitions_map) {
+    auto & [joint_name, scale, input_name] = joint_params;
+
+    if (joint_name.empty())
+      joint_name = name;
+
+    if (input_name.empty())
+      input_name = name;
+
+    RCLCPP_DEBUG(logger, "  - %s -> %s", input_name.c_str(), joint_name.c_str());;
+
+    if (scale == 0.0) {
+      RCLCPP_WARN(logger, "joints.%s.scale isn't set! Values of 0 will always be sent for this joint.",
+                  joint_name.c_str());
+    }
+
+    joints_.emplace_back(JointHandle{joint_name, inputs.axes[input_name], scale});
   }
 }
 
@@ -126,21 +117,38 @@ return_type JointSpaceControlMode::on_update(const rclcpp::Time & now, const rcl
     return return_type::OK;
   }
 
-
   auto msg = std::make_unique<nova_interfaces::msg::ArmFkVelocityTargets>();
   msg->header.stamp = now;
 
+  RCLCPP_DEBUG(logger, "Calculating speed coefficient");
   const float speed_coefficient = params_.use_speed_input ? std::max(speed_->value(), 0.0f) : 1.0f;
 
+  RCLCPP_DEBUG(logger, "Updating joint inputs");
   for (const auto& [name, axis, scale] : joints_) {
+    RCLCPP_DEBUG(logger, "  [%s]", name.c_str());
+  }
+
+  RCLCPP_DEBUG(logger, "Updating joint inputs");
+  for (const auto& [name, axis, scale] : joints_) {
+    RCLCPP_DEBUG(logger, "  [%s]", name.c_str());
+
+    if (!axis) {
+      RCLCPP_ERROR(logger, "Axis::SharedPtr is missing for joint %s", name.c_str());
+      continue;
+    }
+
     msg->name.emplace_back(name);
 
     const float input = axis->value();
+
+    RCLCPP_DEBUG(logger, "  - %s\t%f", name.c_str(), input);
     double velocity = static_cast<double>(input) * speed_coefficient * scale;
 
+    RCLCPP_DEBUG(logger, "  - Putting velocity into message");
     msg->velocity.emplace_back(velocity);
   }
 
+  RCLCPP_DEBUG(logger, "Publishing message");
   if (publisher_) {
     publisher_->publish(std::move(msg));
   }

--- a/src/ros/rover/arm/arm_control_modes/joint_space_control_mode/src/joint_space_control_mode_parameters.yaml
+++ b/src/ros/rover/arm/arm_control_modes/joint_space_control_mode/src/joint_space_control_mode_parameters.yaml
@@ -21,3 +21,20 @@ joint_space_control_mode:
       type: string
       default_value: "speed"
       description: "The name of the axis input that scales the output speed from 0 to 1."
+
+  joint_definitions:
+    type: string_array
+    default_value: ["j1", "j2", "j3", "j4", "j5", "j6"]
+    description: "Declares the names of all joints to use when trying to get joint parameters."
+
+  joints:
+    __map_joint_definitions:
+      name:
+        type: string
+        default_value: ""
+      scale:
+        type: double
+        default_value: 0.0
+      input_name:
+        type: string
+        default_value: ""

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -156,7 +156,7 @@ protected:
    * @param[in]  time   The time to stamp the published Transform with.
    * @param[in]  pose   The pose to publish to tf2 as the twistmapper target pose.
    */
-  void publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose);
+  void publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose, const std::string& name = "");
 
   /**
    * @brief Generates an SRDF string for use with MoveIt2 libraries, based on params_.joint_names

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/include/nova_twistmapper/nova_twistmapper.hpp
@@ -18,7 +18,6 @@ EDITED:	  23/04/2025
 EDITED BY:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 TODO:
- - Remove RPY rotation
  - Apply twist relative to the header.frame_id
    reference frame, with the endeffector as
    default
@@ -125,7 +124,8 @@ protected:
    *
    * This will NOT order the joints correctly for MoveIt2.
    */
-  void update_twistmapper_pose(const rclcpp::Time &time, const rclcpp::Duration &period);
+  Eigen::Isometry3d integrate_twist(const std::vector<double> &seed_state, const rclcpp::Duration &period,
+                                    const Eigen::Isometry3d &current_target_pose);
 
   /**
    * @brief Creates an rclcpp::Node to give to the kinematics_sovler_ plugin, as we can't give it an
@@ -151,11 +151,12 @@ protected:
   void halt();
 
   /**
-   * @brief Publishes twistmapper_pose_ to tf2
+   * @brief Publishes the given pose to tf2 as the twistmapper's target pose.
    *
-   * @param[in]  the time to stamp the published Transform with.
+   * @param[in]  time   The time to stamp the published Transform with.
+   * @param[in]  pose   The pose to publish to tf2 as the twistmapper target pose.
    */
-  void publish_to_tf2(const rclcpp::Time &time);
+  void publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose);
 
   /**
    * @brief Generates an SRDF string for use with MoveIt2 libraries, based on params_.joint_names
@@ -210,17 +211,15 @@ protected:
   // Twist input
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_stamped_sub_ = nullptr;
   realtime_tools::RealtimeBox<std::shared_ptr<geometry_msgs::msg::TwistStamped>> received_twist_stamped_ptr_{nullptr};
+  /// The last seen header.frame_id in the twist_stamped_sub_ callback. ONLY ACCESS FROM twist_stamped_sub_!
+  std::string last_frame_id_ = "";
 
-  /// Result of the twistmapper, and input to IK. Desired position and orientation of the end effector relative to the base.
-  tf2::Transform twistmapper_pose_ = tf2::Transform();
-  tf2::Vector3 twistmapper_pose_rpy_ = tf2::Vector3();
-  rclcpp::Time twistmapper_pose_update_time_ = rclcpp::Time();
+  /// Result of the twistmapper, and input to IK. Desired position and orientation of the end effector relative to the
+  /// base.
+  Eigen::Isometry3d twistmapper_pose_ = Eigen::Isometry3d::Identity();
 
   // broadcasting twistmapper
   std::shared_ptr<tf2_ros::TransformBroadcaster> twistmapper_pose_tf_broadcaster_;
-  // Previously used to get the initial value of twistmapper_pose_
-  // std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
-  // std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
 
   // MoveIt2 Structures
   /// The URDF model for the arm. Needs to exist for the lifecycle of the kinematics_solver_ and robot_model_.

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -29,6 +29,9 @@ EDITED BY:
 namespace
 {
   constexpr auto DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST = "/arm_ik_twist_stamped"; // TODO: changeme
+
+  // Used to avoid division by zero. Threshold for where to call small numbers essentially zero in vector normalization.
+  constexpr auto EPSILON = 1e-8;
 } // namespace
 
 using std::placeholders::_1;
@@ -86,35 +89,65 @@ namespace nova_twistmapper
     return {interface_configuration_type::INDIVIDUAL, conf_names};
   }
 
-  void NovaTwistmapper::update_twistmapper_pose(const rclcpp::Time &time, const rclcpp::Duration &period) {
+  Eigen::Isometry3d NovaTwistmapper::integrate_twist(const std::vector<double> &seed_state,
+                                                     const rclcpp::Duration &period,
+                                                     const Eigen::Isometry3d &current_target_pose) {
+    // Retrieve the twist
     std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
     received_twist_stamped_ptr_.get(twist_stamped);
 
     if (twist_stamped == nullptr) {
       RCLCPP_WARN(get_node()->get_logger(), "Haven't yet received a TwistStamped message to use for the twistmapper.");
-      return;
+      return current_target_pose;
     }
 
-    const auto& twist = twist_stamped->twist;
+    const auto twist_msg = twist_stamped->twist;
+    const auto twist_frame_id = twist_stamped->header.frame_id.empty() ? params_.fallback_frame_id
+                                                                       : twist_stamped->header.frame_id;
+    // Stop holding the shared pointer
+    twist_stamped.reset();
 
-    tf2::Vector3 tf2_twist_angular;
-    tf2::fromMsg(twist.angular, tf2_twist_angular);
+    // Find the reference frame transform for the given frame_id
+    std::vector<geometry_msgs::msg::Pose> poses;
+    auto result = kinematics_solver_->getPositionFK({twist_frame_id}, seed_state, poses);
 
-    twistmapper_pose_rpy_ = twistmapper_pose_rpy_ + tf2_twist_angular * period.seconds();
-    // Create rotation matrix from twist.angular as XYZ euler
-    auto rotation_matrix = tf2::Matrix3x3();
-    rotation_matrix.setRPY(twistmapper_pose_rpy_.x(), twistmapper_pose_rpy_.y(), twistmapper_pose_rpy_.z());
+    if (!result) {
+      RCLCPP_ERROR(get_node()->get_logger(), "Failed to do forward kinematics to find the twist frame");
+      return current_target_pose;
+    }
+    if (poses.empty()) {
+      RCLCPP_ERROR(get_node()->get_logger(), "No poses returned from forward kinematics!");
+      return current_target_pose;
+    }
 
-    const auto linear = tf2::Vector3(
-      twist.linear.x * period.seconds(),
-      twist.linear.y * period.seconds(),
-      twist.linear.z * period.seconds());
+    Eigen::Isometry3d twist_frame;
+    Eigen::fromMsg(poses[0], twist_frame);
 
-    // TODO: Test this actually works as expected.
-    // TODO: Add a tf buffer and make use of the header.frame_id from the twist_stamped to allow IK to be done relative to anything. Then Teleop would just need to use the end effector frame by default
-    // TODO: If using tf like this, also have the twistmapper broadcast the target frame, so it can reference itself.
-    twistmapper_pose_.setOrigin(linear + twistmapper_pose_.getOrigin());
-    twistmapper_pose_.setBasis(rotation_matrix);
+    // Extract data from the twist message into a usable format for math
+    Eigen::Matrix<double, 6, 1> twist;
+    Eigen::fromMsg(twist_msg, twist);
+    Eigen::Vector3d twist_linear = twist.block<3, 1>(0, 0);
+    Eigen::Vector3d twist_angular = twist.block<3, 1>(3, 0);
+
+    // Construct a 4x4 matrix from the above linear and angular values, but as a displacement rather than velocity.
+    Eigen::Isometry3d new_pose = current_target_pose;
+
+    // Set translational components
+    new_pose.translation() = current_target_pose.translation() + twist_frame.linear() * twist_linear * period.seconds();
+
+    // Set angular components
+    auto twist_angular_norm = twist_angular.norm();
+    // Only apply rotation if it is non-zero enough to avoid precision errors
+    if (twist_angular_norm > EPSILON) {
+      // Create rotation matrix from twist_angular * period.seconds. This isn't an angular velocity, but a displacement.
+      Eigen::AngleAxisd angular_diff(twist_angular_norm * period.seconds(), twist_frame.linear() * twist_angular / twist_angular_norm);
+
+      // This 'linear' does not mean the same thing as the twist's 'linear'!
+      // It is the linear component of the affine transformation matrix.
+      new_pose.linear() = angular_diff.toRotationMatrix() * current_target_pose.linear();
+    }
+
+    return new_pose;
   }
 
   controller_interface::return_type NovaTwistmapper::update(const rclcpp::Time &time, const rclcpp::Duration &period)
@@ -131,35 +164,26 @@ namespace nova_twistmapper
       return controller_interface::return_type::OK;
     }
 
-    auto old_pose = twistmapper_pose_;
-    auto old_rpy = twistmapper_pose_rpy_;
+    std::vector<double> joint_state_values = get_state_pos_values();
 
-    // Get a new pose
-    update_twistmapper_pose(time, period);
-    publish_to_tf2(time);
+    // Integrate twist to get a new pose
+    const auto new_pose = integrate_twist(joint_state_values, period, twistmapper_pose_);
+    publish_to_tf2(time, new_pose);
 
     // Do IK to find the joint values for that pose
-    std::vector<double> joint_state_values = get_state_pos_values();
     std::vector<double> solution;
-    geometry_msgs::msg::Pose pose = tf2::toMsg(tf2::transformToEigen(tf2::toMsg(twistmapper_pose_)));
+    geometry_msgs::msg::Pose pose_msg = tf2::toMsg(new_pose);
     moveit_msgs::msg::MoveItErrorCodes error_codes;
 
-    //auto result = kinematics_solver_->getPositionIK(pose, joint_state_values, solution, error_codes);
-    auto result = kinematics_solver_->searchPositionIK(pose, joint_state_values, params_.kinematics_solver_timeout, solution, error_codes);
+    auto result = kinematics_solver_->getPositionIK(pose_msg, joint_state_values, solution, error_codes);
     if (!result) {
-      twistmapper_pose_ = old_pose;
-      twistmapper_pose_rpy_ = old_rpy;
-      RCLCPP_WARN_THROTTLE(logger, *get_node()->get_clock(), 500,
-                           "Failed to find solution to inverse kinematics: error code %d (\"%s\"). %s", error_codes.val,
-                           moveit::core::errorCodeToString(error_codes).c_str(), error_codes.message.c_str());
-
+      RCLCPP_WARN_THROTTLE(logger, *get_node()->get_clock(), 200, "Failed to find solution to inverse kinematics.");
       return controller_interface::return_type::OK;
     }
 
+    // Validate the solution
     if (check_path_for_self_intersection(joint_state_values, solution)) {
-      twistmapper_pose_ = old_pose;
-      twistmapper_pose_rpy_ = old_rpy;
-      RCLCPP_WARN_THROTTLE(logger, *get_node()->get_clock(), 500, "Inverse Kinematics solution self intersects!");
+      RCLCPP_WARN_THROTTLE(logger, *get_node()->get_clock(), 200, "Inverse Kinematics solution self intersects!");
       return controller_interface::return_type::OK;
     }
 
@@ -167,6 +191,9 @@ namespace nova_twistmapper
     for (size_t i = 0; i < solution.size(); i++) {
       registered_joint_handles_[i].command.get().set_value(solution[i]);
     }
+
+    // Keep new pose for next iteration
+    twistmapper_pose_ = new_pose;
 
     return controller_interface::return_type::OK;
   }
@@ -189,8 +216,6 @@ namespace nova_twistmapper
     }
 
     twistmapper_pose_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(tf2_ros::TransformBroadcaster(*get_node()));
-    // tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_node()->get_clock());
-    // tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
     twist_stamped_sub_ = get_node()->create_subscription<geometry_msgs::msg::TwistStamped>(
       DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST,
@@ -212,6 +237,19 @@ namespace nova_twistmapper
             "Received message with zero timestamp, setting it to current "
             "time, this message will only be shown once");
           msg->header.stamp = get_node()->get_clock()->now();
+        }
+
+        auto new_frame_id = msg->header.frame_id.empty() ? params_.fallback_frame_id : msg->header.frame_id;
+
+        if (new_frame_id != last_frame_id_) {
+          // Update references to new reference frame for the real-time thread here!
+          // We can do tricks to optimise the real-time thread by precomputing work here. For example, automatically
+          // checking if a frame is relative to the end effector to see if we can do a cheaper version of FK for any
+          // frames relative to the end effector.
+
+          // TODO: Do some optimisations and magic tricks here!
+
+          last_frame_id_ = new_frame_id;
         }
 
         received_twist_stamped_ptr_.set(std::move(msg));
@@ -299,13 +337,48 @@ namespace nova_twistmapper
 
   std::string NovaTwistmapper::construct_srdf_fallback_string(const urdf::ModelInterfaceSharedPtr &urdf_model,
                                                               std::string joint_group_name) {
+    auto logger = get_node()->get_logger();
+
     std::ostringstream srdf_stream;
     srdf_stream << "<robot name=\"" << urdf_model->getName() << "\">\n";
     srdf_stream << "  <group name=\"" << joint_group_name << "\">\n";
     for (const auto& joint : params_.joint_names)
       srdf_stream << "    <joint name=\"" << joint << "\"/>\n";
-    srdf_stream << "    <chain base_link=\"" << params_.kinematics_base_frame << "\" tip_link=\"" << params_.kinematics_endeffector_frame << "\" />\n";
+
+    if (params_.add_chain_to_srdf)
+      srdf_stream << "    <chain base_link=\"" << params_.kinematics_base_frame << "\" tip_link=\"" << params_.kinematics_endeffector_frame << "\" />\n";
+
     srdf_stream << "  </group>\n";
+
+    if (params_.add_allowed_collisions_to_srdf && planning_scene_) {
+      RCLCPP_INFO(logger, "Generating and adding allowed collisions in the fallback SRDF!");
+
+      // Get the current state
+      moveit::core::RobotState& state = planning_scene_->getCurrentStateNonConst();
+      state.setToDefaultValues();
+      state.update();
+
+      // Set up request/result
+      collision_detection::CollisionRequest req;
+      collision_detection::CollisionResult res;
+      req.contacts = true;      // We get contact info to generate the allowed collision matrix from
+      req.max_contacts = 1024;  // This was chosen arbitrarily as some large number
+
+      // Perform self-collision check
+      planning_scene_->checkSelfCollision(req, res, state);
+
+      // Add all colliding pairs to the ACM
+      for (const auto &contact_pair : res.contacts)
+      {
+        RCLCPP_INFO(logger, "  - \"%s\" and \"%s\"",
+                    contact_pair.first.first.c_str(), contact_pair.first.second.c_str());
+        const auto &link1 = contact_pair.first.first;
+        const auto &link2 = contact_pair.first.second;
+
+        srdf_stream << "  <disable_collisions link1=\"" << link1 << "\" link2=\"" << link2 << "\" reason=\"Never\"/>\n";
+      }
+    }
+
     srdf_stream << "</robot>\n";
     auto srdf_string = srdf_stream.str();
     return srdf_string;
@@ -384,13 +457,6 @@ namespace nova_twistmapper
     // Store result to twistmapper_pose_
     tf2::fromMsg(poses[0], twistmapper_pose_);
 
-    // Set twistmapper_pose_rpy_ to match
-    double roll, pitch, yaw;
-    twistmapper_pose_.getBasis().getRPY(roll, pitch, yaw);
-    twistmapper_pose_rpy_.setX(roll);
-    twistmapper_pose_rpy_.setY(pitch);
-    twistmapper_pose_rpy_.setZ(yaw);
-
     // Set initial command interface values from state interface
     for (auto& joint : registered_joint_handles_) {
       joint.command.get().set_value(joint.state_pos.get().get_value());
@@ -452,8 +518,6 @@ namespace nova_twistmapper
     kinematics_compat_node_.reset();
 
     twistmapper_pose_tf_broadcaster_.reset();
-    // tf_buffer_.reset();
-    // tf_listener_.reset();
 
     // Reset subscriptions
     twist_stamped_sub_.reset();
@@ -482,13 +546,11 @@ namespace nova_twistmapper
     twist_stamped->twist.angular.z = 0;
   }
 
-  void NovaTwistmapper::publish_to_tf2(const rclcpp::Time &time) {
+  void NovaTwistmapper::publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose) {
     // Publish twistmapper pose to tf2
-    geometry_msgs::msg::TransformStamped transform_stamped;
-    transform_stamped.transform = toMsg(twistmapper_pose_);
+    auto transform_stamped = tf2::eigenToTransform(pose);
     transform_stamped.header.stamp = time;
 
-    // TODO: Parameterize
     transform_stamped.child_frame_id = params_.kinematics_output_target_frame;
     transform_stamped.header.frame_id = params_.kinematics_base_frame;
 

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -28,8 +28,6 @@ EDITED BY:
 
 namespace
 {
-  constexpr auto DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST = "/arm_ik_twist_stamped"; // TODO: changeme
-
   // Used to avoid division by zero. Threshold for where to call small numbers essentially zero in vector normalization.
   constexpr auto EPSILON = 1e-8;
 } // namespace
@@ -218,7 +216,7 @@ namespace nova_twistmapper
     twistmapper_pose_tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(tf2_ros::TransformBroadcaster(*get_node()));
 
     twist_stamped_sub_ = get_node()->create_subscription<geometry_msgs::msg::TwistStamped>(
-      DEFAULT_INPUT_TOPIC_END_EFFECTOR_TWIST,
+      params_.twist_stamped_topic,
       rclcpp::SystemDefaultsQoS(),
       [this, logger](const std::shared_ptr<geometry_msgs::msg::TwistStamped> msg) -> void
       {

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper.cpp
@@ -90,12 +90,14 @@ namespace nova_twistmapper
   Eigen::Isometry3d NovaTwistmapper::integrate_twist(const std::vector<double> &seed_state,
                                                      const rclcpp::Duration &period,
                                                      const Eigen::Isometry3d &current_target_pose) {
+    const auto logger = get_node()->get_logger();
+
     // Retrieve the twist
     std::shared_ptr<geometry_msgs::msg::TwistStamped> twist_stamped;
     received_twist_stamped_ptr_.get(twist_stamped);
 
     if (twist_stamped == nullptr) {
-      RCLCPP_WARN(get_node()->get_logger(), "Haven't yet received a TwistStamped message to use for the twistmapper.");
+      RCLCPP_WARN(logger, "Haven't yet received a TwistStamped message to use for the twistmapper.");
       return current_target_pose;
     }
 
@@ -110,16 +112,20 @@ namespace nova_twistmapper
     auto result = kinematics_solver_->getPositionFK({twist_frame_id}, seed_state, poses);
 
     if (!result) {
-      RCLCPP_ERROR(get_node()->get_logger(), "Failed to do forward kinematics to find the twist frame");
+      RCLCPP_ERROR(logger, "Failed to do forward kinematics to find the twist frame");
       return current_target_pose;
     }
     if (poses.empty()) {
-      RCLCPP_ERROR(get_node()->get_logger(), "No poses returned from forward kinematics!");
+      RCLCPP_ERROR(logger, "No poses returned from forward kinematics!");
       return current_target_pose;
     }
 
     Eigen::Isometry3d twist_frame;
     Eigen::fromMsg(poses[0], twist_frame);
+
+    if (params_.publish_debug_frames) {
+      publish_to_tf2(get_node()->get_clock()->now(), twist_frame, std::string(get_node()->get_name()) + "_twist_frame");
+    }
 
     // Extract data from the twist message into a usable format for math
     Eigen::Matrix<double, 6, 1> twist;
@@ -544,12 +550,12 @@ namespace nova_twistmapper
     twist_stamped->twist.angular.z = 0;
   }
 
-  void NovaTwistmapper::publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose) {
+  void NovaTwistmapper::publish_to_tf2(const rclcpp::Time &time, const Eigen::Isometry3d &pose, const std::string& name) {
     // Publish twistmapper pose to tf2
     auto transform_stamped = tf2::eigenToTransform(pose);
     transform_stamped.header.stamp = time;
 
-    transform_stamped.child_frame_id = params_.kinematics_output_target_frame;
+    transform_stamped.child_frame_id = name.empty() ? params_.kinematics_output_target_frame : name;
     transform_stamped.header.frame_id = params_.kinematics_base_frame;
 
     RCLCPP_INFO_ONCE(get_node()->get_logger(), "Broadcasting twistmapper pose as '%s', child of '%s'.",

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
@@ -34,6 +34,11 @@ nova_twistmapper:
     default_value: true,
     description: "When true, adds a chain from the base to the end effector to the fallback SRDF. This is needed for KDL to work, but breaks the BanksiaKinematicsPlugin."
   }
+  publish_debug_frames: {
+    type: bool,
+    default_value: false,
+    description: "When true, extra frames will be published on tf2 to help with debugging twistmapper behaviour."
+  }
 
   # Kinematics Solving
   kinematics_solver: {

--- a/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
+++ b/src/ros/rover/arm/arm_controllers/nova_twistmapper/src/nova_twistmapper_parameter.yaml
@@ -6,7 +6,7 @@ nova_twistmapper:
   }
   chained_controller_name: {
     type: string,
-    default_value: "nova_ik_controller",
+    default_value: "",
     description: "The name of the chainable controller to capture reference interfaces from. Leave empty to use hardware 
     interfaces."
   }
@@ -17,6 +17,12 @@ nova_twistmapper:
     default_value: "/arm_ik_twist_stamped",
     description: "The name of the topic to get teleop twist stamped messages from. Applies relative to the 
     header.frame_id frame."
+  }
+  fallback_frame_id: {
+    type: string,
+    default_value: "endeffector_kinematics",
+    description: "The default value of header.frame_id for received TwistStamped messages. Used when no frame_id is 
+      provided in a message."
   }
   add_allowed_collisions_to_srdf: {
     type: bool,

--- a/src/ros/rover/arm/teleop_arm/launch/teleop.launch.py
+++ b/src/ros/rover/arm/teleop_arm/launch/teleop.launch.py
@@ -12,6 +12,7 @@ def launch_setup(context, *args, **kwargs):
 
     teleop_params = LaunchConfiguration('teleop_params')
     log_inputs = LaunchConfiguration('log_inputs')
+    log_level = LaunchConfiguration('log_level').perform(context)
 
     return [
         # Runs teleop_node with the given parameter files
@@ -20,7 +21,7 @@ def launch_setup(context, *args, **kwargs):
             executable='teleop_node',
             output='screen',
 
-            arguments=['--node-name', 'teleop_arm'],
+            arguments=['--node-name', 'teleop_arm', '--ros-args', '--log-level', log_level],
 
             # You can add multiple parameter files here:
             parameters=[
@@ -50,6 +51,11 @@ def generate_launch_description():
 
     declared_arguments = [
         # You can declare arguments to your launch file like this!
+        DeclareLaunchArgument(
+            name='log_level',
+            default_value='INFO',
+            description='The log level to use for the teleop_node',
+        ),
         DeclareLaunchArgument(
             name='teleop_params',
             default_value=PathJoinSubstitution([teleop_arm_dir, 'params', 'teleop.yaml']),

--- a/src/ros/rover/arm/teleop_arm/params/teleop.yaml
+++ b/src/ros/rover/arm/teleop_arm/params/teleop.yaml
@@ -50,28 +50,28 @@ joint_space_mode:
   ros__parameters:
     topic: "/arm_fk_velocity_target"
     joints:
-      1:
-        name: "j1"
+      j1:
+        name: "J1"
         input_name: "j1"
         scale: 0.36
-      2:
-        name: "j2"
+      j2:
+        name: "J2"
         input_name: "j2"
         scale: 0.36
-      3:
-        name: "j3"
+      j3:
+        name: "J3"
         input_name: "j3"
         scale: 0.36
-      4:
-        name: "j4"
+      j4:
+        name: "J4"
         input_name: "j4"
         scale: 0.36
-      5:
-        name: "j5"
+      j5:
+        name: "J5"
         input_name: "j5"
         scale: 0.36
-      6:
-        name: "j6"
+      j6:
+        name: "J6"
         input_name: "j6"
         scale: 0.36
 
@@ -142,3 +142,14 @@ joy_input_source:
     ]
 
     # TODO: remapping
+    remap:
+      axes:
+        speed:
+          from: TRIGGERRIGHT
+
+        J1:
+          from: LEFTX
+        j1:
+          from: LEFTX
+        j2:
+          from: LEFTY

--- a/src/ros/rover/arm/teleop_arm/params/teleop.yaml
+++ b/src/ros/rover/arm/teleop_arm/params/teleop.yaml
@@ -27,6 +27,7 @@ teleop_arm:
         type: "joint_space_control_mode/JointSpaceControlMode"
         controllers:
           - nova_arm_velocity_controller
+
       task_space_mode:
         type: "teleop_modular_twist/TwistControlMode"
         controllers:
@@ -123,11 +124,11 @@ task_space_mode:
     # Prevent velocities larger than the specified values from being emitted
     limits:
       linear:
-        all: 0.25
+        all: 0.1
         normalized: true
         scale_with_speed: true
       angular:
-        all: 0.785398163395
+        all: 0.2
         normalized: true
         scale_with_speed: true
 
@@ -216,14 +217,14 @@ joy_input_source:
               negative: "A"
         angular:
           x:
-            from: RIGHTX
+            from_buttons:
+              positive: "X"
+              negative: "B"
           y:
             from: RIGHTY
             invert: true
           z:
-            from_buttons:
-              positive: "X"
-              negative: "B"
+            from: RIGHTX
 
       buttons:
         lock:

--- a/src/ros/rover/arm/teleop_arm/params/teleop.yaml
+++ b/src/ros/rover/arm/teleop_arm/params/teleop.yaml
@@ -7,48 +7,78 @@ teleop_arm:
 
     # The minimum rate at which updates occur.
     # Leaving this unset will allow for indefinite lapses between updates.
-    min_update_rate: 2.0
+    min_update_rate: 4.0
 
     input_sources:
-      names: [
-        "joy_input_source"
-      ]
+      names:
+        - joy_input_source
 
       # Then declare its type!
       joy_input_source:
         type: "teleop_modular_joy/JoyInputSource"
 
     control_modes:
-      names: [
-        "joint_space_mode",
-        "task_space_mode"
-      ]
+      names:
+        - joint_space_mode
+        - task_space_mode
 
       # Then declare its type!
       joint_space_mode:
         type: "joint_space_control_mode/JointSpaceControlMode"
+        controllers:
+          - nova_arm_velocity_controller
       task_space_mode:
         type: "teleop_modular_twist/TwistControlMode"
+        controllers:
+          - nova_arm_position_controller
+          - nova_twistmapper
 
     commands:
-      names: [
-        "enter_task_space",
-        "enter_joint_space"
-      ]
+      names:
+        - enter_task_space
+        - enter_joint_space
 
-      enter_task_space_mode:
+      enter_task_space:
         on: "task_space/down"
-        type: "activate_control_mode"
-        name: "task_space_mode"
-      enter_joint_space_mode:
+        type: switch_control_mode
+        to: task_space_mode
+      enter_joint_space:
         on: "task_space/up"
-        type: "activate_control_mode"
-        name: "joint_space_mode"
+        type: switch_control_mode
+        to: joint_space_mode
+      lock:
+        on_any: ["lock/down", "start"]
+        type: set_button
+        name: locked
+        value: true
+      unlock:
+        on: "unlock/up"
+        type: set_button
+        name: locked
+        value: false
+      log_locked:
+        on: "locked/down"
+        type: log
+        message: "Locked"
+      log_unlocked:
+        on: "locked/down"
+        type: log
+        message: "Unlocked"
 
 
 joint_space_mode:
   ros__parameters:
     topic: "/arm_fk_velocity_target"
+    use_speed_input: false
+
+    joint_definitions:
+      - j1
+      - j2
+      - j3
+      - j4
+      - j5
+      - j6
+
     joints:
       j1:
         name: "J1"
@@ -81,12 +111,12 @@ task_space_mode:
     # Topic to send TwistStamped messages to.
     stamped_topic: "/arm_ik_twist_stamped"
     # Use the input named "speed" to scale everything.
-    use_speed_input: true
+    use_speed_input: false
 
     # Values to multiply inputs with.
     scale:
       linear:
-        all: 0.25
+        all: 0.125
       angular:
         all: 0.785398163395
 
@@ -109,47 +139,96 @@ joy_input_source:
     # https://docs.ros.org/en/ros2_packages/rolling/api/joy/index.html
     # If you use joy_node, you'll need to figure out what the mapping is yourself.
     # So, run joy, `ros2 topic echo /joy`, and mess around with your controller to figure out what it is for you.
-    button_definitions: [
-      "A",
-      "B",
-      "X",
-      "Y",
-      "BACK",
-      "GUIDE",
-      "START",
-      "LEFTSTICK",
-      "RIGHTSTICK",
-      "LEFTSHOULDER",
-      "RIGHTSHOULDER",
-      "DPAD_UP",
-      "DPAD_DOWN",
-      "DPAD_LEFT",
-      "DPAD_RIGHT",
-      "MISC1",
-      "PADDLE1",
-      "PADDLE2",
-      "PADDLE3",
-      "PADDLE4",
-      "TOUCHPAD"
-    ]
-    axis_definitions: [
-      "LEFTX",
-      "LEFTY",
-      "RIGHTX",
-      "RIGHTY",
-      "TRIGGERLEFT",
-      "TRIGGERRIGHT"
-    ]
+    button_definitions:
+      - "A"
+      - "B"
+      - "X"
+      - "Y"
+      - BACK
+      - GUIDE
+      - START
+      - LEFTSTICK
+      - RIGHTSTICK
+      - LEFTSHOULDER
+      - RIGHTSHOULDER
+      - DPAD_UP
+      - DPAD_DOWN
+      - DPAD_LEFT
+      - DPAD_RIGHT
+      - MISC1
+      - PADDLE1
+      - PADDLE2
+      - PADDLE3
+      - PADDLE4
+      - TOUCHPAD
+    axis_definitions:
+      - LEFTX
+      - LEFTY
+      - RIGHTX
+      - RIGHTY
+      - TRIGGERLEFT
+      - TRIGGERRIGHT
 
-    # TODO: remapping
     remap:
       axes:
         speed:
           from: TRIGGERRIGHT
+          invert: true
 
-        J1:
-          from: LEFTX
+        # Joint space
         j1:
-          from: LEFTX
+          from_buttons:
+            positive: DPAD_RIGHT
+            negative: DPAD_LEFT
+          invert: true
         j2:
-          from: LEFTY
+          from_buttons:
+            positive: DPAD_UP
+            negative: DPAD_DOWN
+          invert: true
+        j3:
+          from_buttons:
+            positive: "Y"
+            negative: "A"
+        j4:
+          from: RIGHTY
+          invert: true
+        j5:
+          from: RIGHTX
+        j6:
+          from_buttons:
+            positive: "X"
+            negative: "B"
+
+        # Task space
+        linear:
+          x:
+            from_buttons:
+              positive: DPAD_UP
+              negative: DPAD_DOWN
+          y:
+            from_buttons:
+              positive: DPAD_RIGHT
+              negative: DPAD_LEFT
+          z:
+            from_buttons:
+              positive: "Y"
+              negative: "A"
+        angular:
+          x:
+            from: RIGHTX
+          y:
+            from: RIGHTY
+            invert: true
+          z:
+            from_buttons:
+              positive: "X"
+              negative: "B"
+
+      buttons:
+        lock:
+          from: BACK
+        unlock:
+          from: START
+        task_space:
+          from: LEFTSHOULDER


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Merges changes to make twist.angular be applied via an angle-axis relative to some reference frame_id in nova_twistmapper

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

In one terminal, run:
```sh
ros2 launch arm_bringup mock.launch.py rviz:=True controllers:=/home/nova/nova/src/ros/rover/arm/arm_bringup/params/new.controllers.yaml
```

In another terminal, run:
```sh
mros2 launch teleop_arm teleop.launch.py teleop_params:=/home/nova/nova/src/ros/rover/arm/teleop_arm/params/teleop.yaml log_inputs:=True
```

Then plug in an xbox or ps5 controller. 

You can find the control scheme under `src/ros/rover/arm/teleop_arm/params/teleop.yaml`.

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:arm;tag:control
<!-- TAGS END -->
