### PR TITLE
Scimbal Cam GUI Improvements

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/CameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/CameraComponent.tsx
@@ -167,7 +167,7 @@ export const CameraComponent = (props: CameraComponentProps) => {
         {streamingState === StreamingState.LOADING && <Spinner />}
       </div>
 
-      <CardFooter className="absolute z-1 bottom-0 bg-gradient-to-t from-black/100 to-black/15">
+      <CardFooter className="absolute z-1 bottom-0 bg-gradient-to-t from-black/80 to-black/0">
         <div className="w-full flex flex-row justify-between px-1 items-center">
           <div className="text-lg font-semibold py-1">{cameraName}</div>
           {(isHovered || isSettingsOpen) && (

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useEffect } from "react";
 import { useBifrost } from "../../../../redux/actions/bifrost/useBifrostAction.ts";
 import { RosService } from "../../../../ros/services/rosService.ts";
 import OverlayedCameraComponent from "./OverlayedCameraComponent.tsx";
 import { BaseCameraComponentProps } from "../CameraComponent.tsx";
-import { Input, Tooltip } from "@nextui-org/react";
+import { Input, Tooltip, Switch } from "@nextui-org/react";
 import { useGenericStore } from "../../../../hooks/useGenericStore.ts";
 
 export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> = (props) => {
@@ -28,11 +28,14 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     responseToast: false
   }), [serviceBifrost]);
 
-
+  
   let clickAndHoldInterval: ReturnType<typeof setInterval>;
+  const [clickAndHoldEnabled, setClickAndHoldEnabled] = React.useState(false);
+  const [windowWideWASD, setWindowWideWASD] = React.useState(false);
 
   // Handle click and hold movement
   const handleClickandHoldDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    if (!clickAndHoldEnabled) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
@@ -58,7 +61,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     clearInterval(clickAndHoldInterval)
   }
 
-  // WASD Controls
+  // WASD Controls Component Wide
   const handleInput = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
     switch (e.key.toLowerCase()) {
       case 'a': incrementPan(-stepNumber); break;
@@ -67,6 +70,33 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
       case 's': incrementTilt(stepNumber); break;
     }
   }, [incrementPan, incrementTilt, stepNumber])
+
+  useEffect(() => {
+    if(!windowWideWASD) return;
+
+    const handleKey = (e: KeyboardEvent) => {
+    switch (e.key.toLowerCase()) {
+      case 'a':
+        incrementPan(-stepNumber); //negative pan is left
+        break;
+      case 'd':
+        incrementPan(stepNumber);//positive pan is right
+        break;
+      case 'w':
+        incrementTilt(-stepNumber);//negative tilt is up
+        break;
+      case 's':
+        incrementTilt(stepNumber);//positive tilt is down
+        break;
+      default:
+        break;
+    }
+  };
+  
+   
+    window.addEventListener('keyup', handleKey);
+  return () => window.removeEventListener('keyup', handleKey);
+  }, [incrementPan, incrementTilt, stepNumber, windowWideWASD]);
 
 
   const stepSizeInput = (
@@ -87,28 +117,42 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
           onValueChange={setStep}
         />
       </Tooltip>
+      <Switch
+        size="sm"
+        isSelected={clickAndHoldEnabled}
+        onValueChange={setClickAndHoldEnabled}
+      >
+        Enable Click & Hold
+      </Switch>
+      <Switch
+      size="sm"
+      isSelected={windowWideWASD}
+      onValueChange={setWindowWideWASD}
+    >
+      Enable Window Wide WASD
+    </Switch>
     </>
   )
 
   return (
     <div
       tabIndex={0}
-      onKeyDown={handleInput}
+      onKeyDown={windowWideWASD ? undefined : handleInput}
       onMouseDown={handleClickandHoldDown}
-          onMouseUp={handleClickandHoldRelease}
-          onMouseLeave={handleClickandHoldRelease}
-      
+      onMouseUp={handleClickandHoldRelease}
+      onMouseLeave={handleClickandHoldRelease}
+
     >
       <OverlayedCameraComponent
         {...props}
-        overlay={<div 
-          
+        overlay={<div
+
           onMouseDown={(e) => e.stopPropagation()}
-    onMouseUp={(e) => e.stopPropagation()}
-    onMouseLeave={(e) => e.stopPropagation()}
+          onMouseUp={(e) => e.stopPropagation()}
+          onMouseLeave={(e) => e.stopPropagation()}
         />}
         settingsFormChildren={stepSizeInput}
-        
+
       />
     </div>
   );

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -33,7 +33,9 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
   const clickAndHoldInterval = React.useRef<ReturnType<typeof setInterval> | null>(null);
   const [clickAndHoldEnabled, setClickAndHoldEnabled] = useGenericStore<boolean>("clickAndHold");
   const [windowWideWASD, setWindowWideWASD] = useGenericStore<boolean>("windowWideWASD");
-  const [hasFocus, setHasFocus] = React.useState(false);
+  
+
+
 
   // Handle click and hold movement
   const handleClickandHoldDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -66,7 +68,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     }
   };
 
