### PR TITLE
Feat: can_sleuth battery

### DIFF
--- a/src/other/can_sleuth/README.md
+++ b/src/other/can_sleuth/README.md
@@ -47,7 +47,7 @@ Devices
 - LED Driver (not implemented)
 - Kiln (not implemented)
 - Misc Science stuff (not implemented)
-- Battery (not implemented)
+- Battery
 
 Systems (payloads):
 - Taipan Arm

--- a/src/other/can_sleuth/can_sleuth/devices/battery.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery.py
@@ -20,24 +20,25 @@ class Battery(candevice.CanDevice):
     """Battery Tracer, shows the state of the battery on the canbus
     """
 
-    telemetry = {
-            0: (
-                ("V(Cell 1)", ">H", "mV", str),
-                ("V(Cell 2)", ">H", "mV", str),
-                ("V(Cell 3)", ">H", "mV", str),
-                ("V(Cell 4)", ">H", "mV", str)
-            ),
-            1: (
-                ("V(Cell 5)", ">H", "mV", str),
-                ("V(Cell 6)", ">H", "mV", str),
-                ("V(Cell 7)", ">H", "mV", str),
-                ("V(Cell 8)", ">H", "mV", str)
-            ),
-            2: (
-                ("I(Peak)", ">h", "mA", lambda x: str(x*10)), # centi-amps to mili-amps
-                ("V(Peak)", ">H", "mV", str)
-            )
-            }
+    def telemetry(self, idNumber):
+        return {
+                (0x400 | idNumber << 4): (
+                    ("V(Cell 1)", ">H", "mV", str),
+                    ("V(Cell 2)", ">H", "mV", str),
+                    ("V(Cell 3)", ">H", "mV", str),
+                    ("V(Cell 4)", ">H", "mV", str)
+                ),
+                (0x401 | idNumber << 4): (
+                    ("V(Cell 5)", ">H", "mV", str),
+                    ("V(Cell 6)", ">H", "mV", str),
+                    ("V(Cell 7)", ">H", "mV", str),
+                    ("V(Cell 8)", ">H", "mV", str)
+                ),
+                (0x402 | idNumber << 4): (
+                    ("I(Peak)", ">h", "mA", lambda x: str(x*10)), # centi-amps to mili-amps
+                    ("V(Peak)", ">H", "mV", str)
+                )
+                }
 
     # TODO: 4B3 and 0B3 for the shutdown handshake
 
@@ -50,18 +51,8 @@ class Battery(candevice.CanDevice):
         """
 
         # we match telemetry from the battery, and the shutdown handshake ids
-        self.id = idNumber
-        super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4);
+        super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=idNumber<<4, telemetry=self.telemetry(idNumber))
 
-        for telemIdNumber in Battery.telemetry:
-            fields = []
-            for name, fmt, units, toReadable in Battery.telemetry[telemIdNumber]:
-                fields.append(device.Device.SimpleBytesAttribute(fmt, name, toReadable, units))
-
-            # I can still hear my FIT2099 TA telling me off
-            candevice.CanDevice.SimpleCANMessageHandler(
-                    self, 0x400 | (self.id << 4) | telemIdNumber, fields
-                    )
 
     def update(self):
         pass

--- a/src/other/can_sleuth/can_sleuth/devices/battery.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery.py
@@ -1,0 +1,71 @@
+'''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Can Sleuth / Simulator
+
+Nova Battery Tracer
+
+See also: https://www.notion.so/MNR-CANBUS-Standards-9dc47508ed3e4dfda2aa9ae97fe1ad54
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+EDITED BY: Orlando Chamberlain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+from . import candevice
+from . import device
+
+class Battery(candevice.CanDevice):
+    """Battery Tracer, shows the state of the battery on the canbus
+    """
+
+
+    # all 16 bit integers
+    telemetry = {
+            0: (
+                ("V(Cell 1)", ">H", "mV", str),
+                ("V(Cell 2)", ">H", "mV", str),
+                ("V(Cell 3)", ">H", "mV", str),
+                ("V(Cell 4)", ">H", "mV", str)
+            ),
+            1: (
+                ("V(Cell 5)", ">H", "mV", str),
+                ("V(Cell 6)", ">H", "mV", str),
+                ("V(Cell 7)", ">H", "mV", str),
+                ("V(Cell 8)", ">H", "mV", str)
+            ),
+            2: (
+                ("I(Peak)", ">h", "mA", lambda x: str(x*10)), # centi-amps to mili-amps
+                ("V(Peak)", ">H", "mV", str)
+            )
+            }
+
+    # TODO: 4B3 and 0B3 for the shutdown handshake
+
+    def __init__(self, name="Battery", idNumber=0xB, interface="can0"):
+        """Create the Battery sniffer
+
+        :param name: Display name of the battery
+        :param idNumber: the id of this battery
+        :param interface: the name of the canbus this blcmd is on
+        """
+
+        # we match both commands to the battery and telemetry/errors coming back
+        self.id = idNumber
+        super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4);
+
+        for telemIdNumber in Battery.telemetry:
+            fields = []
+            for name, fmt, units, toReadable in Battery.telemetry[telemIdNumber]:
+                fields.append(device.Device.SimpleBytesAttribute(fmt, name, toReadable, units))
+
+            # I can still hear my FIT2099 TA telling me off
+            candevice.CanDevice.SimpleCANMessageHandler(
+                    self, 0x400 | (self.id << 4) | telemIdNumber, fields
+                    )
+
+    def update(self):
+        pass
+
+

--- a/src/other/can_sleuth/can_sleuth/devices/battery.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery.py
@@ -21,22 +21,23 @@ class Battery(candevice.CanDevice):
     """
 
     def telemetry(self, idNumber):
