### PR TITLE
Centralise all aliases to macros default nix

### DIFF
--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -46,28 +46,16 @@ in
           nova = "cd ${cfg.sourceDir}/..";
           nixfiles = "cd ${cfg.nixfileDir}";
           rover = "${nova}/src/ros/rover";
-          core = "${nova}/src/ros/rover/core";
-          control = "${nova}/src/ros/rover/control";
-          electronics = "${nova}/src/ros/rover/electronics";
-          elec = electronics;
-          visualisation = "${nova}/src/ros/visualisation";
-          visualization = visualisation;
-          vis = visualisation;
-          viz = visualisation;
+          arm = "${nova}/src/ros/rover/arm";
+          autonomous = "${nova}/src/ros/rover/auto";
+          auto = autonomous;
+          chassis = "${nova}/src/ros/rover/chassis";
           science = "${nova}/src/ros/rover/science";
           camerasdir = "${nova}/src/ros/cameras2";
-          autonomous = "${nova}/src/ros/rover/autonomous";
-          auto = autonomous;
           gui = "${nova}/src/ros/nova-gui/nova-gui";
-          tutorials = "${nova}/src/ros/tutorials";
-          pic = "${nova}/src/other/pics";
-          pics = pic;
-          arduino = "${nova}/src/other/arduinos";
-          arduinos = arduino;
-          ik = "${nova}/src/other/ik_machine";
           coms = "${nova}/src/other/coms_utils";
 
-          # Networking aliases
+          # Networking 
           jetson = "ssh -Y nvidia@10.0.0.10";
           jetson-wifi = "ssh -Y nvidia@tegra-ubuntu";
           orin = "ssh -Y nova@10.0.0.11";
@@ -79,16 +67,9 @@ in
           N2 = "ssh -Y nova@10.0.2.12";
           N3 = "ssh -Y nova@10.0.2.13";
 
-          # Application aliases
+          # Application 
           code = "codium";
           urdf-tool = "nix-shell ${cfg.nixfileDir}/home/macros/urdf-tool.nix";
-
-          # Stubs to ease migration
-          setup = ''echo 'The setup alias is no longer necessary. To try new changes, please use "ws-build" or "nixos-rebuild" instead.' #'';
-          check = ''echo 'The check alias is no longer relevant. Use "journalctl -u <service>" instead.' #'';
-          stop = ''echo 'The stop alias is no longer relevant. Use "systemctl stop <service>" instead.' #'';
-          restart = ''echo 'The restart alias is no longer relevant. Use "systemctl restart <service>" instead.' #'';
-          wifi = ''echo 'The wifi alias is no longer relevant. Use "nmtui" or "nmcli" instead.' #'';
 
           # Nano v Vim
           set_vim = "export EDITOR=vim";
@@ -102,7 +83,7 @@ in
           rover_dds_super_client = "FASTRTPS_DEFAULT_PROFILES_FILE=${./ros_discovery/rover_super_client_configuration.xml}";
           base_pi_dds_super_client = "FASTRTPS_DEFAULT_PROFILES_FILE=${./ros_discovery/base_pi_super_client_configuration.xml}";
 
-          # Hydra aliases
+          # Hydra 
           hydra-vomit = "${pkgs.bash}/bin/bash ${../../../scripts/hydra-vomit.sh}";
 
           # Launch rover or payloads
@@ -133,9 +114,6 @@ in
           zero-arm = "${pkgs.bash}/bin/bash ${../../../scripts/zero-arm.sh}";
           zero-pivots = "${pkgs.bash}/bin/bash ${../../../scripts/zero-pivots.sh}";
           list-blcmds = "more ${cfg.nixfileDir}/doc/blcmd-ids.md";
-          
-          # Shell
-          predict-shell = "nix-shell ~/nova/src/other/ilmenite_ml";
 
           # GUI
           gui-shell = "nova-shell -A pkgs.ros.nova-gui";
@@ -164,7 +142,7 @@ in
           shitdown = "shutdown now";
           diddy = "sudo shitdown";
 
-          # Auto Aliases
+          # Auto 
           launch-auto-rover = "~/Builds/master/bin/ros2 launch auto_bringup urc.launch.py";
           launch-auto-base = "~/Builds/master/bin/ros2 run nova_utils start_auto.py";
           launch-sim = "~/Builds/master/bin/ros2 launch auto_bringup everything.launch.py";
