### PR TITLE
Feat/rtabmap launch

### DIFF
--- a/src/ros/rover/auto/auto_bringup/CMakeLists.txt
+++ b/src/ros/rover/auto/auto_bringup/CMakeLists.txt
@@ -28,6 +28,7 @@ install(DIRECTORY
   resources
   rviz
   maps
+  topic
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
+++ b/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
@@ -14,7 +14,7 @@ CREATION:	27/04/2023
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction, TimerAction
 from launch.substitutions import  PathJoinSubstitution, LaunchConfiguration
 from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -41,8 +41,9 @@ def launch_setup(context, *args, **kwargs):
     sim_params = LaunchConfiguration('sim_params')
     use_respawn = LaunchConfiguration('use_respawn')
     world = LaunchConfiguration('world')
+    rtabmap = LaunchConfiguration('rtabmap')
 
-    return [
+    auto_bringup_common_nodes = GroupAction([
         IncludeLaunchDescription(
             condition=IfCondition(gazebo),
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'gazebo.launch.py'])),
@@ -89,6 +90,20 @@ def launch_setup(context, *args, **kwargs):
                 'use_sim_time': gazebo,
                 'map_params': map_params,
             }.items()
+        ),
+    ])
+    return [
+        IncludeLaunchDescription(
+            condition = IfCondition(rtabmap),
+            launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'rtabmap.launch.py'])),
+            launch_arguments={
+                'pointclouds':'False',
+                # 'gazebo': gazebo,
+            }.items()
+        ),
+        TimerAction(
+            period = 10.0, #Delay in seconds
+            actions = [auto_bringup_common_nodes],
         ),
     ]
 
@@ -183,6 +198,11 @@ def generate_launch_description():
             name='world',
             default_value=PathJoinSubstitution([nova_gazebo_dir, 'worlds', 'urc_obstacles.sdf']),
             description='Full path to world model file to load',
+        ),
+        DeclareLaunchArgument(
+            name='rtabmap',
+            default_value='False',
+            description='Launch rtabmap?',
         ),
     ]
 

--- a/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
+++ b/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
@@ -11,6 +11,7 @@ NODES:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE: 	auto_bringup
 CREATION:	27/04/2023
+EDITED:     26/09/2025
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 from launch import LaunchDescription

--- a/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
+++ b/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
@@ -14,11 +14,12 @@ CREATION:	27/04/2023
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction, TimerAction
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction, TimerAction, ExecuteProcess, RegisterEventHandler
 from launch.substitutions import  PathJoinSubstitution, LaunchConfiguration
 from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
+from launch.event_handlers import OnProcessExit
 
 def launch_setup(context, *args, **kwargs):
     auto_bringup_dir = FindPackageShare('auto_bringup')
@@ -43,6 +44,13 @@ def launch_setup(context, *args, **kwargs):
     world = LaunchConfiguration('world')
     rtabmap = LaunchConfiguration('rtabmap')
 
+    # Check rtabmap and gps values
+    rtabmap_value = rtabmap.perform(context).lower()
+    gps_value = gps.perform(context).lower()
+
+    # Disable GPS if rtabmap is enabled
+    gps_enabled = 'true' if gps_value == 'true' and rtabmap_value != 'true' else 'false'
+
     auto_bringup_common_nodes = GroupAction([
         IncludeLaunchDescription(
             condition=IfCondition(gazebo),
@@ -64,7 +72,7 @@ def launch_setup(context, *args, **kwargs):
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'localization.launch.py'])),
             launch_arguments={
                 'gazebo': gazebo,
-                'gps': gps,
+                'gps': gps_enabled,
                 'rl_params': rl_params,
             }.items()
         ),
@@ -92,20 +100,31 @@ def launch_setup(context, *args, **kwargs):
             }.items()
         ),
     ])
-    return [
-        IncludeLaunchDescription(
-            condition = IfCondition(rtabmap),
-            launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'rtabmap.launch.py'])),
-            launch_arguments={
-                'pointclouds':'False',
-                # 'gazebo': gazebo,
-            }.items()
-        ),
-        TimerAction(
-            period = 10.0, #Delay in seconds
-            actions = [auto_bringup_common_nodes],
-        ),
-    ]
+    wait_for_rtabmap = ExecuteProcess(
+        cmd=[
+            'python3',
+            PathJoinSubstitution([auto_bringup_dir, 'topic', 'wait_for_topic.py'])
+        ],
+        name='wait_for_rtabmap_topic',
+        output='screen'
+    )
+    if rtabmap_value == 'true':
+        return [
+            IncludeLaunchDescription(
+                launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'rtabmap.launch.py'])),
+                launch_arguments={'pointclouds': 'False'}.items()
+            ),
+            wait_for_rtabmap,
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=wait_for_rtabmap,
+                    on_exit=[auto_bringup_common_nodes],
+                )
+            )
+        ]
+    else:
+        return [auto_bringup_common_nodes]
+
 
 def generate_launch_description():
     auto_bringup_dir = FindPackageShare('auto_bringup')

