### PR TITLE
Changed default twist message to zeroes instead NaNs

### DIFF
--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -517,18 +517,11 @@ void NovaDriveControllerBase::reset_buffers()
   hwif_wrapper_->reset_handles();
   reset_limiter_buffers();
 
-  // Fill RealtimeBuffer with NaNs so it will contain a known value
-  // but still indicate that no command has yet been sent.
+  // Reset received twist message to zeroes
   received_twist_msg_ptr_.reset();
-  std::shared_ptr<TwistStamped> empty_twist_ptr = std::make_shared<TwistStamped>();
-  empty_twist_ptr->header.stamp = get_node()->now();
-  empty_twist_ptr->twist.linear.x = std::numeric_limits<double>::quiet_NaN();
-  empty_twist_ptr->twist.linear.y = std::numeric_limits<double>::quiet_NaN();
-  empty_twist_ptr->twist.linear.z = std::numeric_limits<double>::quiet_NaN();
-  empty_twist_ptr->twist.angular.x = std::numeric_limits<double>::quiet_NaN();
-  empty_twist_ptr->twist.angular.y = std::numeric_limits<double>::quiet_NaN();
-  empty_twist_ptr->twist.angular.z = std::numeric_limits<double>::quiet_NaN();
-  received_twist_msg_ptr_.writeFromNonRT(empty_twist_ptr);
+  std::shared_ptr<TwistStamped> default_twist_ptr = std::make_shared<TwistStamped>();
+  default_twist_ptr->header.stamp = get_node()->now();
+  received_twist_msg_ptr_.writeFromNonRT(default_twist_ptr);
 }
 
 void NovaDriveControllerBase::halt()


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

(For drive)
Changed the default twist message before any messages are received from teleop to be zeroes instead of NaNs, so no more message spamming on start up!