@@ -179,18 +157,18 @@ in
           launch-yolo = "~/Builds/master/bin/ros2 launch auto_bringup yolo.launch.py";
           oak-gui = "~/Builds/master/bin/ros2 launch auto_bringup oak-gui.launch.py";
 
-          # GPS Alias
+          # GPS
           launch-gps = "~/Builds/master/bin/ros2 launch nova_bringup gps_rover.launch.py gps_params:=/home/nova/nova/src/ros/rover/nova_bringup/params/gps.yaml";
           mast = "ssh nova@10.0.0.150";
 
-          # Master build binary shorthand alias
+          # Master build binaries
           mros2 = "~/Builds/master/bin/ros2";
           mrviz2 = "~/Builds/master/bin/rviz2";
           mrviz = "~/Builds/master/bin/rviz2";
           mxacro = "~/Builds/master/bin/xacro ${cfg.sourceDir}/ros/rover/rover_description/banksia/urdf/rover.urdf.xacro";
           mrqt = "~/Builds/master/bin/rqt";
 
-          # Arm Aliases
+          # Arm
           launch-typing = "~/Builds/master/bin/ros2 launch arm_bringup typing.launch.py";
           launch-arm-control = "~/Builds/master/bin/ros2 launch arm_bringup control.launch.py arm:=False old_arm:=True";
           launch-path-control = "~/Builds/master/bin/ros2 launch arm_bringup path.control.launch.py arm:=False old_arm:=True";
@@ -200,13 +178,16 @@ in
           run-arm-teleop-xbox = "~/Builds/master/bin/ros2 run teleop_arm_joy teleop_arm_joy_node --ros-args --params-file ${cfg.sourceDir}/ros/rover/teleop_arm_joy/config/old.xbox.config.yaml";
           run-joy = "~/Builds/master/bin/ros2 run joy joy_node";
 
-          # ros2_control Aliases
+          # Science
+          ilmenite-shell = "nix-shell ~/nova/src/other/ilmenite_ml";
+
+          # ros2_control
           controllers-list = "~/Builds/master/bin/ros2 control list_controllers";
           controllers-set = "~/Builds/master/bin/ros2 control set_controller_state";
           activate-path = "~/Builds/master/bin/ros2 control set_controller_state nova_path_planner active";
           deactivate-path = "~/Builds/master/bin/ros2 control set_controller_state nova_path_planner inactive";
 
-          # Ducket Aliases
+          # Ducket
           ducket-pos = "cansend can0 0C1#7000";
           ducket-neg = "cansend can0 0C1#9000";
           ducket = "cansend can0 0C1#7000";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -177,7 +177,11 @@ in
           launch-nav = "~/Builds/master/bin/ros2 launch auto_bringup navigation.launch.py";
           launch-rviz = "~/Builds/master/bin/ros2 launch auto_bringup rviz.launch.py";
           launch-yolo = "~/Builds/master/bin/ros2 launch auto_bringup yolo.launch.py";
-          gui-oak = "~/Builds/master/bin/ros2 launch auto_bringup oak-gui.launch.py";
+          oak-gui = "~/Builds/master/bin/ros2 launch auto_bringup oak-gui.launch.py";
+          auto_bag = "ros2 bag record /T265/pose /depth_camera/d435_1/cloud /autonomous/occupancy_grid /object_detector/markers /ar_tracker/tags goal_manager/confirmed_targets -s mcap -b 500000000";
+          start_mapping = "ros2 param set /mapper do_mapping False";
+          stop_mapping = "ros2 param set /mapper do_mapping True";
+
 
           # GPS Alias
           launch-gps = "~/Builds/master/bin/ros2 launch nova_bringup gps_rover.launch.py gps_params:=/home/nova/nova/src/ros/rover/nova_bringup/params/gps.yaml";
@@ -199,6 +203,10 @@ in
           run-arm-teleop = "~/Builds/master/bin/ros2 run teleop_arm_joy teleop_arm_joy_node";
           run-arm-teleop-xbox = "~/Builds/master/bin/ros2 run teleop_arm_joy teleop_arm_joy_node --ros-args --params-file ${cfg.sourceDir}/ros/rover/teleop_arm_joy/config/old.xbox.config.yaml";
           run-joy = "~/Builds/master/bin/ros2 run joy joy_node";
