### PR TITLE
fix: nova-git-metadata: don't make builds fail without .git

### DIFF
--- a/nixfiles/modules/home/macros/launch/default.nix
+++ b/nixfiles/modules/home/macros/launch/default.nix
@@ -172,6 +172,10 @@ in
     buildInputs = [pkgs.git];
     buildPhase = ''
       mkdir -p $out
+      if [ ! -d .git ]; then
+        echo "Not a git repository." > $out/nova-git-metadata
+        exit 0
+      fi
       echo -e "Checking git status at $(basename `git rev-parse --show-toplevel`)"
       GIT_COMMIT=$(git rev-parse HEAD)
       GIT_DATE=$(git show -s --format=%ci HEAD)


### PR DESCRIPTION
When hydra tries to build this it fails because .git is missing. This means hydra doesn't build this and the final workspace package.

Check if .git is missing and if so then just fail silently to ensure it doesn't break the build.

see also: https://github.com/MonashNovaRover/nova/pull/735#discussion_r2442434487

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:bug;tag:software;tag:ci/cd;tag:ready_for_review
<!-- TAGS END -->
