### PR TITLE
ci lib: reenable aliases for release-lib

### DIFF
--- a/nixfiles/ci/lib.nix
+++ b/nixfiles/ci/lib.nix
@@ -9,7 +9,18 @@ let
   nixfiles = nova-monorepo + "/nixfiles";
 in rec {
   pkgs = import nixpkgs { };
-  releaseLib = import (pkgs.path + "/pkgs/top-level/release-lib.nix") { inherit supportedSystems; };
+  #releaseLib = import (pkgs.path + "/pkgs/top-level/release-lib.nix") { inherit supportedSystems; };
+  releaseLib = import (pkgs.path + "/pkgs/top-level/release-lib.nix") {
+    inherit supportedSystems;
+    nixpkgsArgs = {
+      config = {
+        allowAliases = true; # https://github.com/NixOS/nixpkgs/blob/a50c9f77d238909b5f96d97dab0f69d1c9abefa8/pkgs/top-level/release-lib.nix#L9 override this to true
+        allowUnfree = false;
+        inHydra = true;
+      };
+      __allowFileset = false;
+    };
+  };
 
   # repos = map (repo: args.${repo}) repoNames;
   repos = if repoNames == null


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/2116eb760b44f4e44d500f32ab9f2570fc586dac

I think this is what broke it, if aliases are disabled then the hostPlatform etc attributes don't exist.

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