-  const containerRef = React.useRef<HTMLDivElement | null>(null);
+
 
   // WASD Controls Component Wide
   const handleInput = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -105,13 +107,9 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     window.addEventListener('keyup', handleKey);
     return () => window.removeEventListener('keyup', handleKey);
   }, [incrementPan, incrementTilt, stepNumber, windowWideWASD]);
-  
-  useEffect(() => {
-    if (!windowWideWASD) {
-      containerRef.current?.blur();
-      setHasFocus(false);
-    }
-  }, [windowWideWASD]);
+
+
+
 
 
   const stepSizeInput = (
@@ -151,16 +149,18 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
 
   return (
     <div
-      ref={containerRef}
+
       tabIndex={0}
       onKeyDown={windowWideWASD ? undefined : handleInput}
-      onMouseDown={handleClickandHoldDown}
+      onMouseDown={(e) => {
+  
+        handleClickandHoldDown(e);
+      }}
       onMouseUp={handleClickandHoldRelease}
       onMouseLeave={handleClickandHoldRelease}
-      onFocus={() => setHasFocus(true)}
-      onBlur={() => setHasFocus(false)}
+
       style={
-        windowWideWASD || hasFocus
+        windowWideWASD 
           ? {
             outline: '2px solid #4da3ff',
             outlineOffset: '2px',
@@ -171,12 +171,9 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     >
       <OverlayedCameraComponent
         {...props}
-        overlay={<div
-
-        // onMouseDown={(_) => undefined}
-        // onMouseUp={( => e.stopPropagation()}
-        // onMouseLeave={(e) => e.stopPropagation()}
-        />}
+        overlay={
+          <div />
+        }
         settingsFormChildren={stepSizeInput}
 
       />

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -28,10 +28,11 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     responseToast: false
   }), [serviceBifrost]);
 
-  
+
   let clickAndHoldInterval: ReturnType<typeof setInterval>;
-  const [clickAndHoldEnabled, setClickAndHoldEnabled] = React.useState(false);
-  const [windowWideWASD, setWindowWideWASD] = React.useState(false);
+  const [clickAndHoldEnabled, setClickAndHoldEnabled] = useGenericStore<boolean>("clickAndHold");
+  const [windowWideWASD, setWindowWideWASD] = useGenericStore<boolean>("windowWideWASD");
+  const [hasFocus, setHasFocus] = React.useState(false);
 
   // Handle click and hold movement
   const handleClickandHoldDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -72,30 +73,30 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
   }, [incrementPan, incrementTilt, stepNumber])
 
   useEffect(() => {
-    if(!windowWideWASD) return;
+    if (!windowWideWASD) return;
 
     const handleKey = (e: KeyboardEvent) => {
-    switch (e.key.toLowerCase()) {
-      case 'a':
-        incrementPan(-stepNumber); //negative pan is left
-        break;
-      case 'd':
-        incrementPan(stepNumber);//positive pan is right
-        break;
-      case 'w':
-        incrementTilt(-stepNumber);//negative tilt is up
-        break;
-      case 's':
-        incrementTilt(stepNumber);//positive tilt is down
-        break;
-      default:
-        break;
-    }
-  };
-  
-   
+      switch (e.key.toLowerCase()) {
+        case 'a':
+          incrementPan(-stepNumber); //negative pan is left
+          break;
+        case 'd':
+          incrementPan(stepNumber);//positive pan is right
+          break;
+        case 'w':
+          incrementTilt(-stepNumber);//negative tilt is up
+          break;
+        case 's':
+          incrementTilt(stepNumber);//positive tilt is down
+          break;
+        default:
+          break;
+      }
+    };
+
+
     window.addEventListener('keyup', handleKey);
-  return () => window.removeEventListener('keyup', handleKey);
+    return () => window.removeEventListener('keyup', handleKey);
   }, [incrementPan, incrementTilt, stepNumber, windowWideWASD]);
 
 