+
+          # Arm service aliases
+          arm_config_info = "ros2 service call control/arm_config_info arm_interfaces/srv/ArmConfigInfo";
+          arm_reset_control_pose = "ros2 service call control/arm_reset_control_pose std_srvs/srv/Trigger";
 
           # ros2_control Aliases
           controllers-list = "~/Builds/master/bin/ros2 control list_controllers";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -179,7 +179,7 @@ in
           run-joy = "~/Builds/master/bin/ros2 run joy joy_node";
 
           # Science
-          ilmenite-shell = "nix-shell ~/nova/src/other/ilmenite_ml";
+          predict-shell = "nix-shell ~/nova/src/other/ilmenite_ml"; # please come up with a more descriptive and less generic alias
 
           # ros2_control
           controllers-list = "~/Builds/master/bin/ros2 control list_controllers";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -178,10 +178,6 @@ in
           launch-rviz = "~/Builds/master/bin/ros2 launch auto_bringup rviz.launch.py";
           launch-yolo = "~/Builds/master/bin/ros2 launch auto_bringup yolo.launch.py";
           oak-gui = "~/Builds/master/bin/ros2 launch auto_bringup oak-gui.launch.py";
-          auto_bag = "ros2 bag record /T265/pose /depth_camera/d435_1/cloud /autonomous/occupancy_grid /object_detector/markers /ar_tracker/tags goal_manager/confirmed_targets -s mcap -b 500000000";
-          start_mapping = "ros2 param set /mapper do_mapping False";
-          stop_mapping = "ros2 param set /mapper do_mapping True";
-
 
           # GPS Alias
           launch-gps = "~/Builds/master/bin/ros2 launch nova_bringup gps_rover.launch.py gps_params:=/home/nova/nova/src/ros/rover/nova_bringup/params/gps.yaml";
@@ -203,10 +199,6 @@ in
           run-arm-teleop = "~/Builds/master/bin/ros2 run teleop_arm_joy teleop_arm_joy_node";
           run-arm-teleop-xbox = "~/Builds/master/bin/ros2 run teleop_arm_joy teleop_arm_joy_node --ros-args --params-file ${cfg.sourceDir}/ros/rover/teleop_arm_joy/config/old.xbox.config.yaml";
           run-joy = "~/Builds/master/bin/ros2 run joy joy_node";
-
-          # Arm service aliases
-          arm_config_info = "ros2 service call control/arm_config_info arm_interfaces/srv/ArmConfigInfo";
-          arm_reset_control_pose = "ros2 service call control/arm_reset_control_pose std_srvs/srv/Trigger";
 
           # ros2_control Aliases
           controllers-list = "~/Builds/master/bin/ros2 control list_controllers";

--- a/src/ros/rover/default.nix
+++ b/src/ros/rover/default.nix
@@ -22,26 +22,4 @@
   #pythonPackages = pythonPackages: with pythonPackages; {
     
   #};
-
-  shellAliases = {
-    # Launching aliases
-    base = "ros2 launch nova_bringup base.launch.py";
-    drive = "ros2 launch drive_bringup drive.launch.py";
-    arm = "ros2 launch nova_bringup arm.launch.py";
-    sci = "ros2 launch nova_bringup urc_science.launch.py";
-    auto_drive = "ros2 launch drive_bringup drive.launch.py auto:=True";
-    localisation = "ros2 launch auto_bringup localization.launch.py";
-    localization = "ros2 launch auto_bringup localization.launch.py";
-    urdf = "ros2 launch nova_bringup urdf.launch.py";
-    rosbridge = "ros2 launch rosbridge_server rosbridge_websocket_launch.xml";
-
-    # Service aliases
-    arm_config_info = "ros2 service call control/arm_config_info arm_interfaces/srv/ArmConfigInfo";
-    arm_reset_control_pose = "ros2 service call control/arm_reset_control_pose std_srvs/srv/Trigger";
-
-    # Autonomous aliases
-    auto_bag = "ros2 bag record /T265/pose /depth_camera/d435_1/cloud /autonomous/occupancy_grid /object_detector/markers /ar_tracker/tags goal_manager/confirmed_targets -s mcap -b 500000000";
-    start_mapping = "ros2 param set /mapper do_mapping False";
-    stop_mapping = "ros2 param set /mapper do_mapping True";
-  };
 }


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

We had aliases defined in two different places with some overlap/duplicates.
This removes them from rover's default.nix and keeps it all in nixfiles/home/macro/default.nix


## Memes
<img width="364" height="294" alt="image" src="https://github.com/user-attachments/assets/645d7f20-b224-4cff-b399-e33c90e1fbef" />

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:nixfiles;tag:ready_for_review
<!-- TAGS END -->