+        strPadded = lambda width: lambda x: str(x).ljust(width)
         return {
                 (0x400 | idNumber << 4): (
-                    ("V(Cell 1)", ">H", "mV", str),
-                    ("V(Cell 2)", ">H", "mV", str),
-                    ("V(Cell 3)", ">H", "mV", str),
-                    ("V(Cell 4)", ">H", "mV", str)
+                    ("V(Cell 1)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 2)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 3)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 4)", ">H", "mV", strPadded(4))
                 ),
                 (0x401 | idNumber << 4): (
-                    ("V(Cell 5)", ">H", "mV", str),
-                    ("V(Cell 6)", ">H", "mV", str),
-                    ("V(Cell 7)", ">H", "mV", str),
-                    ("V(Cell 8)", ">H", "mV", str)
+                    ("V(Cell 5)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 6)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 7)", ">H", "mV", strPadded(4)),
+                    ("V(Cell 8)", ">H", "mV", strPadded(4))
                 ),
                 (0x402 | idNumber << 4): (
-                    ("I(Peak)", ">h", "mA", lambda x: str(x*10)), # centi-amps to mili-amps
-                    ("V(Peak)", ">H", "mV", str)
+                    ("I(Peak)", ">h", "mA", lambda x: strPadded(4)(x*10)), # centi-amps to mili-amps
+                    ("V(Peak)", ">H", "mV", strPadded(4))
                 )
                 }
 

--- a/src/other/can_sleuth/can_sleuth/devices/battery.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery.py
@@ -20,8 +20,6 @@ class Battery(candevice.CanDevice):
     """Battery Tracer, shows the state of the battery on the canbus
     """
 
