### PR TITLE
feat: PC2 Auger

### DIFF
--- a/src/ros/rover/nova_generic/python_control2/python_control2/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/__init__.py
@@ -2,6 +2,7 @@ from .controller_manager.Interface import Interface, InterfaceCollection
 from .controllers.Controller import Controller
 from .hardware_interfaces.HardwareInterface import HardwareInterface
 from .hardware_interfaces.Direction import Direction
+from .controller_manager.Activation import Activation
 from .controller_manager.ControllerManagerBuilder import ControllerManagerBuilder
 from .controller_manager.ControllerManager import ControllerManager
 from .controller_manager.Contexts import Contexts

--- a/src/ros/rover/nova_generic/python_control2/python_control2/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/__init__.py
@@ -1,6 +1,7 @@
 from .controller_manager.Interface import Interface, InterfaceCollection
 from .controllers.Controller import Controller
 from .hardware_interfaces.HardwareInterface import HardwareInterface
+from .hardware_interfaces.Direction import Direction
 from .controller_manager.ControllerManagerBuilder import ControllerManagerBuilder
 from .controller_manager.ControllerManager import ControllerManager
 from .controller_manager.Contexts import Contexts

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
@@ -1,3 +1,4 @@
+from rclpy.node import Node
 from teleop_python_utils import Button
 
 class Activation:
@@ -8,13 +9,14 @@ class Activation:
     pool of buttons that when pressed deactivates the system.
     """
 
-    def __init__(self, active_button: Button, inactive_button_pool: list[Button], start_active: bool=False):
+    def __init__(self, active_button: Button, inactive_button_pool: list[Button], node: Node, start_active: bool=False):
         """
         :param active_button: Button that activates.
         :param inactive_button_pool: Buttons that deactivate.
         :param start_active: Whether to start active or not, defaults to False.
         """
         self.active = start_active
+        self.node = node
         self.active_button = active_button
         self.inactive_button_pool = inactive_button_pool
 
@@ -23,13 +25,17 @@ class Activation:
         for but in inactive_button_pool:
             but.add_callback(self.deactivate)
 
+        self.node.get_logger().info(f"{self.node.get_name()} is {"ACTIVE" if self.active else "INACTIVE"}")
+
     def activate(self):
         """ Activates the system """
         self.active = True
+        self.node.get_logger().info(f"{self.node.get_name()} ACTIVATED")
 
     def deactivate(self):
         """ Deactivates the system """
         self.active = False
+        self.node.get_logger().info(f"{self.node.get_name()} DEACTIVATED")
 
     def is_active(self):
         return self.active

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
@@ -29,13 +29,15 @@ class Activation:
 
     def activate(self):
         """ Activates the system """
+        if not self.active:
+            self.node.get_logger().info(f"{self.node.get_name()} ACTIVATED")
         self.active = True
-        self.node.get_logger().info(f"{self.node.get_name()} ACTIVATED")
 
     def deactivate(self):
         """ Deactivates the system """
+        if self.active:
+            self.node.get_logger().info(f"{self.node.get_name()} DEACTIVATED")
         self.active = False
-        self.node.get_logger().info(f"{self.node.get_name()} DEACTIVATED")
 
     def is_active(self):
         return self.active

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/Activation.py
@@ -1,0 +1,38 @@
+from teleop_python_utils import Button
+
+class Activation:
+    """
+    Class to represent whether a python control2 system is active or not
+
+    Has a teleop button that when pressed activates the system and a
+    pool of buttons that when pressed deactivates the system.
+    """
+
+    def __init__(self, active_button: Button, inactive_button_pool: list[Button], start_active: bool=False):
+        """
+        :param active_button: Button that activates.
+        :param inactive_button_pool: Buttons that deactivate.
+        :param start_active: Whether to start active or not, defaults to False.
+        """
+        self.active = start_active
+        self.active_button = active_button
+        self.inactive_button_pool = inactive_button_pool
+
+        # Add button callbacks
+        self.active_button.add_callback(self.activate)
+        for but in inactive_button_pool:
+            but.add_callback(self.deactivate)
+
+    def activate(self):
+        """ Activates the system """
+        self.active = True
+
+    def deactivate(self):
+        """ Deactivates the system """
+        self.active = False
+
+    def is_active(self):
+        return self.active
+
+    def __bool__(self):
+        return self.active

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/ControllerManagerBuilder.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/ControllerManagerBuilder.py
@@ -3,6 +3,8 @@ import rclpy
 from rclpy.node import Node
 from typing import Type, TypeVar, List, Any, Optional
 from teleop_python_utils import Inputs
+
+from .Activation import Activation
 from .ControllerManager import ControllerManager
 from ..controllers.Controller import Controller
 from ..controllers.DeferredConstructor import DeferredConstructor
@@ -153,6 +155,43 @@ class ControllerManagerBuilder:
         """
         self._cm.contexts[Inputs] = inputs
         return self
+
+    def with_activation_buttons(self, start_active: bool=False, active_button_name: str="", inactive_button_pool_names: list[str]=[""]):
+        """
+        Allows a system to be activatable by adding an activation object to the cm context
+        that controllers can use to conditionally run code.
+
+        Can only have one Activation in a python control2 system.
+
+        :param start_active: Whether to start active or not, defaults to False.
+        :param active_button_name: Name of button that activates.
+        :param inactive_button_pool_names: Name of buttons that deactivate.
+        """
+        # Declare parameters
+        start_active: bool = self._cm.declare_parameter(
+            "active",
+            start_active,
+            'On start node status').value
+        active_button_name: str = self._cm.declare_parameter(
+            "active_button",
+            active_button_name,
+            'Button name that activates the system').value
+        inactive_button_pool_names: list[str] = self._cm.declare_parameter(
+            "inactive_button_pool",
+            inactive_button_pool_names,
+            'list of button name that deactivates the system').get_parameter_value().string_array_value
+
+        # Get button references
+        if Inputs not in self._cm.contexts:
+            raise AssertionError("`.with_teleop` must be called before `.with_activation_buttons`")
+
+        inputs = self._cm.contexts[Inputs]
+        active_button = inputs.get_button(active_button_name)
+        inactive_button_pool = [inputs.get_button(name) for name in inactive_button_pool_names]
+
+        # Create Activation object and add to cm context.
+        self._cm.contexts[Activation] = Activation(active_button, inactive_button_pool, start_active)
+
 
     def spin(self, default_update_rate: float=20, auto_run_rclpy: bool=True) -> None:
         """ Repeatedly updates until the program ends.

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/ControllerManagerBuilder.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/ControllerManagerBuilder.py
@@ -190,7 +190,8 @@ class ControllerManagerBuilder:
         inactive_button_pool = [inputs.get_button(name) for name in inactive_button_pool_names]
 
         # Create Activation object and add to cm context.
-        self._cm.contexts[Activation] = Activation(active_button, inactive_button_pool, start_active)
+        self._cm.contexts[Activation] = Activation(active_button, inactive_button_pool, self._cm.node, start_active)
+        return self
 
 
     def spin(self, default_update_rate: float=20, auto_run_rclpy: bool=True) -> None:

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controller_manager/__init__.py
@@ -1,3 +1,4 @@
+from .Activation import Activation
 from .ControllerManager import ControllerManager
 from .Contexts import Contexts
 from .Interface import Interface, InterfaceCollection

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
@@ -6,7 +6,7 @@ old arm.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 COMMAND INTERFACES:
   - <joint>/effort      [value between -1 and 1] or
-  - <joint>/velocity    [value between -1 and 1]
+  - <joint>/velocity    [m/s ???]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        python_control2
 AUTHOR(S):      Bailey Chessum

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
@@ -1,3 +1,16 @@
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hardware interface for CAN Motor Drivers (CMD).
+CMDs are used primarily for brushed motors on the
+old arm.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        python_control2
+AUTHOR(S):      Bailey Chessum
+CREATION:       13/01/25
+EDITED:         13/01/25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
 from typing import List
 
 import jcan
@@ -69,7 +82,6 @@ class CMDHardware(HardwareInterface):
     def __init__(self, contexts: Contexts,
                  joint: str="",
                  can_id: int=0,
-                 reverse: bool=False,
                  max_effort: float=1.0, max_effort_can: int=0x7FFF,
                  max_velocity: float=0.0, max_velocity_can: int=0x7FFF):
         """ Constructor, deferred until the control manager has been spun.
@@ -84,8 +96,6 @@ class CMDHardware(HardwareInterface):
         # Default joint name to the hardware interface name
         if len(joint) == 0:
             joint = self.name
-
-        self.reverse = 1 if self.declare_parameter("reverse", reverse).value else -1
 
         self.declare_parameter("joint", joint)
         self.declare_parameter("can_id", can_id)
@@ -154,9 +164,9 @@ class CMDHardware(HardwareInterface):
         :param period: The time elapsed since the last update, in seconds.
         """
         if self.effort_cmd:
-            self.effort_handle.send_value(self.bus, self.can_id, self.effort_cmd.value * self.reverse)
+            self.effort_handle.send_value(self.bus, self.can_id, self.effort_cmd.value)
         elif self.velocity_cmd:
-            self.velocity_handle.send_value(self.bus, self.can_id, self.velocity_cmd.value * self.reverse)
+            self.velocity_handle.send_value(self.bus, self.can_id, self.velocity_cmd.value)
         else:
             # Send a stop command
             frame_id : int = (CanIdPrefix.SEND.value << 8) | (self.can_id << 4) | CMDHardwareCommand.STOP.value

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
@@ -69,6 +69,7 @@ class CMDHardware(HardwareInterface):
     def __init__(self, contexts: Contexts,
                  joint: str="",
                  can_id: int=0,
+                 reverse: bool=False,
                  max_effort: float=1.0, max_effort_can: int=0x7FFF,
                  max_velocity: float=0.0, max_velocity_can: int=0x7FFF):
         """ Constructor, deferred until the control manager has been spun.
