### PR TITLE
feat: allow local teleop_modular source directory to be specified

### DIFF
--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -89,11 +89,14 @@ let
       (import ./overlay)
 
       # Add teleop_modular
-      (import (pkgs.fetchFromGitHub {
+      # To use local source code for teleop modular, run in your terminal before building:
+      # $ export TELEOP_PATH:=~/path/to/teleop_modular
+      # (this only applies to the one terminal, and wont apply to any future shell sessions)
+      (import ((pkgs.lib.maybeEnv "TELEOP_PATH" (pkgs.fetchFromGitHub {
         owner = "BaileyChessum";
         repo = "teleop_modular";
         inherit (revisions.teleop-modular) rev hash;
-      } + "/overlay.nix"))
+      })) + "/overlay.nix"))
 
       # Add internally defined packages.
       (self: super: import ./packages/other { inherit (self) callPackage; })


### PR DESCRIPTION


<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

You can set the `TELEOP_PATH` env variable to point to your local source code for teleop_modular to make ws-build build with that teleop_modular source:

```sh
export TELEOP_PATH:=~/path/to/teleop_modular
```

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->