-
-    # all 16 bit integers
     telemetry = {
             0: (
                 ("V(Cell 1)", ">H", "mV", str),
@@ -47,11 +45,11 @@ class Battery(candevice.CanDevice):
         """Create the Battery sniffer
 
         :param name: Display name of the battery
-        :param idNumber: the id of this battery
-        :param interface: the name of the canbus this blcmd is on
+        :param idNumber: the can id of this battery
+        :param interface: the name of the canbus this battery is on
         """
 
-        # we match both commands to the battery and telemetry/errors coming back
+        # we match telemetry from the battery, and the shutdown handshake ids
         self.id = idNumber
         super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4);
 

--- a/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
@@ -44,6 +44,7 @@ class BatteryEmulator(candevice.CanDevice):
         for telemId in battery.Battery.telemetry:
             bytes_ = b''
             for i, (name, fmt, units, toReadable) in enumerate(battery.Battery.telemetry[telemId]):
+                # create some values that vary over time
                 val = (10+i*100+(self.state*i))
                 bytes_ += struct.pack(fmt, val)
 

--- a/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
@@ -1,0 +1,54 @@
+'''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Can Sleuth / Simulator
+
+Nova Battery Emulator
+
+See also: https://www.notion.so/MNR-CANBUS-Standards-9dc47508ed3e4dfda2aa9ae97fe1ad54
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+EDITED BY: Orlando Chamberlain
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+from . import candevice
+from . import device
+from . import battery
+
+import struct
+
+class BatteryEmulator(candevice.CanDevice):
+    """Battery Emulator
+    """
+    # TODO: 4B3 and 0B3 for the shutdown handshake
+
+    def __init__(self, name="Battery", idNumber=0xB, interface="can0"):
+        """Create the Battery sniffer
+
+        :param name: Display name of the battery
+        :param idNumber: the id of this battery
+        :param interface: the name of the canbus this blcmd is on
+        """
+
+        # we match only the shut down confirmed message from the jetson.
+        self.id = idNumber
+        self.state = 0
+        super().__init__(name, interface , canIdMask=0xfff, canIdMatch=(self.id<<4)|0x3);
+
+
+    def update(self):
+        self.state = (self.state+1)%100
+
+        for telemId in battery.Battery.telemetry:
+            bytes_ = b''
+            for i, (name, fmt, units, toReadable) in enumerate(battery.Battery.telemetry[telemId]):
+                val = (10+i*100+(self.state*i))
+                bytes_ += struct.pack(fmt, val)
+
+            self.sendFrame(0x400| self.id << 4 | telemId, list(bytes_))
+
+
+
+

--- a/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
+++ b/src/other/can_sleuth/can_sleuth/devices/battery_emulator.py
@@ -41,9 +41,9 @@ class BatteryEmulator(candevice.CanDevice):
     def update(self):
         self.state = (self.state+1)%100
 
-        for telemId in battery.Battery.telemetry:
+        for telemId in battery.Battery.telemetry(None, self.id):
             bytes_ = b''
-            for i, (name, fmt, units, toReadable) in enumerate(battery.Battery.telemetry[telemId]):
+            for i, (name, fmt, units, toReadable) in enumerate(battery.Battery.telemetry(None,self.id)[telemId]):
                 # create some values that vary over time
                 val = (10+i*100+(self.state*i))
                 bytes_ += struct.pack(fmt, val)

--- a/src/other/can_sleuth/can_sleuth/devices/blcmd.py
+++ b/src/other/can_sleuth/can_sleuth/devices/blcmd.py
@@ -52,26 +52,6 @@ class BLCMD(candevice.CanDevice):
         self.lastCommand = BLCMD.commands[commandNumber]["name"] \
                 + str(BLCMD.commands[commandNumber]["fmt"](frame.data))
 
-    telemetry = {
-            1: (
-                ("velocity", ">H", "", None),
-                ("Qcurrent", ">H", "", None)
-            ),
-            2: (
-                ("interval", ">H", "", None),
-                ("Dcurrent", ">H", "", None)
-            ),
-            3: (
-                ("resolverPosition", ">h", "°", lambda x: f"{x*360/0x10000:+03.2f}"),
-                ("resolverTurns", ">h", "", None) # only correct for multiturn!
-            ),
-            4: (
-                ("power", ">H", "", None),
-                ("voltage", ">H", "", None),
-                ("temperature", ">H", "", None),
-                ("current", ">H", "", None),
-            ),
-            }
 
     errorCodes = {
            0: "NO_STEPS",
@@ -87,26 +67,16 @@ class BLCMD(candevice.CanDevice):
             10:"STALL_TRIGGERED",
             11:"OVER_SPEED",
     }
-    def _errCb(self, frame):
-        """process errors on can
-        """
-        if (len(frame.data) != 2):
-            return
 
-        match frame.data[0]:
-            case 0:
-                level = "ERR "
-            case 1:
-                level = "WARN"
-            case 2:
-                level = "INFO"
-            case 3:
-                level = "GATE"
+    errorLevels = {
+            0: "ERR ",
+            1: "WARN",
+            2: "INFO",
+            3: "GATE"
+            }
 
-        message = self.errorCodes.get(frame.data[1], frame.data[1])
-        self.error = f"{level}: {message}"
 
-    def __init__(self, name, idNumber, interface):
+    def __init__(self, name, idNumber, interface, multiturn=False):
         """Create the BLCMD sniffer
 
         :param name: Display name of the blcmd
@@ -116,30 +86,53 @@ class BLCMD(candevice.CanDevice):
 
         # we match both commands to the blcmd and telemetry/errors coming back
         self.id = idNumber
-        super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4);
+
+        if multiturn:
+            telem3 = (
+                ("resolverPosition", ">h", "°", lambda x: f"{x*360*4/0x10000:+03.2f}"),
+                ("resolverTurns", ">h", "", None)
+            )
+        else:
+            telem3 = (
+                ("resolverPosition", ">h", "°", lambda x: f"{x*360/0x10000:+03.2f}"),
+                ("resolverVelocity", ">h", "", None)
+            )
+
+        # telemetry from the blcmd
+        telemetry = {
+                (0x400 | self.id << 4): (
+                    ("err", "BB", "", lambda x:
+                     f"{self.errorLevels.get(x[0],str(x[0]))} {self.errorCodes.get(x[1],str(x[1]))}"
+                     ),
+                ),
+                (0x401 | self.id << 4): (
+                    ("velocity", ">H", "", None),
+                    ("Qcurrent", ">H", "", None),
+                ),
+                (0x402 | self.id << 4): (
+                    ("interval", ">H", "", None),
+                    ("Dcurrent", ">H", "", None),
+                ),
+                (0x403 | self.id << 4): telem3,
+                (0x404 | self.id << 4): (
+                    ("power", ">H", "", None),
+                    ("voltage", ">H", "", None),
+                    ("temperature", ">H", "", None),
+                    ("current", ">H", "", None),
+                ),
+            }
+
+        super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4, telemetry=telemetry);
 
         # Commands from the computer
         for cmd in BLCMD.commands.keys():
             canId = (self.id<<4) | cmd
             self.addCallback(canId, self._cmdCb)
 
-        # telemetry from the blcmd
-        for telemIdNumber in BLCMD.telemetry:
-            fields = []
-            for name, fmt, units, toReadable in BLCMD.telemetry[telemIdNumber]:
-                fields.append(self.SimpleBytesAttribute(fmt, name, toReadable, units))
 
-            # I can still hear my FIT2099 TA telling me off
-            self.SimpleCANMessageHandler(
-                    self, 0x400 | (self.id << 4) | telemIdNumber, fields
-                    )
 
         # TODO: trace get/set configuration messages on can
 
-        # errors from blcmd
-        self.error = None
-        self.registerAttr("err", lambda: self.error, 25)
-        self.addCallback(0x400 | (self.id<<4), self._errCb);
 
         self.lastCommand = ""
         self.registerAttr("msg", lambda: self.lastCommand, 15)

--- a/src/other/can_sleuth/can_sleuth/devices/blcmd.py
+++ b/src/other/can_sleuth/can_sleuth/devices/blcmd.py
@@ -15,6 +15,8 @@ EDITED BY: Orlando Chamberlain
 
 from . import candevice
 
+import math
+
 def _toHex(x):
     if x:
         ret = "0x"
@@ -50,25 +52,26 @@ class BLCMD(candevice.CanDevice):
         self.lastCommand = BLCMD.commands[commandNumber]["name"] \
                 + str(BLCMD.commands[commandNumber]["fmt"](frame.data))
 
-    # all 16 bit integers
-    telemetryTypes = {
-            1: ["velocity", "Qcurrent"],
-            2: ["interval", "Dcurrent"],
-            3: ["resolverPosition", "resolverVelocity"],
-            4: ["power", "voltage", "temperature", "current"]
+    telemetry = {
+            1: (
+                ("velocity", ">H", "", None),
+                ("Qcurrent", ">H", "", None)
+            ),
+            2: (
+                ("interval", ">H", "", None),
+                ("Dcurrent", ">H", "", None)
+            ),
+            3: (
+                ("resolverPosition", ">h", "°", lambda x: f"{x*360/0x10000:+03.2f}"),
+                ("resolverTurns", ">h", "", None) # only correct for multiturn!
+            ),
+            4: (
+                ("power", ">H", "", None),
+                ("voltage", ">H", "", None),
+                ("temperature", ">H", "", None),
+                ("current", ">H", "", None),
+            ),
             }
-
-    def _telemCb(self, frame):
-        """process telemetry on can
-        """
-        telemetryNumber = frame.id&0xf
-        labels = self.telemetryTypes[telemetryNumber]
-        if len(frame.data) == len(labels)*2:
-            for i, label in enumerate(labels):
-                # TODO: I think this is wrong for negative integers
-                #self.telemetry[label] = frame.data[2*i]*0xff + frame.data[2*i+1]
-                self.telemetry[label] = hex(0x10000+frame.data[2*i]*0xff + frame.data[2*i+1])[3:]
-
 
     errorCodes = {
            0: "NO_STEPS",
@@ -114,7 +117,6 @@ class BLCMD(candevice.CanDevice):
         # we match both commands to the blcmd and telemetry/errors coming back
         self.id = idNumber
         super().__init__(name, interface , canIdMask=0xbf0, canIdMatch=self.id<<4);
-        self.telemetry = {}
 
         # Commands from the computer
         for cmd in BLCMD.commands.keys():
@@ -122,14 +124,15 @@ class BLCMD(candevice.CanDevice):
             self.addCallback(canId, self._cmdCb)
 
         # telemetry from the blcmd
-        for type_ in self.telemetryTypes.keys():
-            canId = 0x400 | (self.id<<4) | type_
-            for label in self.telemetryTypes[type_]:
-                self.telemetry[label]=None
-                def telemAttrGetter(label):
-                    return lambda: self.telemetry[label]
-                self.registerAttr(label, telemAttrGetter(label), 5)
-            self.addCallback(canId, self._telemCb)
+        for telemIdNumber in BLCMD.telemetry:
+            fields = []
+            for name, fmt, units, toReadable in BLCMD.telemetry[telemIdNumber]:
+                fields.append(self.SimpleBytesAttribute(fmt, name, toReadable, units))
+
+            # I can still hear my FIT2099 TA telling me off
+            self.SimpleCANMessageHandler(
+                    self, 0x400 | (self.id << 4) | telemIdNumber, fields
+                    )
 
         # TODO: trace get/set configuration messages on can
 

--- a/src/other/can_sleuth/can_sleuth/devices/blcmd_emulator.py
+++ b/src/other/can_sleuth/can_sleuth/devices/blcmd_emulator.py
@@ -22,7 +22,7 @@ from . import candevice
 class BLCMDEmulator(candevice.CanDevice):
     """BLCMD Emulator class
     """
-    def __init__(self, name, id_, bus, hasResolver=True):
+    def __init__(self, name, id_, bus, hasResolver=True, multiturn=False):
         """Create a BLCMD emulator
 
         :param name: Display name for this blcmd
@@ -54,6 +54,8 @@ class BLCMDEmulator(candevice.CanDevice):
         self.hasResolver = int(bool(hasResolver)) # ensure this is 0 or 1
         self.minInterval = 122 # I don't know what this physically means
 
+        self.multiturn = multiturn
+
         # in radians, corresponding to 0x8000
         self.max_pos = 4*math.pi; 
         self.max_vel = 2*math.pi;
@@ -77,13 +79,17 @@ class BLCMDEmulator(candevice.CanDevice):
         """
         data = []
         pos = int(0x8000 * self.pos / self.max_pos)
-        turns = (pos << 2) % 0xffff
-        # TODO: I think this format is for multiturn, im not sure if it is correct for
-        # blcmds without https://github.com/MonashNovaRover/pics/commit/24fc219b7e7aa04ab15c95b6f487e0b8a9c38043
         data.append((pos >> 8) & 0xff)
         data.append(pos & 0xff)
-        data.append((turns >> 8 ) & 0xff)
-        data.append(turns & 0xff)
+        if (self.multiturn):
+            turns = (pos << 2) % 0xffff
+            data.append((turns >> 8 ) & 0xff)
+            data.append(turns & 0xff)
+        else:
+            vel = int(0x8000 * self.vel / self.max_vel)
+            data.append((vel >> 8 ) & 0xff)
+            data.append(vel & 0xff)
+
         self.send_message(3, data, 4)
 
     def update(self):

--- a/src/other/can_sleuth/can_sleuth/devices/blcmd_emulator.py
+++ b/src/other/can_sleuth/can_sleuth/devices/blcmd_emulator.py
@@ -61,8 +61,8 @@ class BLCMDEmulator(candevice.CanDevice):
         self.registerAttr("Pos", lambda:f"{360*self.pos/(2*math.pi) :+06.1f}", 6, units="°")
         self.registerAttr("Vel", lambda:f"{360*self.vel/(2*math.pi) :+06.1f}", 6, units="°/s")
 
-    def telem3(self):
-        """Send telemetry message 3
+    def telem1(self):
+        """Send telemetry message 1
         """
         data = []
         vel = int(0x8000 * self.vel / self.max_vel)
@@ -70,14 +70,10 @@ class BLCMDEmulator(candevice.CanDevice):
         data.append(vel & 0xff)
         data.append(0) # TODO: Qcurrent
         data.append(0)
-        # ??? why do the telem ids need to be swapped
-        # the blcmd hardware code doesn't look like it
-        # would be swapped, and yet when I log what each
-        # telem callback gets, it has it swapped...
         self.send_message(1, data, 4)
 
-    def telem1(self):
-        """Send telemetry message 1
+    def telem3(self):
+        """Send telemetry message 3
         """
         data = []
         pos = int(0x8000 * self.pos / self.max_pos)

--- a/src/other/can_sleuth/can_sleuth/devices/candevice.py
+++ b/src/other/can_sleuth/can_sleuth/devices/candevice.py
@@ -45,6 +45,24 @@ class CanDevice(device.Device):
 
         self.bus.open(interface)
 
+    class SimpleCANMessageHandler():
+        def __init__(self, canDevice, canId, fields: List[device.Device.SimpleBytesAttribute]):
+            self._fields = fields
+            for field in self._fields:
+                # I am filled with regret and I can hear my FIT2099 TA shouting at me.
+                canDevice.attrs.append(field)
+
+            canDevice.addCallback(canId, self.onMsg)
+
+        def onMsg(self, frame):
+            position = 0
+            for field in self._fields:
+                length = field.getByteLength()
+                field.updateBytesValue(
+                        bytes(frame.data[position:position+length])
+                    )
+                position += length
+
     def addCallback(self, canId, callback):
         """Add a callback function for a specific CAN ID
 

--- a/src/other/can_sleuth/can_sleuth/devices/candevice.py
+++ b/src/other/can_sleuth/can_sleuth/devices/candevice.py
@@ -46,7 +46,17 @@ class CanDevice(device.Device):
         self.bus.open(interface)
 
     class SimpleCANMessageHandler():
+        """Helper for processing telemetry messages from can devices
+        """
         def __init__(self, canDevice, canId, fields: List[device.Device.SimpleBytesAttribute]):
+            """
+
+            :param canDevice: the CanDevice that this telemetry message belongs to
+            :param canId: the can id for this telemetry message
+            :param fields: one attribute for every value represented by the payload of this can message
+            construct these with whatever integer size and signed/unsigned and unit conversions as per
+            whatever the can device does.
+            """
             self._fields = fields
             for field in self._fields:
                 # I am filled with regret and I can hear my FIT2099 TA shouting at me.
@@ -55,6 +65,9 @@ class CanDevice(device.Device):
             canDevice.addCallback(canId, self.onMsg)
 
         def onMsg(self, frame):
+            """Callback for when we recieve a can message. We split the message's payload up and
+            send each section of bytes to the respective SimpleBytesAttribute
+            """
             position = 0
             for field in self._fields:
                 length = field.getByteLength()

--- a/src/other/can_sleuth/can_sleuth/devices/candevice.py
+++ b/src/other/can_sleuth/can_sleuth/devices/candevice.py
@@ -18,7 +18,7 @@ from typing import List
 from . import device
 
 class CanDevice(device.Device):
-    def __init__(self, name, interface, canIdList=None, canIdMask=None, canIdMatch=None):
+    def __init__(self, name, interface, canIdList=None, canIdMask=None, canIdMatch=None, telemetry={}):
         """Create the can device
 
         :param name: display name
@@ -33,6 +33,11 @@ class CanDevice(device.Device):
         Using a mask:
         :param canIdMask: bitmask for the CAN IDs you want to register callbacks for
         :param canIdMatch: what you want to match
+
+        :param telemetry: dictionary of canIdNumber: (name, fmt, units, toReadable or None).
+        fmt is for struct.unpack, units is str, toReadable is function that takes
+        the output of struct.unpack and makes it human readable or none if you just
+        want raw hex to be displayed.
         """
 
         super().__init__(name)
@@ -44,6 +49,16 @@ class CanDevice(device.Device):
             self.bus.set_id_filter_mask(canIdMatch, canIdMask)
 
         self.bus.open(interface)
+
+        for telemIdNumber in telemetry:
+            fields = []
+            for name, fmt, units, toReadable in telemetry[telemIdNumber]:
+                fields.append(self.SimpleBytesAttribute(name, fmt, units, toReadable))
+
+            # I can still hear my FIT2099 TA telling me off
+            CanDevice.SimpleCANMessageHandler(
+                    self, telemIdNumber, fields
+                    )
 
     class SimpleCANMessageHandler():
         """Helper for processing telemetry messages from can devices

--- a/src/other/can_sleuth/can_sleuth/devices/device.py
+++ b/src/other/can_sleuth/can_sleuth/devices/device.py
@@ -56,6 +56,8 @@ class Device(abc.ABC):
             super().__init__(name, self._getValue, outputWidth, self._getRaw, outputHeight, units)
 
         def updateBytesValue(self, bytesValue: bytes):
+            """update the binary (bytes) representation of this attribute
+            """
             self._bytesValue = bytesValue
             val = struct.unpack(self._bytesFmt, self._bytesValue)
             if len(val) == 1:

--- a/src/other/can_sleuth/can_sleuth/devices/device.py
+++ b/src/other/can_sleuth/can_sleuth/devices/device.py
@@ -32,7 +32,7 @@ class Device(abc.ABC):
         units: str = ""
 
     class SimpleBytesAttribute(Attribute):
-        def __init__(self, bytesFmt, name, toHumanReadable, units):
+        def __init__(self, name, bytesFmt, units, toHumanReadable):
             """Helper for making attributes where the data is in a binary format, unpacked and then converted to human units.
 
             bytesFmt: str, the meaning of these is explained here https://docs.python.org/3/library/struct.html#format-strings
@@ -47,12 +47,15 @@ class Device(abc.ABC):
 
             self._byteLength = struct.calcsize(self._bytesFmt)
 
-            self._bytesValue: bytes = bytes(self._byteLength)
-            self._unpackedValue: int = 0
+            self.updateBytesValue(bytes(self._byteLength)) # all zeros
 
             exampleOutput = self._getValue()
-            outputHeight = len(exampleOutput) # how many lines of text
-            outputWidth = max(map(len, exampleOutput)) # widest line of text
+            if isinstance(exampleOutput, str):
+                outputHeight = 1
+                outputWidth = len(exampleOutput)
+            else:
+                outputHeight = len(exampleOutput) # how many lines of text
+                outputWidth = max(map(len, exampleOutput)) # widest line of text
 
             self._bytesValue: bytes = None
             self._unpackedValue: int = None

--- a/src/other/can_sleuth/can_sleuth/devices/device.py
+++ b/src/other/can_sleuth/can_sleuth/devices/device.py
@@ -37,21 +37,25 @@ class Device(abc.ABC):
 
             bytesFmt: str, the meaning of these is explained here https://docs.python.org/3/library/struct.html#format-strings
             name: str, the attribute name
-            toHumanReadable: converter function from unpacked value to human readable value
+            toHumanReadable: converter function from unpacked value to human readable value or none if only raw hex works
             units str: units for this attribute
             """
 
             self._bytesFmt = bytesFmt
 
-            self._bytesValue: bytes = None
-            self._unpackedValue: int = None
             self._toHumanReadable = toHumanReadable # function returning list of strings?
 
             self._byteLength = struct.calcsize(self._bytesFmt)
 
-            exampleOutput = self._toHumanReadable(0)
+            self._bytesValue: bytes = bytes(self._byteLength)
+            self._unpackedValue: int = 0
+
+            exampleOutput = self._getValue()
             outputHeight = len(exampleOutput) # how many lines of text
             outputWidth = max(map(len, exampleOutput)) # widest line of text
+
+            self._bytesValue: bytes = None
+            self._unpackedValue: int = None
 
             super().__init__(name, self._getValue, outputWidth, self._getRaw, outputHeight, units)
 
@@ -71,11 +75,15 @@ class Device(abc.ABC):
             return self._byteLength
 
         def _getRaw(self):
-            return "0x"+self._bytesValue
+            if self._bytesValue is None:
+                return ""
+            return "0x"+self._bytesValue.hex()
 
         def _getValue(self):
             if self._unpackedValue is None:
                 return ""
+            if self._toHumanReadable is None:
+                return self._getRaw()
             return self._toHumanReadable(self._unpackedValue)
 
     def getName(self):

--- a/src/other/can_sleuth/can_sleuth/devices/device.py
+++ b/src/other/can_sleuth/can_sleuth/devices/device.py
@@ -12,6 +12,7 @@ EDITED BY: Orlando Chamberlain
 '''
 
 import abc
+import struct
 from dataclasses import dataclass
 
 class Device(abc.ABC):
@@ -29,6 +30,51 @@ class Device(abc.ABC):
         raw: object = lambda: None # function returning string
         height: int = 1
         units: str = ""
+
+    class SimpleBytesAttribute(Attribute):
+        def __init__(self, bytesFmt, name, toHumanReadable, units):
+            """Helper for making attributes where the data is in a binary format, unpacked and then converted to human units.
+
+            bytesFmt: str, the meaning of these is explained here https://docs.python.org/3/library/struct.html#format-strings
+            name: str, the attribute name
+            toHumanReadable: converter function from unpacked value to human readable value
+            units str: units for this attribute
+            """
+
+            self._bytesFmt = bytesFmt
+
+            self._bytesValue: bytes = None
+            self._unpackedValue: int = None
+            self._toHumanReadable = toHumanReadable # function returning list of strings?
+
+            self._byteLength = struct.calcsize(self._bytesFmt)
+
+            exampleOutput = self._toHumanReadable(0)
+            outputHeight = len(exampleOutput) # how many lines of text
+            outputWidth = max(map(len, exampleOutput)) # widest line of text
+
+            super().__init__(name, self._getValue, outputWidth, self._getRaw, outputHeight, units)
+
+        def updateBytesValue(self, bytesValue: bytes):
+            self._bytesValue = bytesValue
+            val = struct.unpack(self._bytesFmt, self._bytesValue)
+            if len(val) == 1:
+                self._unpackedValue = val[0]
+            else:
+                self._unpackedValue = val
+                
+
+        def getByteLength(self):
+            # Check how many bytes this attribute uses.
+            return self._byteLength
+
+        def _getRaw(self):
+            return "0x"+self._bytesValue
+
+        def _getValue(self):
+            if self._unpackedValue is None:
+                return ""
+            return self._toHumanReadable(self._unpackedValue)
 
     def getName(self):
         return self.name

--- a/src/other/can_sleuth/can_sleuth/systems.py
+++ b/src/other/can_sleuth/can_sleuth/systems.py
@@ -15,6 +15,7 @@ from can_sleuth.devices import blcmd
 from can_sleuth.devices import blcmd_emulator
 from can_sleuth.devices import led as LED #gotta rename some things
 from can_sleuth.devices import battery
+from can_sleuth.devices import battery_emulator
 
 # Interface specifies the bus (usually a canbus) that the system/payload is connected to,
 # emulate indicates if in addition to tracing the state of the system/payload, if we should
@@ -64,6 +65,8 @@ def drive25_26(interface="can0", emulate=False):
         for id_ in names.keys():
             hasResolver = names[id_][2] == "P" # only pivots have resolvers/abcoder
             devices.append(blcmd_emulator.BLCMDEmulator(names[id_], id_, interface, hasResolver=hasResolver))
+
+        devices.append(battery_emulator.BatteryEmulator(interface=interface))
     return devices
 
 def led(interface = "can0", emulate=False):

--- a/src/other/can_sleuth/can_sleuth/systems.py
+++ b/src/other/can_sleuth/can_sleuth/systems.py
@@ -25,12 +25,12 @@ def taipan_spherical(interface="can1", emulate=False):
     """The Taipan Arm Payload with its exciting four bar linkage and spherical wrist.
     """
     devices = [
-            blcmd.BLCMD(f"J{x}", x, interface) for x in range(1,6+1)
+            blcmd.BLCMD(f"J{x}", x, interface, multiturn=True) for x in range(1,6+1)
             ]
 
     if emulate:
         devices += [
-            blcmd_emulator.BLCMDEmulator(f"J{x}", x, interface) for x in range(1,6+1)
+            blcmd_emulator.BLCMDEmulator(f"J{x}", x, interface, multiturn=True) for x in range(1,6+1)
             ]
 
     return devices

--- a/src/other/can_sleuth/can_sleuth/systems.py
+++ b/src/other/can_sleuth/can_sleuth/systems.py
@@ -14,6 +14,7 @@ EDITED BY: Orlando Chamberlain
 from can_sleuth.devices import blcmd
 from can_sleuth.devices import blcmd_emulator
 from can_sleuth.devices import led as LED #gotta rename some things
+from can_sleuth.devices import battery
 
 # Interface specifies the bus (usually a canbus) that the system/payload is connected to,
 # emulate indicates if in addition to tracing the state of the system/payload, if we should
@@ -52,6 +53,10 @@ def drive25_26(interface="can0", emulate=False):
             }
 
     devices = []
+
+    devices.append(battery.Battery(interface=interface))
+
+    devices.extend(led(interface=interface, emulate=emulate))
 
     for id_ in names.keys():
         devices.append(blcmd.BLCMD(names[id_], id_, interface))


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

add battery to the can sleuth/sim

also refactor it a bit to make it easier to decode binary bytes from can messages into human readable data. We do this first by using struct.unpack, and then the user supplies a function that converts it to human text (simplest is just `str`)



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->


## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->
<img width="627" height="1883" alt="image" src="https://github.com/user-attachments/assets/d702c791-7a59-4076-ae97-82ce25e17467" />


## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

`can_sleuth -e taipan -e drive` there should be battery as well!

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

me when
<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