@@ -125,12 +126,12 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
         Enable Click & Hold
       </Switch>
       <Switch
-      size="sm"
-      isSelected={windowWideWASD}
-      onValueChange={setWindowWideWASD}
-    >
-      Enable Window Wide WASD
-    </Switch>
+        size="sm"
+        isSelected={windowWideWASD}
+        onValueChange={setWindowWideWASD}
+      >
+        Enable Window Wide WASD
+      </Switch>
     </>
   )
 
@@ -141,6 +142,16 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
       onMouseDown={handleClickandHoldDown}
       onMouseUp={handleClickandHoldRelease}
       onMouseLeave={handleClickandHoldRelease}
+      onFocus={() => setHasFocus(true)}
+      onBlur={() => setHasFocus(false)}
+      style={
+        windowWideWASD || hasFocus
+          ? {
+            outline: '2px solid #4da3ff',
+            outlineOffset: '2px',
+          }
+          : undefined
+      }
 
     >
       <OverlayedCameraComponent

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -29,7 +29,8 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
   }), [serviceBifrost]);
 
 
-  let clickAndHoldInterval: ReturnType<typeof setInterval>;
+
+  const clickAndHoldInterval = React.useRef<ReturnType<typeof setInterval> | null>(null);
   const [clickAndHoldEnabled, setClickAndHoldEnabled] = useGenericStore<boolean>("clickAndHold");
   const [windowWideWASD, setWindowWideWASD] = useGenericStore<boolean>("windowWideWASD");
   const [hasFocus, setHasFocus] = React.useState(false);
@@ -37,6 +38,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
   // Handle click and hold movement
   const handleClickandHoldDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     if (!clickAndHoldEnabled) return;
+    if (clickAndHoldInterval.current) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
@@ -50,17 +52,21 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     const verticalDirection = y >= centerY ? 1 : -1
 
 
-    clickAndHoldInterval = setInterval(() => {
-
+    clickAndHoldInterval.current = setInterval(() => {
       incrementPan(stepNumber * horizontalDirection);
       incrementTilt(stepNumber * verticalDirection);
+    }, 50);
 
-    }, 50)
-  }, [incrementPan, incrementTilt, stepNumber])
+  }, [clickAndHoldEnabled, incrementPan, incrementTilt, stepNumber])
 
   const handleClickandHoldRelease = () => {
-    clearInterval(clickAndHoldInterval)
-  }
+    if (clickAndHoldInterval.current) {
+      clearInterval(clickAndHoldInterval.current);
+      clickAndHoldInterval.current = null;
+    }
+  };
+
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
 
   // WASD Controls Component Wide
   const handleInput = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -95,9 +101,17 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     };
 
 
+
     window.addEventListener('keyup', handleKey);
     return () => window.removeEventListener('keyup', handleKey);
   }, [incrementPan, incrementTilt, stepNumber, windowWideWASD]);
