### PR TITLE
hotfix until electrical increases pivot limits

### DIFF
--- a/src/ros/rover/drive/drive_controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
+++ b/src/ros/rover/drive/drive_controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
@@ -111,6 +111,9 @@ Commands PivotDriveController::twist_to_commands(
         previous_speeds_, period.seconds());
     }
 
+    // hotfix until electrical increases pivot limits
+    turning_radius = std::clamp(turning_radius, -0.001, 0.001);
+
     // To ensure better intended movement in autonomous mode, we wait for the pivots to reach
     // the desired angle before moving. Lenience may be adjusted by pivot_rate_tolerance.
     const auto& prev_positions =

--- a/src/ros/rover/drive/drive_controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
+++ b/src/ros/rover/drive/drive_controllers/pivot_drive_controller/src/pivot_drive_controller.cpp
@@ -111,6 +111,7 @@ Commands PivotDriveController::twist_to_commands(
         previous_speeds_, period.seconds());
     }
 
+    // TODO: DELETE THIS
     // hotfix until electrical increases pivot limits
     turning_radius = std::clamp(turning_radius, -0.001, 0.001);
 


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
There is currently a miniscule (think 8th or 10th decimal point) inaccuracy between the pivot offset defined in the hardware interfaces and the actual pivot offset IRL, which causes the pivots IRL to flip 180 degrees back to stay within limits when sent a full left/right turn (turning radius = 0).

The calculations in the drive code should actually be correct, this is a temporary hotfix until electrical increases the pivot limits. When that happens, this line should be removed.


<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