--- a/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
+++ b/src/ros/rover/auto/auto_bringup/launch/everything.launch.py
@@ -45,14 +45,7 @@ def launch_setup(context, *args, **kwargs):
     world = LaunchConfiguration('world')
     rtabmap = LaunchConfiguration('rtabmap')
 
-    # Check rtabmap and gps values
-    rtabmap_value = rtabmap.perform(context).lower()
-    gps_value = gps.perform(context).lower()
-
-    # Disable GPS if rtabmap is enabled
-    gps_enabled = 'true' if gps_value == 'true' and rtabmap_value != 'true' else 'false'
-
-    auto_bringup_common_nodes = GroupAction([
+    nodes = GroupAction([
         IncludeLaunchDescription(
             condition=IfCondition(gazebo),
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'gazebo.launch.py'])),
@@ -73,7 +66,7 @@ def launch_setup(context, *args, **kwargs):
             launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'localization.launch.py'])),
             launch_arguments={
                 'gazebo': gazebo,
-                'gps': gps_enabled,
+                'gps': gps,
                 'rl_params': rl_params,
             }.items()
         ),
@@ -101,31 +94,40 @@ def launch_setup(context, *args, **kwargs):
             }.items()
         ),
     ])
-    wait_for_rtabmap = ExecuteProcess(
+
+    wait_for_cameras = ExecuteProcess(
         cmd=[
             'python3',
-            PathJoinSubstitution([auto_bringup_dir, 'topic', 'wait_for_topic.py'])
+            PathJoinSubstitution([auto_bringup_dir, 'topic', 'wait_for_topic.py']),
         ],
-        name='wait_for_rtabmap_topic',
-        output='screen'
+        name='wait_for_cameras_topic',
+        output='screen',
     )
-    if rtabmap_value == 'true':
-        return [
-            IncludeLaunchDescription(
-                launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'rtabmap.launch.py'])),
-                launch_arguments={'pointclouds': 'False'}.items()
-            ),
-            wait_for_rtabmap,
-            RegisterEventHandler(
-                OnProcessExit(
-                    target_action=wait_for_rtabmap,
-                    on_exit=[auto_bringup_common_nodes],
-                )
-            )
-        ]
-    else:
-        return [auto_bringup_common_nodes]
 
+    return [
+        GroupAction(
+            condition=IfCondition(rtabmap),
+            actions=[
+                IncludeLaunchDescription(
+                    launch_description_source=PythonLaunchDescriptionSource(PathJoinSubstitution([auto_bringup_dir, 'launch', 'rtabmap.launch.py'])),
+                    launch_arguments={'pointclouds': 'False'}.items(),
+                ),
+                wait_for_cameras,
+                RegisterEventHandler(
+                    OnProcessExit(
+                        target_action=wait_for_cameras,
+                        on_exit=[nodes],
+                    ),
+                ),
+            ],
+        ),
+        GroupAction(
+            condition=UnlessCondition(rtabmap),
+            actions=[
+                nodes,
+            ],
+        ),
+    ]
 
 def generate_launch_description():
     auto_bringup_dir = FindPackageShare('auto_bringup')

--- a/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
+++ b/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
@@ -3,22 +3,23 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Monash Nova Rover Team
 
-This node ensures that a predefined list of required ROS 2 topics
-is active before continuing execution. It is primarily used to
-synchronize startup logic and ensure all sensor streams are
+This node ensures that a predefined list of 
+required ROS 2 topics is active before continuing 
+execution. It is primarily used to synchronize 
+startup logic and ensure all sensor streams are
 publishing before other nodes depend on them.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODE: topic_waiter
 TOPICS:
-  - /oak/rgbd/image_raw [sensor_msgs/msg/Image]
-  - /bootie/rgbd/image_raw [sensor_msgs/msg/Image]
-  - /oak/rgb/image_raw [sensor_msgs/msg/Image]
-  - /oak/stereo/image_raw [sensor_msgs/msg/Image]
-  - /oak/rgb/camera_info [sensor_msgs/msg/CameraInfo]
-  - /bootie/rgb/image_raw [sensor_msgs/msg/Image]
-  - /bootie/stereo/image_raw [sensor_msgs/msg/Image]
-  - /bootie/rgb/camera_info [sensor_msgs/msg/CameraInfo]
+  - /oak/rgbd/image_raw         [sensor_msgs/msg/Image]
+  - /bootie/rgbd/image_raw      [sensor_msgs/msg/Image]
+  - /oak/rgb/image_raw          [sensor_msgs/msg/Image]
+  - /oak/stereo/image_raw       [sensor_msgs/msg/Image]
+  - /oak/rgb/camera_info        [sensor_msgs/msg/CameraInfo]
+  - /bootie/rgb/image_raw       [sensor_msgs/msg/Image]
+  - /bootie/stereo/image_raw    [sensor_msgs/msg/Image]
+  - /bootie/rgb/camera_info     [sensor_msgs/msg/CameraInfo]
 SERVICES: None
 ACTIONS: None
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
+++ b/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
@@ -55,12 +55,13 @@ class TopicWaiter(Node):
         self.start_time = time.time()
 
     def all_topics_active(self):