@@ -83,6 +84,8 @@ class CMDHardware(HardwareInterface):
         # Default joint name to the hardware interface name
         if len(joint) == 0:
             joint = self.name
+
+        self.reverse = 1 if self.declare_parameter("reverse", reverse).value else -1
 
         self.declare_parameter("joint", joint)
         self.declare_parameter("can_id", can_id)
@@ -151,9 +154,9 @@ class CMDHardware(HardwareInterface):
         :param period: The time elapsed since the last update, in seconds.
         """
         if self.effort_cmd:
-            self.effort_handle.send_value(self.bus, self.can_id, self.effort_cmd.value)
+            self.effort_handle.send_value(self.bus, self.can_id, self.effort_cmd.value * self.reverse)
         elif self.velocity_cmd:
-            self.velocity_handle.send_value(self.bus, self.can_id, self.velocity_cmd.value)
+            self.velocity_handle.send_value(self.bus, self.can_id, self.velocity_cmd.value * self.reverse)
         else:
             # Send a stop command
             frame_id : int = (CanIdPrefix.SEND.value << 8) | (self.can_id << 4) | CMDHardwareCommand.STOP.value

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/CMDHardware.py
@@ -4,10 +4,14 @@ Hardware interface for CAN Motor Drivers (CMD).
 CMDs are used primarily for brushed motors on the
 old arm.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - <joint>/effort      [value between -1 and 1] or
+  - <joint>/velocity    [value between -1 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        python_control2
 AUTHOR(S):      Bailey Chessum
-CREATION:       13/01/25
-EDITED:         13/01/25
+CREATION:       30/09/25
+EDITED:         30/09/25
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/Direction.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/Direction.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+from enum import Enum
+
+
+class Direction(Enum):
+    """Enum for the different directions of the motors"""
+    POSITIVE = 1
+    NEGATIVE = -1

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
@@ -68,7 +68,7 @@ class QCMDHardware(HardwareInterface):
         # Update params
         self.can_id: int = self.get_parameter("can_id").value
         self.joint: str = self.get_parameter("joint").value
-        self.reversed: int = 1 if self.get_parameter("reversed").value else -1
+        self.reversed: int = -1 if self.get_parameter("reversed").value else 1
 
         self.max_effort = self.get_parameter("max_effort").value
         self.max_effort_can = self.get_parameter("max_effort_can").value

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
@@ -9,8 +9,8 @@ COMMAND INTERFACES:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        python_control2
 AUTHOR(S):      Felicity Matthews
-CREATION:       13/01/25
-EDITED:         13/01/25
+CREATION:       13/01/26
+EDITED:         13/01/26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
@@ -1,7 +1,7 @@
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Hardware interface for Quad CAN Motor Drivers (QCMD).
-CMDs are used primarily for motors in the science
+QCMDs are used primarily for motors in the science
 and EC payloads.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 COMMAND INTERFACES:

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/QCMDHardware.py
@@ -1,0 +1,120 @@
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hardware interface for Quad CAN Motor Drivers (QCMD).
+CMDs are used primarily for motors in the science
+and EC payloads.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - <joint>/effort  [value between -1 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        python_control2
+AUTHOR(S):      Felicity Matthews
+CREATION:       13/01/25
+EDITED:         13/01/25
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+
+import jcan
+
+from ..controller_manager.Interface import Interface, InterfaceCollection
+from .HardwareInterface import HardwareInterface
+from ..controller_manager.Contexts import Contexts
+from struct import pack
+
+
+class QCMDHardware(HardwareInterface):
+    effort_cmd: Interface
+    can_id: int
+    # The name of the joint
+    joint: str
+    reversed: bool
+    max_effort: float
+    max_effort_can: int
+
+    def __init__(self, contexts: Contexts,
+                 joint: str="",
+                 can_id: int=0,
+                 reversed: bool=False,
+                 max_effort: float=1.0, max_effort_can: int=0x7FFF):
+        """ Constructor, deferred until the control manager has been spun.
+        If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
+
+        :param contexts: A collection of dependency injection class instances you can index by class type.
+        """
+        super().__init__(contexts)
+
+        self.bus = contexts[jcan.Bus]
+
+        # Default joint name to the hardware interface name
+        if len(joint) == 0:
+            joint = self.name
+
+        self.declare_parameter("joint", joint, "Name of the joint")
+        self.declare_parameter("can_id", can_id, "CAN ID of the QCMD")
+        self.declare_parameter("reversed", reversed, "Whether the output should be reversed")
+        self.declare_parameter("max_effort", max_effort, "Max percentage of output to send")
+        self.declare_parameter("max_effort_can", max_effort_can, "Max CAN message value that can be sent")
+
+    def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection):
+        """ Used to set up your HardwareInterface. Run once before any other class method.
+        Use this method to get data from self.node, and get references to any command or state interface you need.
+
+        :param command_interfaces: A collection of Interfaces used to send messages to hardware. Get any command
+        interfaces you need from this, then store them in member variables.
+        :param state_interfaces: A collection of Interfaces containing the current state of the robot. Get any state
+        interfaces you need from this, then store them in member variables.
+        :returns: None or True if configured successfully. False otherwise.
+        """
+        # Update params
+        self.can_id: int = self.get_parameter("can_id").value
+        self.joint: str = self.get_parameter("joint").value
+        self.reversed: int = 1 if self.get_parameter("reversed").value else -1
+
+        self.max_effort = self.get_parameter("max_effort").value
+        self.max_effort_can = self.get_parameter("max_effort_can").value
+
+        # Get command interfaces
+        self.effort_cmd = command_interfaces[self.joint + "/effort"]
+
+        # Validate command interface configuration
+        if not self.effort_cmd:
+            self.logger.warn(f"QCMDHardware \"{self.name}\" has no populated command interfaces. "
+                             f"(\"{self.joint}/effort\")")
+
+        return True
+
+    def on_read(self, now: float, period: float):
+        """ Called to read values from hardware, and put them into stored state interfaces.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        pass
+
+    def on_write(self, now: float, period: float):
+        """ Called to write to hardware using values stored in command interfaces.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        frame = self.construct_frame()
+        self.bus.send(frame)
+
+    def construct_frame(self) -> jcan.Frame:
+        """ Construct the jcan Frame based on current command interface """
+        # Set the data based on the effort, max percent value, max can value and reversed
+        # Effort is directional.
+        data = int(self.effort_cmd.value * self.max_effort * self.max_effort_can * self.reversed)
+
+        # Check if the data is greater than the max value
+        # If it is, set the data to the max value
+        if data > self.max_effort_can:
+            data = self.max_effort_can
+        elif data < -self.max_effort_can:
+            data = -self.max_effort_can
+
+        # Pack the data into a list
+        packed_data = list(pack('>h', int(data)))
+
+        # Create and return the frame
+        frame = jcan.Frame(id=self.can_id, data=packed_data)
+
+        return frame

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/__init__.py
@@ -1,3 +1,3 @@
 from .HardwareInterface import HardwareInterface
-
+from .Direction import Direction
 from .CMDHardware import CMDHardware

--- a/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/hardware_interfaces/__init__.py
@@ -1,3 +1,4 @@
 from .HardwareInterface import HardwareInterface
 from .Direction import Direction
 from .CMDHardware import CMDHardware
+from .QCMDHardware import QCMDHardware

--- a/src/ros/rover/science/science/CMakeLists.txt
+++ b/src/ros/rover/science/science/CMakeLists.txt
@@ -66,6 +66,7 @@ install(PROGRAMS
         science/urc/urc_uv_vis_spec.py
         science/analysis_arm.py
         science/auger.py
+        science/auger_old.py
         science/nir_probe_publisher.py
         science/scimbal_cam.py
         science/control_test.py

--- a/src/ros/rover/science/science/default.nix
+++ b/src/ros/rover/science/science/default.nix
@@ -41,7 +41,6 @@ buildRosPackage {
   ] ++
   [
     nova-python-control
-    nova-python-control2
     nova-input-interfaces
     nova-camera-msgs
     teleop-modular-python-utils

--- a/src/ros/rover/science/science/default.nix
+++ b/src/ros/rover/science/science/default.nix
@@ -41,6 +41,7 @@ buildRosPackage {
   ] ++
   [
     nova-python-control
+    nova-python-control2
     nova-input-interfaces
     nova-camera-msgs
     teleop-modular-python-utils

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -79,6 +79,7 @@ class AugerController(Controller):
         if not self.active:
             self.drill_cmd.value = 0
             self.actuation_cmd.value = 0
+            return
 
         # Update Command Interfaces
         # Update drill speed

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -44,12 +44,6 @@ class AugerController(Controller):
 
         self.drill_direction = Direction.POSITIVE
 
-        # Do any setup logic here, save any contexts you want reference to in the future.
-        # Save Input references here
-        self.active_button_name = self.declare_parameter("active_button", f"{self.name}_active").value
-        self.inactive_button_pool_names = self.declare_parameter("inactive_button_pool", []).value
-        self.active = self.declare_parameter("start_active", True)
-
         # Get inputs
         # Actuation axis
         self.actuation_axis_name = self.declare_parameter("actuation_axis", "auger_actuation").value
@@ -65,8 +59,8 @@ class AugerController(Controller):
 
         self.drill_button = inputs.get_button(self.drill_button_name)
         self.speed_axis = inputs.get_axis(self.speed_axis_name)
-        inputs.get_event(f"{self.drill_clockwise_button_name}/down").add_callback(self.update_drill_direction(Direction.POSITIVE))
-        inputs.get_event(f"{self.drill_anticlockwise_button_name}/down").add_callback(self.update_drill_direction(Direction.NEGATIVE))
+        inputs.get_button(self.drill_clockwise_button_name).add_callback(self.update_drill_direction(Direction.POSITIVE))
+        inputs.get_button(self.drill_anticlockwise_button_name).add_callback(self.update_drill_direction(Direction.NEGATIVE))
 
     def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
         """ Used to set up your Controller. Run once before any other class method.

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -6,6 +6,10 @@ and down and drills.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODE: AugerController
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - actuation/effort    [value between -1 and 1]
+  - drill/effort        [value between -1 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        science
 AUTHOR(S):      Felicity Matthews
 CREATION:       13/01/26

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -1,27 +1,22 @@
 #!/usr/bin/env python3
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<insert purpose here>
+Controller for the science Auger which actuates up
+and down and drills.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODE: AugerController
-TOPICS:
-  - publisher: <topic> [<msg type>]
-SERVICES:
-	- service: <service> [<srv type>]
-ACTIONS: None
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        science
-AUTHOR(S):      <insert your name>
-CREATION:       <current date>
-EDITED:         <current date>
+AUTHOR(S):      Felicity Matthews
+CREATION:       13/01/26
+EDITED:         13/01/26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import rclpy
 from rclpy.node import Node
 from typing import Optional
 from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, Direction
-
-from python_control2.hardware_interfaces import CMDHardware
+from python_control2.hardware_interfaces import QCMDHardware
 from teleop_python_utils import Inputs
 
 
@@ -29,9 +24,6 @@ class AugerController(Controller):
     # Command interfaces
     actuation_cmd: Interface
     drill_cmd: Interface
-
-    # State interfaces
-    # state: Interface
 
     def __init__(self, contexts: Contexts):
         """ Constructor, deferred until the control manager has been spun.
@@ -85,7 +77,7 @@ class AugerController(Controller):
         """
         # Update Command Interfaces
         # Update drill speed
-        self.drill_cmd.value = self.drill_button.value * self.speed_axis.value * self.drill_direction
+        self.drill_cmd.value = self.drill_button.value * self.speed_axis.value * self.drill_direction.value
 
         # Update actuation
         self.actuation_cmd.value = self.actuation_axis.value
@@ -106,8 +98,8 @@ if __name__ == "__main__":
 
     PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller("controller", AugerController) \
-        .with_hardware("actuation", CMDHardware, can_id=0x0C2, max_effort=0.75) \
-        .with_hardware("drill", CMDHardware, can_id=0x0C1, max_effort=0.6) \
+        .with_hardware("actuation", QCMDHardware, can_id=0xC2, max_effort=1) \
+        .with_hardware("drill", QCMDHardware, can_id=0xC1, max_effort=1) \
         .with_teleop(inputs) \
         .with_jcan() \
         .spin()

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -104,8 +104,8 @@ if __name__ == "__main__":
 
     PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller("controller", AugerController) \
-        .with_hardware("actuation", QCMDHardware, can_id=0xC2, max_effort=1) \
-        .with_hardware("drill", QCMDHardware, can_id=0xC1, max_effort=1) \
+        .with_hardware("actuation", QCMDHardware, can_id=0xC2) \
+        .with_hardware("drill", QCMDHardware, can_id=0xC1) \
         .with_teleop(inputs) \
         .with_activation_buttons(start_active=True, active_button_name="activate_auger", inactive_button_pool_names=["activate_cbeam"]) \
         .with_jcan() \

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -19,7 +19,7 @@ EDITED:         <current date>
 import rclpy
 from rclpy.node import Node
 from typing import Optional
-from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface
+from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, Direction
 
 from python_control2.hardware_interfaces import CMDHardware
 from teleop_python_utils import Inputs
@@ -41,7 +41,8 @@ class AugerController(Controller):
         """
         super().__init__(contexts)
         self.logger.info(f"AugerController -- I have been __init__ialized")
-        self.logger.get_child(self.name).info()
+
+        self.drill_direction = Direction.POSITIVE
 
         # Do any setup logic here, save any contexts you want reference to in the future.
         # Save Input references here
@@ -50,15 +51,22 @@ class AugerController(Controller):
         self.active = self.declare_parameter("start_active", True)
 
         # Get inputs
+        # Actuation axis
         self.actuation_axis_name = self.declare_parameter("actuation_axis", "auger_actuation").value
-        self.drill_axis_name = self.declare_parameter("drill_axis", "auger_drill").value
-        self.speed_axis_name = self.declare_parameter("speed_axis", "auger_speed").value
 
         inputs = contexts[Inputs]
-        self.actuation_input = inputs.get_button(self.actuation_axis_name)
-        self.drill_input = inputs.get_axis(self.drill_axis_name)
-        self.speed_input = inputs.get_axis(self.speed_axis_name)
+        self.actuation_axis = inputs.get_axis(self.actuation_axis_name)
 
+        # Drill activate, speed and direction buttons and axes
+        self.drill_button_name = self.declare_parameter("drill_button", "auger_drill").value
+        self.speed_axis_name = self.declare_parameter("speed_axis", "auger_speed").value
+        self.drill_clockwise_button_name = self.declare_parameter("drill_clockwise_button", "auger_drill_clockwise").value
+        self.drill_anticlockwise_button_name = self.declare_parameter("drill_anticlockwise_button", "auger_drill_anticlockwise").value
+
+        self.drill_button = inputs.get_button(self.drill_button_name)
+        self.speed_axis = inputs.get_axis(self.speed_axis_name)
+        inputs.get_event(f"{self.drill_clockwise_button_name}/down").add_callback(self.update_drill_direction(Direction.POSITIVE))
+        inputs.get_event(f"{self.drill_anticlockwise_button_name}/down").add_callback(self.update_drill_direction(Direction.NEGATIVE))
 
     def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
         """ Used to set up your Controller. Run once before any other class method.
@@ -82,8 +90,17 @@ class AugerController(Controller):
         :param period: The time elapsed since the last update, in seconds.
         """
         # Update Command Interfaces
-        # self.cmd.value = 2 * self.state.value
-        # self.logger.info(f"{self.state.value} -> {self.cmd.value}")
+        # Update drill speed
+        self.drill_cmd.value = self.drill_button.value * self.speed_axis.value * self.drill_direction
+
+        # Update actuation
+        self.actuation_cmd.value = self.actuation_axis.value
+
+    def update_drill_direction(self, direction: Direction):
+        def update_drill():
+            self.drill_direction = direction
+        return update_drill
+
 
 if __name__ == "__main__":
     print("Setting up!")

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -83,7 +83,7 @@ class AugerController(Controller):
 
         # Update Command Interfaces
         # Update drill speed
-        self.drill_cmd.value = self.drill_button.value * self.speed_axis.value * self.drill_direction.value
+        self.drill_cmd.value = self.drill_button.value * self.get_drill_speed() * self.drill_direction.value
 
         # Update actuation
         self.actuation_cmd.value = self.actuation_axis.value
@@ -92,6 +92,10 @@ class AugerController(Controller):
         def update_drill():
             self.drill_direction = direction
         return update_drill
+
+    def get_drill_speed(self) -> float:
+        """ gets the drill speed, turning an axis [-1, 1] to a speed [0, 1]"""
+        return (self.speed_axis.value + 1) / 2
 
 
 if __name__ == "__main__":

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -46,7 +46,7 @@ class AugerController(Controller):
 
         # Drill activate, speed and direction buttons and axes
         self.drill_button_name = self.declare_parameter("drill_button", "auger_drill").value
-        self.speed_axis_name = self.declare_parameter("speed_axis", "auger_speed").value
+        self.speed_axis_name = self.declare_parameter("speed_axis", "auger_drill_speed").value
         self.drill_clockwise_button_name = self.declare_parameter("drill_clockwise_button", "auger_drill_clockwise").value
         self.drill_anticlockwise_button_name = self.declare_parameter("drill_anticlockwise_button", "auger_drill_anticlockwise").value
 

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -1,191 +1,102 @@
 #!/usr/bin/env python3
-
-from python_control.sensors.ToggleCommandSensor import ToggleCommandSensor
-from python_control.limits.LimitSwitchLimit import LimitSwitchLimit
-from python_control.controls.Direction import Direction
-from python_control.controls.OneAxisVelocityControl import OneAxisVelocityControl
-from python_control.controllers.CMDVelocityController import CMDVelocityController
-from python_control.sensors.CommandSensor import CommandSensor
-from python_control.ActivatedJoystickControllerNode import ActivatedJoystickControllerNode
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<insert purpose here>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NODE: AugerController
+TOPICS:
+  - publisher: <topic> [<msg type>]
+SERVICES:
+	- service: <service> [<srv type>]
+ACTIONS: None
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        science
+AUTHOR(S):      <insert your name>
+CREATION:       <current date>
+EDITED:         <current date>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
 import rclpy
-from input_interfaces.msg import InputJoystick
-from std_msgs.msg import Bool
+from rclpy.node import Node
+from typing import Optional
+from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface
+
+from python_control2.hardware_interfaces import CMDHardware
+from teleop_python_utils import Inputs
 
 
-class URCAuger(ActivatedJoystickControllerNode):
+class AugerController(Controller):
+    # Command interfaces
+    actuation_cmd: Interface
+    drill_cmd: Interface
 
-    # CAN BUS NAME
-    # The name of the CAN bus to use
-    CAN_BUS = "can1"
+    # State interfaces
+    # state: Interface
 
-    # SENDING CARD IDS
-    # Add any CONTROL FRAME / CARD IDS here
-    AUGER_ACTUATION_CANID_PARAM = "auger_actuation_canid"
-    AUGER_ACTUATION_SEND_FRAME_ID = 0x0C2
-    AUGER_DRILL_CANID_PARAM = "auger_drill_canid"
-    AUGER_DRILL_SEND_FRAME_ID = 0x0C1
+    def __init__(self, contexts: Contexts):
+        """ Constructor, deferred until the control manager has been spun.
+        If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
 
-    # RECEIVING CARD IDS
-    # Add any SENSOR FRAME / CARD IDS here
-    AUGER_LIMIT_RECV_ID = 0x452
+        :param contexts: A collection of dependency injection class instances you can index by class type.
+        """
+        super().__init__(contexts)
+        self.logger.info(f"AugerController -- I have been __init__ialized")
+        self.logger.get_child(self.name).info()
 
+        # Do any setup logic here, save any contexts you want reference to in the future.
+        # Save Input references here
+        self.active_button_name = self.declare_parameter("active_button", f"{self.name}_active").value
+        self.inactive_button_pool_names = self.declare_parameter("inactive_button_pool", []).value
+        self.active = self.declare_parameter("start_active", True)
 
-    # DEPTH HALL SENSORS CAN INFO
-    AUGER_HALL_SENSOR_CANID_PARAM = "auger_hall_sensor_canid"
-    DEFAULT_AUGER_HALL_SENSOR_CANID_PARAM = 0x4A2
-    DEPTH_HIT_DATA = 0x01
-    DEPTH_NOT_HIT_DATA = 0x00
+        # Get inputs
+        self.actuation_axis_name = self.declare_parameter("actuation_axis", "auger_actuation").value
+        self.drill_axis_name = self.declare_parameter("drill_axis", "auger_drill").value
+        self.speed_axis_name = self.declare_parameter("speed_axis", "auger_speed").value
 
-    # PUBLISHING DEPTH INFORMATION
-    AUGER_DEPTH_TOPIC_PREFIX = "/science/auger_depth/"
-
-    # CONTROL NAMES
-    # Add any CONTROL names here
-    AUGER_ACTUATION_NAME = "auger_actuation"
-    AUGER_DRILL_NAME = "auger_drill"
-
-    # CONTROL PARAMETERS
-    # Max Speed as a Percentage (0.0 to 1.0)
-    AUGER_ACTUATION_MAX_PERCENT = 0.75
-    AUGER_DRILL_MAX_PERCENT = 0.6
-    AUGER_DRILL_MAX_PERCENT_PARAM = "max_percent"
-
-    # SENDING COMMAND IDS
-    # Add any CONTROL command ids here
-    STEPPER_SEND_COMMAND_ID = 0x01
-
-    # RECEIVING COMMAND IDS
-    # Add any SENSOR command ids here
-    AUGER_RECV_LIMIT_BOTTOM_COMMAND_ID = 0x01
-    AUGER_RECV_DEPTH_LIMIT_HIT_COMMAND_ID = 0x01
-
-    # CONTROL DIRECTIONS
-    # Add any CONTROL DIRECTIONS here
-    AUGER_ACTUATION_UP = Direction.NEGATIVE
-    AUGER_ACTUATION_DOWN = Direction.POSITIVE
-    AUGER_DRILL_CLOCKWISE = Direction.POSITIVE
-    AUGER_DRILL_COUNTERCLOCKWISE = Direction.NEGATIVE
-
-    def __init__(self):
-        super(URCAuger, self).__init__(name="Auger", can_bus=self.CAN_BUS)
-        logger = self.get_logger()
-
-        # Setting ROS parameters
-        self.declare_parameter(self.AUGER_ACTUATION_CANID_PARAM, self.AUGER_ACTUATION_SEND_FRAME_ID)
-        self.declare_parameter(self.AUGER_DRILL_CANID_PARAM, self.AUGER_DRILL_SEND_FRAME_ID)
-        self.declare_parameter(self.AUGER_DRILL_MAX_PERCENT_PARAM, self.AUGER_DRILL_MAX_PERCENT)
-        self.declare_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM, self.DEFAULT_AUGER_HALL_SENSOR_CANID_PARAM)
-        self.get_logger().info(f"CAN IDs: Actuation = {self.get_parameter(self.AUGER_ACTUATION_CANID_PARAM).value} Drill = {self.get_parameter(self.AUGER_DRILL_CANID_PARAM).value}")
-
-        ## Add publishers
-        self.depth_publisher = self.create_publisher(
-            Bool,
-            self.AUGER_DEPTH_TOPIC_PREFIX + self.get_name(),
-            10
-        )
-
-        ## Add CAN ID Filters
-        self.bus.set_id_filter([self.AUGER_LIMIT_RECV_ID, self.get_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM).value])
-
-        ## Create sensors
-        self.bottom_limit_hall_effect = CommandSensor(
-            logger=logger,
-            bus=self.bus,
-            frame_id=self.AUGER_LIMIT_RECV_ID,
-            command_id=self.AUGER_RECV_LIMIT_BOTTOM_COMMAND_ID,
-            run_can=False
-        )
-
-        self.depth_hall_effect_sensor = ToggleCommandSensor(
-            logger=logger,
-            bus=self.bus,
-            frame_id=self.get_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM).value,
-            state_id_on=self.DEPTH_HIT_DATA,
-            state_id_off=self.DEPTH_NOT_HIT_DATA,
-            publisher = self.depth_publisher,
-        )
-
-        # Create limits
-        self.auger_bottom_limit = LimitSwitchLimit(
-            logger=logger,
-            bus=self.bus,
-            limit_switch=self.bottom_limit_hall_effect,
-        )
-
-        ## Create controls
-        self.auger_actuation = OneAxisVelocityControl(
-            logger=logger,
-            max_percent=self.AUGER_ACTUATION_MAX_PERCENT,
-            direction=self.AUGER_ACTUATION_UP,
-            neg_limit=self.auger_bottom_limit,
-        )
-        self.auger_drill = OneAxisVelocityControl(
-            logger=logger,
-            max_percent=self.get_parameter(self.AUGER_DRILL_MAX_PERCENT_PARAM).value,
-            direction=self.AUGER_DRILL_CLOCKWISE,
-        )
+        inputs = contexts[Inputs]
+        self.actuation_input = inputs.get_button(self.actuation_axis_name)
+        self.drill_input = inputs.get_axis(self.drill_axis_name)
+        self.speed_input = inputs.get_axis(self.speed_axis_name)
 
 
-        ## Create controllers
-        self.auger_actuation_controller = CMDVelocityController(
-            logger=logger,
-            bus=self.bus,
-            frame_id=self.get_parameter(self.AUGER_ACTUATION_CANID_PARAM).value,
-            control=self.auger_actuation
-        )
-        self.auger_drill_controller = CMDVelocityController(
-            logger=logger,
-            bus=self.bus,
-            frame_id=self.get_parameter(self.AUGER_DRILL_CANID_PARAM).value,
-            control=self.auger_drill
-        )
+    def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
+        """ Used to set up your Controller. Run once before any other class method.
+        Use this method to get data from self.node, and get references to any command or state interface you need.
 
-        ## Add the controllers to the node's of controllers
-        self.add_controller(self.AUGER_ACTUATION_NAME, self.auger_actuation_controller)
-        self.add_controller(self.AUGER_DRILL_NAME, self.auger_drill_controller)
+        :param command_interfaces: A collection of Interfaces used to send messages to hardware. Get any command
+        interfaces you need from this, then store them in member variables.
+        :param state_interfaces: A collection of Interfaces containing the current state of the robot. Get any state
+        interfaces you need from this, then store them in member variables.
+        :returns: None or True if configured successfully. False otherwise.
+        """
+        # Save references to interfaces
+        self.logger.info(f"Getting actuation/effort and drill/effort")
+        self.actuation_cmd = command_interfaces["actuation/effort"]
+        self.drill_cmd = command_interfaces["drill/effort"]
 
-        ## Start the CAN bus
-        self.start_can()
-
-    def update_auger_actuation(self, joystick_r: InputJoystick):
-        # Auger height direction is determined by the right joystick's x-axis direction
-        self.auger_actuation.update_direction(self.AUGER_ACTUATION_UP if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_DOWN)
-
-        # Auger velocity is determined by the right joystick's x-axis magnitude
-        if joystick_r.btn_thumb_d_state >= 1 or joystick_r.ax_stick_x < 0:
-            self.bottom_limit_hall_effect.set_sensor_value(False)
-            self.auger_bottom_limit.update_limit_hit(False)
-        self.auger_actuation.update_velocity(velocity=abs(joystick_r.ax_stick_x))
-
-
-    def update_auger_drill(self, joystick_r: InputJoystick):
-        # Drill spin direction is determined by the right joystick thumb buttons
-        # Thumb right = clockwise, Thumb left = counterclockwise
-        if joystick_r.btn_thumb_r_state >= 1:
-            self.auger_drill.update_direction(self.AUGER_DRILL_CLOCKWISE)
-        elif joystick_r.btn_thumb_l_state >= 1:
-            self.auger_drill.update_direction(self.AUGER_DRILL_COUNTERCLOCKWISE)
-
-        # Drill spin velocity is determined by the right joystick trigger
-        if joystick_r.btn_thumb_u_state >= 1:
-            self.auger_drill.update_velocity(1.0)
-        else:
-            self.auger_drill.update_velocity(0)
-
-    def joystick_l(self, joystick_l: InputJoystick):
-        pass
-
-    def joystick_r(self, joystick_r: InputJoystick):
-        self.update_auger_actuation(joystick_r)
-        self.update_auger_drill(joystick_r)
-
-
-def main():
-    rclpy.init()
-    node = URCAuger()
-    rclpy.spin(node)
-    rclpy.shutdown()
-
+    def on_update(self, now: float, period: float):
+        """ Called on every update. You should read values from state interfaces, and set values on command interfaces
+            here.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        # Update Command Interfaces
+        # self.cmd.value = 2 * self.state.value
+        # self.logger.info(f"{self.state.value} -> {self.cmd.value}")
 
 if __name__ == "__main__":
-    main()
+    print("Setting up!")
+
+    rclpy.init()
+
+    node = Node("auger")
+    inputs = Inputs(node).with_topics("/science/input")
+
+    PythonControl(node, update_rate=5, can_bus="can1") \
+        .with_controller("controller", AugerController) \
+        .with_hardware("actuation", CMDHardware, can_id=0x0C2, max_effort=0.75) \
+        .with_hardware("drill", CMDHardware, can_id=0x0C1, max_effort=0.6) \
+        .with_teleop(inputs) \
+        .with_jcan() \
+        .spin()

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -111,7 +111,8 @@ if __name__ == "__main__":
     node = Node("auger")
     inputs = Inputs(node).with_topics("/science/input")
 
-    PythonControl(node, update_rate=5, can_bus="can1") \
+    # ARCh auger system
+    PythonControl(node, update_rate=10, can_bus="can1") \
         .with_controller("controller", AugerController) \
         .with_hardware("actuation", QCMDHardware, can_id=0xC2) \
         .with_hardware("drill", QCMDHardware, can_id=0xC1) \

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -106,6 +106,6 @@ if __name__ == "__main__":
         .with_hardware("actuation", QCMDHardware, can_id=0xC2, max_effort=1) \
         .with_hardware("drill", QCMDHardware, can_id=0xC1, max_effort=1) \
         .with_teleop(inputs) \
-        .with_activation_buttons(start_active=True, active_button_name="select_auger", inactive_button_pool_names=["select_cbeam"]) \
+        .with_activation_buttons(start_active=True, active_button_name="activate_auger", inactive_button_pool_names=["activate_cbeam"]) \
         .with_jcan() \
         .spin()

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -94,6 +94,7 @@ class AugerController(Controller):
 
     def update_drill_direction(self, direction: Direction):
         def update_drill():
+            self.logger.info(f"updated auger drill direction: {"CLOCKWISE" if direction == Direction.POSITIVE else "ANTICLOCKWISE"}")
             self.drill_direction = direction
         return update_drill
 

--- a/src/ros/rover/science/science/science/auger.py
+++ b/src/ros/rover/science/science/science/auger.py
@@ -15,7 +15,7 @@ EDITED:         13/01/26
 import rclpy
 from rclpy.node import Node
 from typing import Optional
-from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, Direction
+from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, Direction, Activation
 from python_control2.hardware_interfaces import QCMDHardware
 from teleop_python_utils import Inputs
 
@@ -35,6 +35,7 @@ class AugerController(Controller):
         self.logger.info(f"AugerController -- I have been __init__ialized")
 
         self.drill_direction = Direction.POSITIVE
+        self.active = contexts[Activation]
 
         # Get inputs
         # Actuation axis
@@ -75,6 +76,10 @@ class AugerController(Controller):
         :param now: The current time, in seconds
         :param period: The time elapsed since the last update, in seconds.
         """
+        if not self.active:
+            self.drill_cmd.value = 0
+            self.actuation_cmd.value = 0
+
         # Update Command Interfaces
         # Update drill speed
         self.drill_cmd.value = self.drill_button.value * self.speed_axis.value * self.drill_direction.value
@@ -101,5 +106,6 @@ if __name__ == "__main__":
         .with_hardware("actuation", QCMDHardware, can_id=0xC2, max_effort=1) \
         .with_hardware("drill", QCMDHardware, can_id=0xC1, max_effort=1) \
         .with_teleop(inputs) \
+        .with_activation_buttons(start_active=True, active_button_name="select_auger", inactive_button_pool_names=["select_cbeam"]) \
         .with_jcan() \
         .spin()

--- a/src/ros/rover/science/science/science/auger_old.py
+++ b/src/ros/rover/science/science/science/auger_old.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+
+from python_control.sensors.ToggleCommandSensor import ToggleCommandSensor
+from python_control.limits.LimitSwitchLimit import LimitSwitchLimit
+from python_control.controls.Direction import Direction
+from python_control.controls.OneAxisVelocityControl import OneAxisVelocityControl
+from python_control.controllers.CMDVelocityController import CMDVelocityController
+from python_control.sensors.CommandSensor import CommandSensor
+from python_control.ActivatedJoystickControllerNode import ActivatedJoystickControllerNode
+import rclpy
+from input_interfaces.msg import InputJoystick
+from std_msgs.msg import Bool
+
+
+class URCAuger(ActivatedJoystickControllerNode):
+
+    # CAN BUS NAME
+    # The name of the CAN bus to use
+    CAN_BUS = "can1"
+
+    # SENDING CARD IDS
+    # Add any CONTROL FRAME / CARD IDS here
+    AUGER_ACTUATION_CANID_PARAM = "auger_actuation_canid"
+    AUGER_ACTUATION_SEND_FRAME_ID = 0x0C2
+    AUGER_DRILL_CANID_PARAM = "auger_drill_canid"
+    AUGER_DRILL_SEND_FRAME_ID = 0x0C1
+
+    # RECEIVING CARD IDS
+    # Add any SENSOR FRAME / CARD IDS here
+    AUGER_LIMIT_RECV_ID = 0x452
+
+
+    # DEPTH HALL SENSORS CAN INFO
+    AUGER_HALL_SENSOR_CANID_PARAM = "auger_hall_sensor_canid"
+    DEFAULT_AUGER_HALL_SENSOR_CANID_PARAM = 0x4A2
+    DEPTH_HIT_DATA = 0x01
+    DEPTH_NOT_HIT_DATA = 0x00
+
+    # PUBLISHING DEPTH INFORMATION
+    AUGER_DEPTH_TOPIC_PREFIX = "/science/auger_depth/"
+
+    # CONTROL NAMES
+    # Add any CONTROL names here
+    AUGER_ACTUATION_NAME = "auger_actuation"
+    AUGER_DRILL_NAME = "auger_drill"
+
+    # CONTROL PARAMETERS
+    # Max Speed as a Percentage (0.0 to 1.0)
+    AUGER_ACTUATION_MAX_PERCENT = 0.75
+    AUGER_DRILL_MAX_PERCENT = 0.6
+    AUGER_DRILL_MAX_PERCENT_PARAM = "max_percent"
+
+    # SENDING COMMAND IDS
+    # Add any CONTROL command ids here
+    STEPPER_SEND_COMMAND_ID = 0x01
+
+    # RECEIVING COMMAND IDS
+    # Add any SENSOR command ids here
+    AUGER_RECV_LIMIT_BOTTOM_COMMAND_ID = 0x01
+    AUGER_RECV_DEPTH_LIMIT_HIT_COMMAND_ID = 0x01
+
+    # CONTROL DIRECTIONS
+    # Add any CONTROL DIRECTIONS here
+    AUGER_ACTUATION_UP = Direction.NEGATIVE
+    AUGER_ACTUATION_DOWN = Direction.POSITIVE
+    AUGER_DRILL_CLOCKWISE = Direction.POSITIVE
+    AUGER_DRILL_COUNTERCLOCKWISE = Direction.NEGATIVE
+
+    def __init__(self):
+        super(URCAuger, self).__init__(name="Auger", can_bus=self.CAN_BUS)
+        logger = self.get_logger()
+
+        # Setting ROS parameters
+        self.declare_parameter(self.AUGER_ACTUATION_CANID_PARAM, self.AUGER_ACTUATION_SEND_FRAME_ID)
+        self.declare_parameter(self.AUGER_DRILL_CANID_PARAM, self.AUGER_DRILL_SEND_FRAME_ID)
+        self.declare_parameter(self.AUGER_DRILL_MAX_PERCENT_PARAM, self.AUGER_DRILL_MAX_PERCENT)
+        self.declare_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM, self.DEFAULT_AUGER_HALL_SENSOR_CANID_PARAM)
+        self.get_logger().info(f"CAN IDs: Actuation = {self.get_parameter(self.AUGER_ACTUATION_CANID_PARAM).value} Drill = {self.get_parameter(self.AUGER_DRILL_CANID_PARAM).value}")
+
+        ## Add publishers
+        self.depth_publisher = self.create_publisher(
+            Bool,
+            self.AUGER_DEPTH_TOPIC_PREFIX + self.get_name(),
+            10
+        )
+
+        ## Add CAN ID Filters
+        self.bus.set_id_filter([self.AUGER_LIMIT_RECV_ID, self.get_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM).value])
+
+        ## Create sensors
+        self.bottom_limit_hall_effect = CommandSensor(
+            logger=logger,
+            bus=self.bus,
+            frame_id=self.AUGER_LIMIT_RECV_ID,
+            command_id=self.AUGER_RECV_LIMIT_BOTTOM_COMMAND_ID,
+            run_can=False
+        )
+
+        self.depth_hall_effect_sensor = ToggleCommandSensor(
+            logger=logger,
+            bus=self.bus,
+            frame_id=self.get_parameter(self.AUGER_HALL_SENSOR_CANID_PARAM).value,
+            state_id_on=self.DEPTH_HIT_DATA,
+            state_id_off=self.DEPTH_NOT_HIT_DATA,
+            publisher = self.depth_publisher,
+        )
+
+        # Create limits
+        self.auger_bottom_limit = LimitSwitchLimit(
+            logger=logger,
+            bus=self.bus,
+            limit_switch=self.bottom_limit_hall_effect,
+        )
+
+        ## Create controls
+        self.auger_actuation = OneAxisVelocityControl(
+            logger=logger,
+            max_percent=self.AUGER_ACTUATION_MAX_PERCENT,
+            direction=self.AUGER_ACTUATION_UP,
+            neg_limit=self.auger_bottom_limit,
+        )
+        self.auger_drill = OneAxisVelocityControl(
+            logger=logger,
+            max_percent=self.get_parameter(self.AUGER_DRILL_MAX_PERCENT_PARAM).value,
+            direction=self.AUGER_DRILL_CLOCKWISE,
+        )
+
+
+        ## Create controllers
+        self.auger_actuation_controller = CMDVelocityController(
+            logger=logger,
+            bus=self.bus,
+            frame_id=self.get_parameter(self.AUGER_ACTUATION_CANID_PARAM).value,
+            control=self.auger_actuation
+        )
+        self.auger_drill_controller = CMDVelocityController(
+            logger=logger,
+            bus=self.bus,
+            frame_id=self.get_parameter(self.AUGER_DRILL_CANID_PARAM).value,
+            control=self.auger_drill
+        )
+
+        ## Add the controllers to the node's of controllers
+        self.add_controller(self.AUGER_ACTUATION_NAME, self.auger_actuation_controller)
+        self.add_controller(self.AUGER_DRILL_NAME, self.auger_drill_controller)
+
+        ## Start the CAN bus
+        self.start_can()
+
+    def update_auger_actuation(self, joystick_r: InputJoystick):
+        # Auger height direction is determined by the right joystick's x-axis direction
+        self.auger_actuation.update_direction(self.AUGER_ACTUATION_UP if joystick_r.ax_stick_x <= 0 else self.AUGER_ACTUATION_DOWN)
+
+        # Auger velocity is determined by the right joystick's x-axis magnitude
+        if joystick_r.btn_thumb_d_state >= 1 or joystick_r.ax_stick_x < 0:
+            self.bottom_limit_hall_effect.set_sensor_value(False)
+            self.auger_bottom_limit.update_limit_hit(False)
+        self.auger_actuation.update_velocity(velocity=abs(joystick_r.ax_stick_x))
+
+
+    def update_auger_drill(self, joystick_r: InputJoystick):
+        # Drill spin direction is determined by the right joystick thumb buttons
+        # Thumb right = clockwise, Thumb left = counterclockwise
+        if joystick_r.btn_thumb_r_state >= 1:
+            self.auger_drill.update_direction(self.AUGER_DRILL_CLOCKWISE)
+        elif joystick_r.btn_thumb_l_state >= 1:
+            self.auger_drill.update_direction(self.AUGER_DRILL_COUNTERCLOCKWISE)
+
+        # Drill spin velocity is determined by the right joystick trigger
+        if joystick_r.btn_thumb_u_state >= 1:
+            self.auger_drill.update_velocity(1.0)
+        else:
+            self.auger_drill.update_velocity(0)
+
+    def joystick_l(self, joystick_l: InputJoystick):
+        pass
+
+    def joystick_r(self, joystick_r: InputJoystick):
+        self.update_auger_actuation(joystick_r)
+        self.update_auger_drill(joystick_r)
+
+
+def main():
+    rclpy.init()
+    node = URCAuger()
+    rclpy.spin(node)
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ros/rover/science/science_bringup/launch/arc_old.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc_old.launch.py
@@ -2,7 +2,7 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ARC launch file for science payload
 
-[NEW] version - use teleop science with this.
+[OLD] version - must use launch-base with this
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODES:
   - science/analysis_arm.py             [analysis_arm]
@@ -14,8 +14,8 @@ NODES:
   - science/kiln_server.py              [kiln_server]
   - science/scimbal_cam.py              [scimbal_cam]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-CREATED:    16/01/2026
-EDITED:     16/01/2026
+CREATED:    12/01/2026
+EDITED:     12/01/2026
 EDITED BY:  Felicity Matthews
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
@@ -30,13 +30,40 @@ def launch_setup(context, *args, **kwargs):
 
     return [
         # Analysis Arm - Nodes for components on the analysis arm
-
-
-        # CBeam - Nodes for components on the CBeam
         Node(
-            name='auger',
+            name='analysis_arm',
             package='science',
-            executable='auger.py',
+            executable='analysis_arm.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='nir_probe_publisher',
+            package='science',
+            executable='nir_probe_publisher.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='arc_sweeper_servo',
+            package='science',
+            executable='arc_sweeper_servo.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='arc_spinny_part',
+            package='science',
+            executable='arc_spinny_part.py',
             output='screen',
             emulate_tty=True,
             parameters=[
@@ -44,9 +71,49 @@ def launch_setup(context, *args, **kwargs):
             ],
         ),
 
+        # CBeam - Nodes for components on the CBeam
+        Node(
+            name='auger',
+            package='science',
+            executable='auger_old.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='c_beam',
+            package='science',
+            executable='analysis_arm.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='kiln_server',
+            package='science',
+            executable='kiln_server.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
 
         # Misc - Nodes for misc components
-
+        Node(
+            name='scimbal_cam',
+            package='science',
+            executable='scimbal_cam.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
     ]
 
 def generate_launch_description():
@@ -65,7 +132,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='science_params',
-            default_value=PathJoinSubstitution([science_bringup_dir, 'params', 'arc.yaml']),
+            default_value=PathJoinSubstitution([science_bringup_dir, 'params', 'arc_old.yaml']),
             description='The main parameter file to use for the science nodes',
         ),
     ]

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -5,29 +5,7 @@
 
 # Analysis Arm - Nodes for components on the analysis arm
 
-analysis_arm:
-  ros__parameters:
-    cmd_id: 0x0D2
-    active: true
-    active_button: "btn_bottom_l1_state"
-    inactive_button_pool:
-      - "btn_bottom_l4_state"
-    using_left_joystick: true
 
-nir_probe_publisher:
-  ros__parameters: {}
-
-arc_sweeper_servo:
-  ros__parameters:
-    servo_id: 0x0A0
-    clockwise_command: 0x01
-    anticlockwise_command: 0x02
-
-
-arc_spinny_part:
-  ros__parameters:
-    servo_id: 0x0A0
-    servo_command: 0x04
 
 # CBeam - Nodes for components on the CBeam
 
@@ -37,20 +15,6 @@ auger:
     auger_actuation_canid: 0x0D1
     max_percent: 0.6
 
-c_beam:
-  ros__parameters:
-    cmd_id: 0x0C2
-    active: false
-    active_button: "btn_bottom_l4_state"
-    inactive_button_pool:
-      - "btn_bottom_l1_state"
-    using_left_joystick: true
-
-kiln_server:
-  ros__parameters: {}
 
 # Misc - Nodes for misc components
 
-scimbal_cam:
-  ros__parameters:
-    servo_ids: [0x0B0, 0x0B0]

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -11,9 +11,19 @@
 
 auger:
   ros__parameters:
-    auger_drill_canid: 0x0C1
-    auger_actuation_canid: 0x0D1
-    max_percent: 0.6
+    can_bus: "can1"
+    active: true
+    active_button: "activate_auger"
+    inactive_button_pool: ["activate_cbeam"]
+    hardware:
+      actuation:
+        can_id: 0x0C2
+        max_effort: 1.0
+        reversed: false
+      drill:
+        can_id: 0x0C1
+        max_effort: 0.5
+        reversed: false
 
 
 # Misc - Nodes for misc components

--- a/src/ros/rover/science/science_bringup/params/arc_old.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc_old.yaml
@@ -1,0 +1,56 @@
+# ==========================================================
+# Monash Nova Rover
+# ARC Science – Default Parameter File
+# ==========================================================
+
+# Analysis Arm - Nodes for components on the analysis arm
+
+analysis_arm:
+  ros__parameters:
+    cmd_id: 0x0D2
+    active: true
+    active_button: "btn_bottom_l1_state"
+    inactive_button_pool:
+      - "btn_bottom_l4_state"
+    using_left_joystick: true
+
+nir_probe_publisher:
+  ros__parameters: {}
+
+arc_sweeper_servo:
+  ros__parameters:
+    servo_id: 0x0A0
+    clockwise_command: 0x01
+    anticlockwise_command: 0x02
+
+
+arc_spinny_part:
+  ros__parameters:
+    servo_id: 0x0A0
+    servo_command: 0x04
+
+# CBeam - Nodes for components on the CBeam
+
+auger:
+  ros__parameters:
+    auger_drill_canid: 0x0C1
+    auger_actuation_canid: 0x0D1
+    max_percent: 0.6
+
+c_beam:
+  ros__parameters:
+    cmd_id: 0x0C2
+    active: false
+    active_button: "btn_bottom_l4_state"
+    inactive_button_pool:
+      - "btn_bottom_l1_state"
+    using_left_joystick: true
+
+kiln_server:
+  ros__parameters: {}
+
+# Misc - Nodes for misc components
+
+scimbal_cam:
+  ros__parameters:
+    servo_ids: [0x0B0, 0x0B0]

--- a/src/ros/rover/science/teleop_science/launch/teleop.launch.py
+++ b/src/ros/rover/science/teleop_science/launch/teleop.launch.py
@@ -38,7 +38,7 @@ def launch_setup(context, *args, **kwargs):
             executable='game_controller_node',  # or joy_node
             output="screen",
             remappings=[
-                ("/joy", "science/joy")
+                ("/joy", "/science/joy")
             ],
         ),
 
@@ -54,7 +54,7 @@ def launch_setup(context, *args, **kwargs):
                         {"device_id": 0, },
                     ],
                     remappings=[
-                        ("/joy", "science/joy/left")
+                        ("/joy", "/science/joy/left")
                     ],
                 ),
                 Node(
@@ -66,7 +66,7 @@ def launch_setup(context, *args, **kwargs):
                         {"device_id": 1, },
                     ],
                     remappings=[
-                        ("/joy", "science/joy/right")
+                        ("/joy", "/science/joy/right")
                     ],
                 ),
             ],

--- a/src/ros/rover/science/teleop_science/launch/teleop.launch.py
+++ b/src/ros/rover/science/teleop_science/launch/teleop.launch.py
@@ -36,7 +36,10 @@ def launch_setup(context, *args, **kwargs):
             condition=UnlessCondition(use_joysticks),
             package='joy',
             executable='game_controller_node',  # or joy_node
-            output="screen"
+            output="screen",
+            remappings=[
+                ("/joy", "science/joy")
+            ],
         ),
 
         GroupAction(
@@ -51,7 +54,7 @@ def launch_setup(context, *args, **kwargs):
                         {"device_id": 0, },
                     ],
                     remappings=[
-                        ("/joy", "/joy_left")
+                        ("/joy", "science/joy/left")
                     ],
                 ),
                 Node(
@@ -63,7 +66,7 @@ def launch_setup(context, *args, **kwargs):
                         {"device_id": 1, },
                     ],
                     remappings=[
-                        ("/joy", "/joy_right")
+                        ("/joy", "science/joy/right")
                     ],
                 ),
             ],

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -67,3 +67,7 @@ game_controller_source:
           from: "B"
         spinny_pos_1:
           from: "X"
+        activate_auger:
+          from: "PADDLE1"
+        activate_cbeam:
+          from: "PADDLE2"

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -68,6 +68,6 @@ game_controller_source:
         spinny_pos_1:
           from: "X"
         activate_auger:
-          from: "PADDLE1"
+          from: "DPAD_UP"
         activate_cbeam:
-          from: "PADDLE2"
+          from: "DPAD_LEFT"

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -57,6 +57,10 @@ game_controller_source:
           from: "LEFTY"
 
       buttons:
+        lock:
+          from: "BACK"
+        unlock:
+          from: "START"
         sweeper_sweep:
           from: "A"
         twitch:

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -65,7 +65,7 @@ game_controller_source:
           from: "START"
         auger_drill_clockwise:
           from: "A"
-        auger_drill_antclockwise:
+        auger_drill_anticlockwise:
           from: "B"
         spinny_pos_1:
           from: "X"

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -53,6 +53,8 @@ game_controller_source:
       axes:
         auger_actuation:
           from: "RIGHTY"
+        auger_drill_speed:
+          from: "LEFTY"
         cbeam_actuation:
           from: "LEFTY"
 
@@ -61,9 +63,9 @@ game_controller_source:
           from: "BACK"
         unlock:
           from: "START"
-        sweeper_sweep:
+        auger_drill_clockwise:
           from: "A"
-        twitch:
+        auger_drill_antclockwise:
           from: "B"
         spinny_pos_1:
           from: "X"
@@ -71,3 +73,5 @@ game_controller_source:
           from: "DPAD_UP"
         activate_cbeam:
           from: "DPAD_LEFT"
+        auger_drill:
+          from: "DPAD_DOWN"

--- a/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/game_controller.config.yaml
@@ -12,7 +12,7 @@ teleop_science:
 
 game_controller_source:
   ros__parameters:
-    topic: "/joy"
+    topic: "/science/joy"
     # These are the default mappings for a game_controller_node.
     # https://docs.ros.org/en/ros2_packages/rolling/api/joy/index.html
     # If you use joy_node, you'll need to figure out what the mapping is yourself.

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -45,10 +45,6 @@ thrustmaster_left:
     ]
 
     remap:
-      axes:
-        cbeam_actuation:
-          from: "ax_stick_x"
-
       buttons:
         lock:
           from: "btn_bottom_l2_state"
@@ -98,3 +94,7 @@ thrustmaster_right:
       buttons:
         sweeper_sweep:
           from: "btn_bottom_r5_state"
+        activate_auger:
+          from: "btn_bottom_l4_state"
+        activate_cbeam:
+          from: "btn_bottom_l1_state"

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -56,7 +56,7 @@ thrustmaster_right:
   ros__parameters:
     topic: "/science/joy/right"
     button_definitions: [
-      "auger_drill",        # Up / Trigger (behind the thumbstick)
+      "r_btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
       "r_btn_thumb_d_state",        # Down
       "r_btn_thumb_l_state",        # Buttons located near the thumb stick (Left)
       "r_btn_thumb_r_state",        # Right
@@ -78,7 +78,7 @@ thrustmaster_right:
       "r_ax_stick_x",               # Left/right
       "r_ax_stick_y",               # Forward/backwards
       "r_ax_stick_twist",           # Twist
-      "auger_drill_speed",
+      "r_ax_slider",
       "r_ax_thumb_x",               # Thumb Axis Data (left/right)
       "r_ax_thumb_y"                # Each Thumb axis can be -1, 0 or 1 (up/down)
     ]

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -15,7 +15,7 @@ teleop_science:
 
 thrustmaster_left:
   ros__parameters:
-    topic: "/joy/left"
+    topic: "science/joy/left"
     button_definitions: [
       "btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
       "btn_thumb_d_state",        # Down
@@ -57,7 +57,7 @@ thrustmaster_left:
 
 thrustmaster_right:
   ros__parameters:
-    topic: "/joy/right"
+    topic: "/science/joy/right"
     button_definitions: [
       "btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
       "btn_thumb_d_state",        # Down

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -46,14 +46,11 @@ thrustmaster_left:
 
     remap:
       buttons:
+        # Lock/Unlock
         lock:
           from: "l_btn_bottom_l2_state"
         unlock:
           from: "l_btn_bottom_l5_state"
-        twitch:
-          from: "l_btn_bottom_r5_state"
-        spinny_pos_1:
-          from: "l_btn_bottom_r1_state"
 
 thrustmaster_right:
   ros__parameters:
@@ -88,12 +85,14 @@ thrustmaster_right:
 
     remap:
       axes:
+        # Auger
         auger_actuation:
           from: "r_ax_stick_y"
         auger_drill_speed:
           from: "r_ax_slider"
 
       buttons:
+        # Auger
         auger_drill:
           from: "r_btn_thumb_u_state"
         sweeper_sweep:
@@ -102,3 +101,7 @@ thrustmaster_right:
           from: "r_btn_bottom_l4_state"
         activate_cbeam:
           from: "r_btn_bottom_l1_state"
+        auger_drill_clockwise:
+          from: "r_btn_thumb_r_state"
+        auger_drill_anticlockwise:
+          from: "r_btn_thumb_l_state"

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -17,86 +17,88 @@ thrustmaster_left:
   ros__parameters:
     topic: "/science/joy/left"
     button_definitions: [
-      "btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
-      "btn_thumb_d_state",        # Down
-      "btn_thumb_l_state",        # Buttons located near the thumb stick (Left)
-      "btn_thumb_r_state",        # Right
-      "btn_bottom_l1_state",      # Buttons located at the bottom left
-      "btn_bottom_l2_state",      # Numbered Left to Right, First then Second row
-      "btn_bottom_l3_state",      # Ordered top left to right, bottom right to left
-      "btn_bottom_l6_state",
-      "btn_bottom_l5_state",
-      "btn_bottom_l4_state",
-      "btn_bottom_r3_state",      # Buttons located at the bottom right
-      "btn_bottom_r2_state",      # Numbered Left to Right, First then Second row
-      "btn_bottom_r1_state",      # Ordered top right to left, bottom left to right
-      "btn_bottom_r4_state",
-      "btn_bottom_r5_state",
-      "btn_bottom_r6_state"
+      "l_btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
+      "l_btn_thumb_d_state",        # Down
+      "l_btn_thumb_l_state",        # Buttons located near the thumb stick (Left)
+      "l_btn_thumb_r_state",        # Right
+      "l_btn_bottom_l1_state",      # Buttons located at the bottom left
+      "l_btn_bottom_l2_state",      # Numbered Left to Right, First then Second row
+      "l_btn_bottom_l3_state",      # Ordered top left to right, bottom right to left
+      "l_btn_bottom_l6_state",
+      "l_btn_bottom_l5_state",
+      "l_btn_bottom_l4_state",
+      "l_btn_bottom_r3_state",      # Buttons located at the bottom right
+      "l_btn_bottom_r2_state",      # Numbered Left to Right, First then Second row
+      "l_btn_bottom_r1_state",      # Ordered top right to left, bottom left to right
+      "l_btn_bottom_r4_state",
+      "l_btn_bottom_r5_state",
+      "l_btn_bottom_r6_state"
     ]
 
     axis_definitions: [
-      "ax_stick_x",               # Left/right
-      "ax_stick_y",               # Forward/backwards
-      "ax_stick_twist",           # Twist
-      "ax_slider",
-      "ax_thumb_x",               # Thumb Axis Data (left/right)
-      "ax_thumb_y"                # Each Thumb axis can be -1, 0 or 1 (up/down)
+      "l_ax_stick_x",               # Left/right
+      "l_ax_stick_y",               # Forward/backwards
+      "l_ax_stick_twist",           # Twist
+      "l_ax_slider",
+      "l_ax_thumb_x",               # Thumb Axis Data (left/right)
+      "l_ax_thumb_y"                # Each Thumb axis can be -1, 0 or 1 (up/down)
     ]
 
     remap:
       buttons:
         lock:
-          from: "btn_bottom_l2_state"
+          from: "l_btn_bottom_l2_state"
         unlock:
-            from: "btn_bottom_l5_state"
+          from: "l_btn_bottom_l5_state"
         twitch:
-          from: "btn_bottom_r5_state"
+          from: "l_btn_bottom_r5_state"
         spinny_pos_1:
-          from: "btn_bottom_r1_state"
+          from: "l_btn_bottom_r1_state"
 
 thrustmaster_right:
   ros__parameters:
     topic: "/science/joy/right"
     button_definitions: [
-      "btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
-      "btn_thumb_d_state",        # Down
-      "btn_thumb_l_state",        # Buttons located near the thumb stick (Left)
-      "btn_thumb_r_state",        # Right
-      "btn_bottom_l1_state",      # Buttons located at the bottom left
-      "btn_bottom_l2_state",      # Numbered Left to Right, First then Second row
-      "btn_bottom_l3_state",      # Ordered top left to right, bottom right to left
-      "btn_bottom_l6_state",
-      "btn_bottom_l5_state",
-      "btn_bottom_l4_state",
-      "btn_bottom_r3_state",      # Buttons located at the bottom right
-      "btn_bottom_r2_state",      # Numbered Left to Right, First then Second row
-      "btn_bottom_r1_state",      # Ordered top right to left, bottom left to right
-      "btn_bottom_r4_state",
-      "btn_bottom_r5_state",
-      "btn_bottom_r6_state"
+      "auger_drill",        # Up / Trigger (behind the thumbstick)
+      "r_btn_thumb_d_state",        # Down
+      "r_btn_thumb_l_state",        # Buttons located near the thumb stick (Left)
+      "r_btn_thumb_r_state",        # Right
+      "r_btn_bottom_l1_state",      # Buttons located at the bottom left
+      "r_btn_bottom_l2_state",      # Numbered Left to Right, First then Second row
+      "r_btn_bottom_l3_state",      # Ordered top left to right, bottom right to left
+      "r_btn_bottom_l6_state",
+      "r_btn_bottom_l5_state",
+      "r_btn_bottom_l4_state",
+      "r_btn_bottom_r3_state",      # Buttons located at the bottom right
+      "r_btn_bottom_r2_state",      # Numbered Left to Right, First then Second row
+      "r_btn_bottom_r1_state",      # Ordered top right to left, bottom left to right
+      "r_btn_bottom_r4_state",
+      "r_btn_bottom_r5_state",
+      "r_btn_bottom_r6_state"
     ]
 
     axis_definitions: [
-      "ax_stick_x",               # Left/right
-      "ax_stick_y",               # Forward/backwards
-      "ax_stick_twist",           # Twist
-      "ax_slider",
-      "ax_thumb_x",               # Thumb Axis Data (left/right)
-      "ax_thumb_y"                # Each Thumb axis can be -1, 0 or 1 (up/down)
+      "r_ax_stick_x",               # Left/right
+      "r_ax_stick_y",               # Forward/backwards
+      "r_ax_stick_twist",           # Twist
+      "auger_drill_speed",
+      "r_ax_thumb_x",               # Thumb Axis Data (left/right)
+      "r_ax_thumb_y"                # Each Thumb axis can be -1, 0 or 1 (up/down)
     ]
 
     remap:
       axes:
         auger_actuation:
-          from: "ax_stick_x"
+          from: "r_ax_stick_y"
         auger_drill_speed:
-          from: "ax_slider"
+          from: "r_ax_slider"
 
       buttons:
+        auger_drill:
+          from: "r_btn_thumb_u_state"
         sweeper_sweep:
-          from: "btn_bottom_r5_state"
+          from: "r_btn_bottom_r5_state"
         activate_auger:
-          from: "btn_bottom_l4_state"
+          from: "r_btn_bottom_l4_state"
         activate_cbeam:
-          from: "btn_bottom_l1_state"
+          from: "r_btn_bottom_l1_state"

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -90,6 +90,8 @@ thrustmaster_right:
       axes:
         auger_actuation:
           from: "ax_stick_x"
+        auger_drill_speed:
+          from: "ax_slider"
 
       buttons:
         sweeper_sweep:

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -15,7 +15,7 @@ teleop_science:
 
 thrustmaster_left:
   ros__parameters:
-    topic: "science/joy/left"
+    topic: "/science/joy/left"
     button_definitions: [
       "btn_thumb_u_state",        # Up / Trigger (behind the thumbstick)
       "btn_thumb_d_state",        # Down

--- a/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/joysticks.config.yaml
@@ -50,6 +50,10 @@ thrustmaster_left:
           from: "ax_stick_x"
 
       buttons:
+        lock:
+          from: "btn_bottom_l2_state"
+        unlock:
+            from: "btn_bottom_l5_state"
         twitch:
           from: "btn_bottom_r5_state"
         spinny_pos_1:

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -54,12 +54,13 @@ input_publisher_mode:
     input_names_topic: "/science/input"
 
     axis_names:
+      # Auger
       - "auger_actuation"   # actuation for both the auger and the c-beam.
       - "auger_drill_speed"
     button_names:
-      - "sweeper_sweep"
-      - "twitch"
-      - "spinny_pos_1"
+      # Auger
       - "activate_auger"
       - "activate_cbeam"
       - "auger_drill"
+      - "auger_drill_clockwise"
+      - "auger_drill_anticlockwise"

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -31,6 +31,7 @@ teleop_science:
         lock:
           on_any:
             - "lock/down"
+            - "start"
           type: set_button
           name: "locked"
           value: true

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -53,9 +53,10 @@ input_publisher_mode:
     input_names_topic: "/science/input"
 
     axis_names:
-      - "auger_actuation"
-      - "cbeam_actuation"
+      - "auger_actuation"   # actuation for both the auger and the c-beam.
     button_names:
       - "sweeper_sweep"
       - "twitch"
       - "spinny_pos_1"
+      - "activate_auger"
+      - "activate_cbeam"

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -55,9 +55,11 @@ input_publisher_mode:
 
     axis_names:
       - "auger_actuation"   # actuation for both the auger and the c-beam.
+      - "auger_drill_speed"
     button_names:
       - "sweeper_sweep"
       - "twitch"
       - "spinny_pos_1"
       - "activate_auger"
       - "activate_cbeam"
+      - "auger_drill"

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -20,34 +20,34 @@ teleop_science:
         type: "input_publisher_mode/InputPublisherMode"
         active: true
 
-      # Add lock and unlock commands
-      commands:
-        names:
-          - lock
-          - unlock
-          - log_locked
-          - log_unlocked
+    # Add lock and unlock commands
+    commands:
+      names:
+        - lock
+        - unlock
+        - log_locked
+        - log_unlocked
 
-        lock:
-          on_any:
-            - "lock/down"
-            - "start"
-          type: set_button
-          name: "locked"
-          value: true
-        unlock:
-          on: "unlock/down"
-          type: set_button
-          name: "locked"
-          value: false
-        log_locked:
-          on: "locked/down"
-          type: log
-          message: "Locked"
-        log_unlocked:
-          on: "locked/up"
-          type: log
-          message: "Unlocked"
+      lock:
+        on_any:
+          - "lock/down"
+          - "start"
+        type: set_button
+        name: "locked"
+        value: true
+      unlock:
+        on: "unlock/down"
+        type: set_button
+        name: "locked"
+        value: false
+      log_locked:
+        on: "locked/down"
+        type: log
+        message: "Locked"
+      log_unlocked:
+        on: "locked/up"
+        type: log
+        message: "Unlocked"
 
 input_publisher_mode:
   ros__parameters:

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -20,6 +20,34 @@ teleop_science:
         type: "input_publisher_mode/InputPublisherMode"
         active: true
 
+      # Add lock and unlock commands
+      commands:
+        names:
+          - lock
+          - unlock
+          - log_locked
+          - log_unlocked
+
+        lock:
+          on_any:
+            - "lock/down"
+          type: set_button
+          name: "locked"
+          value: true
+        unlock:
+          on: "unlock/down"
+          type: set_button
+          name: "locked"
+          value: false
+        log_locked:
+          on: "locked/down"
+          type: log
+          message: "Locked"
+        log_unlocked:
+          on: "locked/up"
+          type: log
+          message: "Unlocked"
+
 input_publisher_mode:
   ros__parameters:
     input_names_topic: "/science/input"


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Migrate the auger code to python control2.

Includes the addition of a new launch file for new code, teleop locking capabilities, and the ability to activate and deactivate pc2 systems.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- migrate auger code
- add qcmd hardware interface
- create new launch file script and params
- add pc2 activation ability
- configure locking functionality to teleop science.

## Steps to test

run:
```
ros2 run science auger.py
```

```
ros2 launch teleop_science teleop.launch.py joystick:=false
```
can play around with params and add `local:=true` to use local directory.

check can output:
```
candump can1
```

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/2a5d71a4-f5d4-43b3-ad03-7981dc4e5d08" />