+  
+  useEffect(() => {
+    if (!windowWideWASD) {
+      containerRef.current?.blur();
+      setHasFocus(false);
+    }
+  }, [windowWideWASD]);
 
 
   const stepSizeInput = (
@@ -137,6 +151,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
 
   return (
     <div
+      ref={containerRef}
       tabIndex={0}
       onKeyDown={windowWideWASD ? undefined : handleInput}
       onMouseDown={handleClickandHoldDown}
@@ -158,9 +173,9 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
         {...props}
         overlay={<div
 
-          onMouseDown={(e) => e.stopPropagation()}
-          onMouseUp={(e) => e.stopPropagation()}
-          onMouseLeave={(e) => e.stopPropagation()}
+        // onMouseDown={(_) => undefined}
+        // onMouseUp={( => e.stopPropagation()}
+        // onMouseLeave={(e) => e.stopPropagation()}
         />}
         settingsFormChildren={stepSizeInput}
 

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -1,10 +1,10 @@
-import React, {useCallback, useEffect, useMemo} from "react";
-import {useBifrost} from "../../../../redux/actions/bifrost/useBifrostAction.ts";
-import {RosService} from "../../../../ros/services/rosService.ts";
+import React, { useCallback, useMemo } from "react";
+import { useBifrost } from "../../../../redux/actions/bifrost/useBifrostAction.ts";
+import { RosService } from "../../../../ros/services/rosService.ts";
 import OverlayedCameraComponent from "./OverlayedCameraComponent.tsx";
-import {BaseCameraComponentProps} from "../CameraComponent.tsx";
-import {Input, Tooltip} from "@nextui-org/react";
-import {useGenericStore} from "../../../../hooks/useGenericStore.ts";
+import { BaseCameraComponentProps } from "../CameraComponent.tsx";
+import { Input, Tooltip } from "@nextui-org/react";
+import { useGenericStore } from "../../../../hooks/useGenericStore.ts";
 
 export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> = (props) => {
   // Default step size for incrementing angles
@@ -16,7 +16,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     return val
   }, [step]);
 
-  const serviceBifrost = useBifrost({service: RosService.SCIMBAL_COMMAND});
+  const serviceBifrost = useBifrost({ service: RosService.SCIMBAL_COMMAND });
   const incrementTilt = useCallback((step: number) => serviceBifrost.callServiceToRedux({
     angles: [step, 0]
   }, {
@@ -28,55 +28,87 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
     responseToast: false
   }), [serviceBifrost]);
 
-  //WASD Controls
-  useEffect(() => {
-    window.addEventListener('keyup', (e) => {
-      switch (e.key) {
-        case 'a':
-          incrementPan(-stepNumber) //negative pan is left
-          break
-        case 'd':
-          incrementPan(stepNumber) //positive pan is right
-          break
-        case 'w':
-          incrementTilt(-stepNumber) //negative tilt is up
-          break
-        case 's':
-          incrementTilt(stepNumber) //positive tilt is down
-          break
-        default:
-          break
-      }
-    });
-  }, [incrementPan, incrementTilt, step]);
+
+  let clickAndHoldInterval: ReturnType<typeof setInterval>;
+
+  // Handle click and hold movement
+  const handleClickandHoldDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const centerX = rect.width / 2
+    const centerY = rect.height / 2;
+
+    // 1 for right, and -1 for left
+    const horizontalDirection = x >= centerX ? 1 : -1
+    // 1 for down, and -1 for up
+    const verticalDirection = y >= centerY ? 1 : -1
+
+
+    clickAndHoldInterval = setInterval(() => {
+
+      incrementPan(stepNumber * horizontalDirection);
+      incrementTilt(stepNumber * verticalDirection);
+
+    }, 50)
+  }, [incrementPan, incrementTilt, stepNumber])
+
+  const handleClickandHoldRelease = () => {
+    clearInterval(clickAndHoldInterval)
+  }
+
+  // WASD Controls
+  const handleInput = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key.toLowerCase()) {
+      case 'a': incrementPan(-stepNumber); break;
+      case 'd': incrementPan(stepNumber); break;
+      case 'w': incrementTilt(-stepNumber); break;
+      case 's': incrementTilt(stepNumber); break;
+    }
+  }, [incrementPan, incrementTilt, stepNumber])
+
 
   const stepSizeInput = (
-      <>
-        <Tooltip
-            className="text-tiny text-default-500 rounded-md"
-            content="Press Enter to confirm"
-            placement="right"
-            key={"Step Size"}
-        >
-          <Input
-              aria-label="Scimbal cam step size"
-              label= "Step size"
-              labelPlacement= "inside"
-              className=""
-              type= "number"
-              value={step}
-              onValueChange={setStep}
-          />
-        </Tooltip>
-      </>
+    <>
+      <Tooltip
+        className="text-tiny text-default-500 rounded-md"
+        content="Press Enter to confirm"
+        placement="right"
+        key={"Step Size"}
+      >
+        <Input
+          aria-label="Scimbal cam step size"
+          label="Step size"
+          labelPlacement="inside"
+          className=""
+          type="number"
+          value={step}
+          onValueChange={setStep}
+        />
+      </Tooltip>
+    </>
   )
 
   return (
-    <div>
+    <div
+      tabIndex={0}
+      onKeyDown={handleInput}
+      onMouseDown={handleClickandHoldDown}
+          onMouseUp={handleClickandHoldRelease}
+          onMouseLeave={handleClickandHoldRelease}
+      
+    >
       <OverlayedCameraComponent
         {...props}
-        overlay={<div/>}
+        overlay={<div 
+          
+          onMouseDown={(e) => e.stopPropagation()}
+    onMouseUp={(e) => e.stopPropagation()}
+    onMouseLeave={(e) => e.stopPropagation()}
+        />}
         settingsFormChildren={stepSizeInput}
+        
       />
     </div>
   );

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/special/GimbalOverlayedCameraComponent.tsx
@@ -164,6 +164,7 @@ export const GimbalOverlayedCameraComponent: React.FC<BaseCameraComponentProps> 
           ? {
             outline: '2px solid #4da3ff',
             outlineOffset: '2px',
+            borderRadius: '14px',
           }
           : undefined
       }

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -331,6 +331,9 @@ export const reduxStores = {
   theta360InputDistance: createGenericStore("theta360InputDistance",""),
   rgbLedStore: createGenericStore("rgbLedStore", { r: "0", g: "0", b: "0" }),
   uvVisBlankStore: createGenericStore("uvVisBlankStore", []),
+  clickAndHold: createGenericStore("clickAndHold", false),
+  windowWideWASD: createGenericStore("windowWideWASD", false),
+
 };
 
 // all store reducers

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -114,6 +114,8 @@ export interface RootState {
   targetTemp : GenericStoreState<number>;
   theta360CompassHeading : GenericStoreState<number>;
   uvVisBlankStore : GenericStoreState<number[]>;
+  clickAndHold : GenericStoreState<boolean>;
+  windowWideWASD : GenericStoreState<boolean>;
 
   batteryStore: IRosSensorMsgsBatteryState;
 


### PR DESCRIPTION
## Descriptions

See #688 

Previously, WASD Controls for the scimbal cam were tied to the browser window. Now, there is a button to toggle between having WASD Controls tied to the browser or requiring the user to select the scimbal component.  

There is also a click and hold feature to move the camera, with a button to toggle it on or off. Both buttons are placed in the settings overlay. Features have not been tested on the actual scimbal cam.  

A new state variable, `windowWideWASD`, has been added that controls how the scimbal cam is controlled using WASD:

- When false: the component uses the `onKeyDown` handler on the gimbal container, ensuring users must select the component to control it using WASD.  
- When true: the browser-wide listener is used, allowing browser page-wide WASD controls.  

Additionally, a new click and hold feature has been added. The direction of the movement is based on the mouse's relative position from the component's center.

---

## Changelogs

- Added a "Enable Click & Hold" button in the scimbal component settings overlay to enable click and hold controls.  
- Added a "Enable Window Wide WASD" button in the scimbal component settings overlay to toggle between window-wide WASD, or requiring the user to click the scimbal component to use WASD controls.

---

## Screenshots

<img width="1478" height="947" alt="Screenshot 2025-12-16 at 15 45 18" src="https://github.com/user-attachments/assets/0ae79678-ee9d-499f-8c46-b32b475fbeeb" />


---

## Steps to Test

1. Run GUI  
2. Run rosbridge  
3. Open the science cameras page  
4. Open the settings overlay of the scimbal cam component  

---

## Memes
![5D132208-5A6F-42DD-B623-7F8844E4E756](https://github.com/user-attachments/assets/65e056e4-cf37-4def-92db-87a197b164c7)

