### PR TITLE
Fix: can_slueth crash less on resize terminal

### DIFF
--- a/src/other/can_sleuth/can_sleuth/main.py
+++ b/src/other/can_sleuth/can_sleuth/main.py
@@ -17,7 +17,7 @@ import sys
 if __name__ == "__main__":
     # ensure we can run this from the git tree
     import os
-    sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0,os.path.join(os.path.dirname(__file__), ".."))
 
 from can_sleuth import manager
 from can_sleuth import systems

--- a/src/other/can_sleuth/can_sleuth/outputs/tui.py
+++ b/src/other/can_sleuth/can_sleuth/outputs/tui.py
@@ -18,7 +18,6 @@ from . import output
 class TUI(output.Output):
     """A Terminal User Interface for rendering the state of the system.
     """
-    # TODO: sometimes we crash when the terminal is resized. I think it tries to draw stuff at locations that no longer exist.
     # TODO: need to make sure we don't hide error messages by accident by clearing the screen when we exit
 
     def __init__(self):
@@ -53,16 +52,21 @@ class TUI(output.Output):
         char = None
         for dev in devices:
             win = windows[dev]
+            if win is None:
+                continue # terminal is too small to show this window
 
-            win.box()
-            win.addstr(0,1,f"<{dev.getName()}>")
-            height = 1
-            for attr in dev.attrs:
-                # TODO: proper support for multiline attrs
-                # we limit the string to the width of the box minus the border (-2)
-                win.addnstr(height, 1, f"{attr.name}: {attr.value()}{attr.units}"+" "*attr.width, win.getmaxyx()[1]-2)
-                height += attr.height
-            win.refresh()
+            try:
+                win.box()
+                win.addstr(0,1,f"<{dev.getName()}>")
+                height = 1
+                for attr in dev.attrs:
+                    # TODO: proper support for multiline attrs
+                    # we limit the string to the width of the box minus the border (-2)
+                    win.addnstr(height, 1, f"{attr.name}: {attr.value()}{attr.units}"+" "*attr.width, win.getmaxyx()[1]-2)
+                    height += attr.height
+                win.refresh()
+            except curses.error:
+                continue # window was probably resized
 
         self._stdscr.refresh()
         try:
@@ -97,8 +101,11 @@ class TUI(output.Output):
                 x = nextX
                 y = startHeight
 
-            sub = screen.subpad(height,width, y, x)
-            windows[dev] = sub
+            try:
+                sub = screen.subpad(height,width, y, x)
+                windows[dev] = sub
+            except:
+                windows[dev] = None
             y += height
             nextX = max(nextX, width+x)
         return windows


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

catch errors caused by unexpected window resize for can slueth. This means it should no longer crash when you resize your terminal.

also a small fix for running from the git tree, before when you run the main script from the git tree although we added the git copy to the python path, any copy existing in the system python path would be found first, we just insert ourselves to the start of the path instead of the end to fix this.

The screen is never cleared tho, so sometimes after resize there's stuff left in the background.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

`can start vcan1`
`~/nova/src/other/can_sleuth/can_sleuth/main.py taipan`
resize your terminal aggressively 

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
best termnal shape
<img width="5806" height="411" alt="image" src="https://github.com/user-attachments/assets/017cb197-84a1-4d58-b3be-1ee06f357117" />

<!-- Absence of Memes and Experiences will be frowned upon-->
