### PR TITLE
nixfiles: jobsets: isos: resolve name conflict

### DIFF
--- a/nixfiles/ci/jobsets/isos.nix
+++ b/nixfiles/ci/jobsets/isos.nix
@@ -41,7 +41,7 @@ let
               ];
 
               isoImage = {
-                isoBaseName = "nixos${lib.optionalString graphical "-graphical"}${lib.optionalString includeWorkspace "-workspace"}";
+                isoBaseName = lib.mkForce "nixos${lib.optionalString graphical "-graphical"}${lib.optionalString includeWorkspace "-workspace"}";
                 squashfsCompression = lib.mkIf (!enableCompression) "xz -noI -noD -noF -noX";
 
                 # Add workspace development dependencies, so that the live


### PR DESCRIPTION
make the iso name a lib.mkForce

error: The option `image.baseName' has conflicting definition values:
- In `/nix/store/081zspnjiwbq85jqhx89gkk2nbyrfg3y-source/nixos/modules/installer/cd-dvd/iso-image.nix': "nixos-graphical-workspace"
- In `/nix/store/081zspnjiwbq85jqhx89gkk2nbyrfg3y-source/nixos/modules/installer/cd-dvd/iso-image.nix': "nixos-nova-nova-25.11pre-git-x86_64-linux" Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