-        available_topics = [t.name for t in self.get_topic_names_and_types()]
+        available_topics = [t[0] for t in self.get_topic_names_and_types()]
         return all(topic in available_topics for topic in REQUIRED_TOPICS)
 
     def spin_until_ready(self):
         self.get_logger().info(f"Waiting for required topics: {REQUIRED_TOPICS}")
         while rclpy.ok():
+            rclpy.spin_once(self, timeout_sec=CHECK_INTERVAL)
             if self.all_topics_active():
                 self.get_logger().info("All required topics are active.")
                 return True

--- a/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
+++ b/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
@@ -1,3 +1,31 @@
+#!/usr/bin/python3
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+This node ensures that a predefined list of required ROS 2 topics
+is active before continuing execution. It is primarily used to
+synchronize startup logic and ensure all sensor streams are
+publishing before other nodes depend on them.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NODE: topic_waiter
+TOPICS:
+  - /oak/rgbd/image_raw [sensor_msgs/msg/Image]
+  - /bootie/rgbd/image_raw [sensor_msgs/msg/Image]
+  - /oak/rgb/image_raw [sensor_msgs/msg/Image]
+  - /oak/stereo/image_raw [sensor_msgs/msg/Image]
+  - /oak/rgb/camera_info [sensor_msgs/msg/CameraInfo]
+  - /bootie/rgb/image_raw [sensor_msgs/msg/Image]
+  - /bootie/stereo/image_raw [sensor_msgs/msg/Image]
+  - /bootie/rgb/camera_info [sensor_msgs/msg/CameraInfo]
+SERVICES: None
+ACTIONS: None
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+AUTHOR(S):	Chetan Karthik Edupalli
+CREATION:	26/09/2025
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data

--- a/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
+++ b/src/ros/rover/auto/auto_bringup/topic/wait_for_topic.py
@@ -1,0 +1,58 @@
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from rclpy.parameter import Parameter
+import sys
+import time
+
+
+REQUIRED_TOPICS = [
+    '/oak/rgbd/image_raw',
+    '/bootie/rgbd/image_raw',
+    '/oak/rgb/image_raw',
+    '/oak/stereo/image_raw',
+    '/oak/rgb/camera_info',
+    '/bootie/rgb/image_raw',
+    '/bootie/stereo/image_raw',
+    '/bootie/rgb/camera_info',
+]
+
+CHECK_INTERVAL = 1.0  # seconds
+TIMEOUT = 10  # seconds to give up
+
+
+class TopicWaiter(Node):
+    def __init__(self):
+        super().__init__('topic_waiter')
+        self.start_time = time.time()
+
+    def all_topics_active(self):
+        available_topics = [t.name for t in self.get_topic_names_and_types()]
+        return all(topic in available_topics for topic in REQUIRED_TOPICS)
+
+    def spin_until_ready(self):
+        self.get_logger().info(f"Waiting for required topics: {REQUIRED_TOPICS}")
+        while rclpy.ok():
+            if self.all_topics_active():
+                self.get_logger().info("All required topics are active.")
+                return True
+            if (time.time() - self.start_time) > TIMEOUT:
+                self.get_logger().error("Timed out waiting for topics.")
+                return False
+            time.sleep(CHECK_INTERVAL)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = TopicWaiter()
+
+    success = node.spin_until_ready()
+    node.destroy_node()
+    rclpy.shutdown()
+
+    if not success:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
everything.launch.py now runs rtabmap :partying_face: 


<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->
This has been a know issue that rtabmap must be run before other stack runs
## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

We now run `ros2 launch auto_bringup everything.launch.py rtabmap:=true` to enable rtabmap (this disables gps). 
everything.launch.py checks for topics published by rtabmap before starting other launch files in the stack.

To run using gps mode, just remove the rtabmap argument from the command, so that would be `ros2 launch auto_bringup everything.launch.py`

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes
<img width="597" height="720" alt="image" src="https://github.com/user-attachments/assets/67884fb9-1947-4dfd-8d8b-4b3da4b6f524" />

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:autonomous;tag:ready_for_review
<!-- TAGS END -->
