### PR TITLE
nixfiles: backport null replacestdenv fix for hydra

### DIFF
--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -8,6 +8,13 @@
 let
   revisions = builtins.fromJSON (builtins.readFile ./revisions.json);
 
+  # backport https://github.com/NixOS/nixpkgs/pull/481399
+  # remove once backported to nixos-unstable
+  nixpkgs-481399 = pkgs.fetchurl {
+    url = "https://github.com/NixOS/nixpkgs/commit/6c6d4daf79263066efae45467cb4a95021ad2bb8.patch";
+    hash = "sha256-ksg95OjJsI88gVUiHX2Iv0y63To4djgLxEof1dibwDk=";
+  };
+
   maybeApplyPatches = { src, patches, ... }@args: if patches == [ ] then src else pkgs.applyPatches args;
 
   # Pin the version of Nixpkgs to ensure reproducibility.
@@ -23,6 +30,7 @@ let
       inherit (revisions.nixpkgs) rev hash;
     };
     patches = [
+      nixpkgs-481399
     ];
   });
 


### PR DESCRIPTION
Backport this change https://github.com/NixOS/nixpkgs/pull/481399 to fix the following eval error.
```
in job ‘aarch64-linux’:
error:
       … in the left operand of the update (//) operator
         at /nix/store/dka4rx7wnw5vplli4j94ji07jhra563v-source/nixfiles/ci/jobsets/workspaces.nix:22:5:
           21|     # Build other workspace packages.
           22|     // hydraPatchedWorkspace.prebuiltPackages
             |     ^
           23|

       … while evaluating the attribute 'hydraPatchedWorkspace'
         at /nix/store/dka4rx7wnw5vplli4j94ji07jhra563v-source/nixfiles/ci/workspaces.nix:5:3:
            4|   workspace = (if rosDistro == null then novaPkgs.ros else novaPkgs.rosPackages.${rosDistro}).nova-workspace;
            5|   hydraPatchedWorkspace = workspace.override
             |   ^
            6|     # Some x86_64 packages fail to build in QEMU on Aarch64. Workarounds

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attempt to call something which is not a function but null: null
       at /nix/store/m4m87ssxc36y92fm3sqqc89ipd6sb7zv-source/pkgs/stdenv/custom/default.nix:34:7:
           33|       assert vanillaPackages.stdenv.targetPlatform == localSystem;
           34|       config.replaceStdenv { pkgs = vanillaPackages; };
             |       ^
           35|   })
```
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
