### PR TITLE
feat: Initial active control modes in teleop modular

### DIFF
--- a/nixfiles/revisions.json
+++ b/nixfiles/revisions.json
@@ -12,7 +12,7 @@
     "hash": "sha256-q2xrIUD+kgyxGXp6oi7QW0QzxL6PsOODRoj/ru9P9ig="
   }, 
   "teleop-modular": {
-    "rev": "fd02354c526198772e2642dcd61582b3b5e7dad5",
-    "hash": "sha256-PlIyAx2POHvmPyQLSQpjMaJlWqTVP1lMxApTNp1Va2c="
+    "rev": "e92074160803a4aa8ab5c09d22f0dcdf32d94189",
+    "hash": "sha256-NNBcbZr5ESMN1uFhNAWm1Y2LYc2MCVDd0Z25Bkkykq8="
   }
 }

--- a/src/ros/rover/arm/teleop_arm/params/teleop.yaml
+++ b/src/ros/rover/arm/teleop_arm/params/teleop.yaml
@@ -24,11 +24,14 @@ teleop_arm:
         - task_space_mode
 
       joint_space_mode:
+        display_name: "Joint Space"
         type: "joint_space_control_mode/JointSpaceControlMode"
+        active: true
         controllers:
           - "nova_arm_velocity_controller"
 
       task_space_mode:
+        display_name: "Task Space (IK)"
         type: "teleop_modular_twist/TwistControlMode"
         controllers:
           - "nova_twistmapper"
@@ -53,7 +56,6 @@ teleop_arm:
       enter_joint_space:
         on_any:
           - "task_space/up"
-          - "start"
         type: switch_control_mode
         activate:
           - "joint_space_mode"
@@ -61,7 +63,9 @@ teleop_arm:
           - "task_space_mode"
 
       lock:
-        on_any: ["lock/down", "start"]
+        on_any:
+          - "lock/down"
+          - "start"
         type: set_button
         name: "locked"
         value: true


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Very simple change. Allows you to specify the teleop_node.control_modes.<<name>>.active param when declaring control modes to make them start up as active.

Additionally allows for a display name to be provided, with more comprehensive logging for control mode switching

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:arm;tag:control
<!-- TAGS END -->
