### PR TITLE
feat: can launch and logging

### DIFF
--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -14,7 +14,8 @@ CREATION:	15/12/2021
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
 from launch import LaunchDescription
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression, Command
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression, Command, \
+    IfElseSubstitution
 from launch.conditions import IfCondition, UnlessCondition
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction, GroupAction, ExecuteProcess, LogInfo
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -101,7 +102,11 @@ def launch_setup(context, *args, **kwargs):
                     ),
                     launch_arguments={
                         "bus" : "can1",
-                        "bitrate" : "250000",
+                        "bitrate" : IfElseSubstitution(
+                            condition=arm,
+                            if_value="250000",
+                            else_value="200000",
+                        ),
                         "log_name" : "arm",
                     }.items()
                 ),

--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -35,6 +35,11 @@ def launch_setup(context, *args, **kwargs):
         '" if bool("', LaunchConfiguration('local'), '") else "',
         FindPackageShare('rover_description'), '"'
     ])
+    nova_bringup_dir = PythonExpression([
+        '"', PathJoinSubstitution([os.path.expanduser("~") + '/nova/src/ros/rover/nova_bringup']),
+        '" if bool("', LaunchConfiguration('local'), '") else "',
+        FindPackageShare('nova_bringup'), '"'
+    ])
 
     controllers = LaunchConfiguration('controllers')
     gazebo = LaunchConfiguration('gazebo')
@@ -89,6 +94,16 @@ def launch_setup(context, *args, **kwargs):
                     executable='spawner',
                     arguments=['nova_end_effector_velocity_controller', '--inactive', "-c", "/arm/controller_manager"],
                     additional_env=show_colours_additional_env,
+                ),
+                IncludeLaunchDescription(
+                    launch_description_source=PythonLaunchDescriptionSource(
+                        PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+                    ),
+                    launch_arguments={
+                        "bus" : "can1",
+                        "bitrate" : "250000",
+                        "log_name" : "arm",
+                    }.items()
                 ),
             ]
         ),

--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -26,28 +26,6 @@ from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 import subprocess
 
-def setup_can(context, *args, **kwargs):
-    def can_is_up():
-        try:
-            result = subprocess.run(["ip", "link", "show", "can0"],
-                capture_output=True, text=True, check=True)
-            return "UP" in result.stdout
-        except subprocess.CalledProcessError:
-            return False
-
-    gazebo = LaunchConfiguration('gazebo').perform(context)  # get argument value as string
-    if gazebo.lower() == 'false':
-        if not can_is_up():
-            try:
-                subprocess.run(["can", "start", "can0"], check=True)
-                return [LogInfo(msg="can0 started successfully")]
-            except subprocess.CalledProcessError as e:
-                return [LogInfo(msg=f"Failed to start can0: {e}")]
-        else:
-            return [LogInfo(msg="can0 is already running")]
-    
-    return []
-
 def launch_setup(context, *args, **kwargs):
     auto = LaunchConfiguration('auto')
     nova_params = LaunchConfiguration('nova_params')
@@ -152,6 +130,16 @@ def launch_setup(context, *args, **kwargs):
                 ),
             ],
         ),
+        IncludeLaunchDescription(
+            launch_description_source=PythonLaunchDescriptionSource(
+                PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+            ),
+            launch_arguments={
+                "bus" : "can0",
+                "bitrate" : "250000",
+                "log_name" : "drive",
+            }.items()
+        ),
     ]
 
 
@@ -215,5 +203,5 @@ def generate_launch_description():
     ]
 
     return LaunchDescription(
-        declared_arguments + [OpaqueFunction(function=launch_setup), OpaqueFunction(function=setup_can)]
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
     )

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -9,7 +9,7 @@ PROCESSES:
   - candump
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 CREATION:   27/01/2026
-EDITED:     01/02/2026
+EDITED:     02/02/2026
 EDITED BY: Jonathan Jia
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
@@ -71,12 +71,8 @@ def launch_setup(context, *args, **kwargs):
             logger.error(f"Failed to create CAN log directory {log_dir_expanded}: {e}")
 
     # generate log file path
-    time_stamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    if log_name:
-        log_file_name = f"{log_name}_{bus}_{time_stamp}.log"
-    else:
-        log_file_name = f"{bus}_{time_stamp}.log"
-    log_path = PathJoinSubstitution([log_dir_expanded, log_file_name])
+    log_file =  f"{log_name}_{bus}.log" if log_name else f"{bus}.log"
+    log_path = PathJoinSubstitution([log_dir_expanded, log_file])
 
     can_logger = ExecuteProcess(
         cmd=[
@@ -122,7 +118,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='log_dir',
-            default_value='~/.nova/log',
+            default_value='~/log',
             description='directory where CAN message log files are stored'
         ),
         DeclareLaunchArgument(

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -8,8 +8,8 @@ Execute this code on the rover to start the
 PROCESSES:
   - candump
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-CREATION:   27/02/2026
-EDITED:     28/02/2026
+CREATION:   27/01/2026
+EDITED:     01/02/2026
 EDITED BY: Jonathan Jia
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 '''
@@ -96,7 +96,7 @@ def launch_setup(context, *args, **kwargs):
                 can_logger,
                 RegisterEventHandler(OnProcessExit(
                     target_action=can_logger,
-                    on_exit=LogInfo(msg="ERROR: CAN logging stopped") # use LogError when available
+                    on_exit=LogInfo(msg="WARNING: CAN logging stopped")
                 ))
             ]
         )
@@ -107,14 +107,13 @@ def generate_launch_description():
     declared_arguments = [
         DeclareLaunchArgument(
             name='bus',
-            default_value='can1',
             description='name of the CAN bus to start/log',
             # reminder to use can instead of vcan
             choices=[f'can{n}' for n in range(0, 10)],
         ),
         DeclareLaunchArgument(
             name='bitrate',
-            default_value="200000",
+            default_value="250000",
             description='bitrate of the CAN bus'
         ),
         DeclareLaunchArgument(

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -15,7 +15,8 @@ EDITED BY: Jonathan Jia
 '''
 from datetime import datetime
 
-import launch.logging
+from logging import Logger
+from launch.logging import get_logger
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, OpaqueFunction, ExecuteProcess, \
     LogInfo, RegisterEventHandler, GroupAction
@@ -26,8 +27,7 @@ import subprocess
 from os.path import expanduser
 
 
-def start_can(bus: str, bitrate: str):
-    logger = launch.logging.get_logger()
+def start_can(bus: str, bitrate: str, logger: Logger):
 
     def can_is_up():
         try:
@@ -47,7 +47,7 @@ def start_can(bus: str, bitrate: str):
             logger.error(f"Failed to start {bus}: {e}")
     else:
         return logger.warning(f"{bus} is already running "
-                              f"(check bitrate; may differ from requested bitrate: {bitrate})")
+                              f"(check bitrate matches requested: {bitrate})")
 
 def launch_setup(context, *args, **kwargs):
     bus = LaunchConfiguration('bus').perform(context)
@@ -57,10 +57,10 @@ def launch_setup(context, *args, **kwargs):
     log_dir_expanded = expanduser(log_dir)
     log_name = LaunchConfiguration('log_name').perform(context)
 
-    logger = launch.logging.get_logger()
+    logger = get_logger("launch.can")
 
     # start can bus
-    start_can(bus, bitrate)
+    start_can(bus, bitrate, logger)
 
     # create log file directory
     if log_can.lower() == "true":

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -113,8 +113,7 @@ def generate_launch_description():
         ),
         DeclareLaunchArgument(
             name='bitrate',
-            default_value="250000",
-            description='bitrate of the CAN bus'
+            description='bitrate of the CAN bus (usually 250000 or 200000)'
         ),
         DeclareLaunchArgument(
             name='log_can',

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -1,0 +1,139 @@
+'''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Monash Nova Rover Team
+
+Execute this code on the rover to start the
+   specified CAN bus with logging
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PROCESSES:
+  - candump
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+CREATION:   27/02/2026
+EDITED:     28/02/2026
+EDITED BY: Jonathan Jia
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+from datetime import datetime
+
+import launch.logging
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, OpaqueFunction, ExecuteProcess, \
+    LogInfo, RegisterEventHandler, GroupAction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.event_handlers import OnProcessExit
+import subprocess
+from os.path import expanduser
+
+
+def start_can(bus: str, bitrate: str):
+    logger = launch.logging.get_logger()
+
+    def can_is_up():
+        try:
+            result = subprocess.run(["ip", "link", "show", bus],
+                                    capture_output=True, text=True, check=True)
+            return "UP" in result.stdout
+        except subprocess.CalledProcessError:
+            return False
+
+    if not can_is_up():
+        logger.info(f"Starting {bus}... (may require password)")
+        try:
+            subprocess.run(["can", "start", bus, bitrate],
+                           capture_output=True, text=True, check=True)
+            logger.info(f"{bus} started successfully")
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to start {bus}: {e}")
+    else:
+        return logger.warning(f"{bus} is already running "
+                              f"(check bitrate; may differ from requested bitrate: {bitrate})")
+
+def launch_setup(context, *args, **kwargs):
+    bus = LaunchConfiguration('bus').perform(context)
+    bitrate = LaunchConfiguration('bitrate').perform(context)
+    log_can = LaunchConfiguration('log_can').perform(context)
+    log_dir = LaunchConfiguration('log_dir').perform(context)
+    log_dir_expanded = expanduser(log_dir)
+    can_log_name = LaunchConfiguration('can_log_name').perform(context)
+
+    logger = launch.logging.get_logger()
+
+    # start can bus
+    start_can(bus, bitrate)
+
+    # create log file directory
+    if log_can.lower() == "true":
+        try:
+            subprocess.run(['mkdir', '-p', log_dir_expanded],
+                           capture_output=True, text=True, check=True)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to create CAN log directory {log_dir_expanded}: {e}")
+
+    # generate log file path
+    time_stamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    if can_log_name:
+        log_file_name = f"{can_log_name}_{bus}_{time_stamp}.log"
+    else:
+        log_file_name = f"{bus}_{time_stamp}.log"
+    log_path = PathJoinSubstitution([log_dir_expanded, log_file_name])
+
+    can_logger = ExecuteProcess(
+        cmd=[
+            "candump",
+            bus,
+            "-f",
+            log_path
+        ],
+        output="screen",
+    )
+
+    return [
+        GroupAction(
+            condition=IfCondition(log_can),
+            actions=[
+                LogInfo(msg=["Logging ", bus," to: ", log_path]),
+                can_logger,
+                RegisterEventHandler(OnProcessExit(
+                    target_action=can_logger,
+                    on_exit=LogInfo(msg="ERROR: CAN logging stopped") # use LogError when available
+                ))
+            ]
+        )
+    ]
+
+def generate_launch_description():
+    
+    declared_arguments = [
+        DeclareLaunchArgument(
+            name='bus',
+            default_value='can1',
+            description='name of the CAN bus to start/log',
+            # reminder to use can instead of vcan
+            choices=[f'can{n}' for n in range(0, 10)],
+        ),
+        DeclareLaunchArgument(
+            name='bitrate',
+            default_value="200000",
+            description='bitrate of the CAN bus'
+        ),
+        DeclareLaunchArgument(
+            name='log_can',
+            default_value='true',
+            description='log CAN messages sent on the CAN bus'
+        ),
+        DeclareLaunchArgument(
+            name='log_dir',
+            default_value='~/.nova/log',
+            description='directory where CAN message log files are stored'
+        ),
+        DeclareLaunchArgument(
+            name='log_name',
+            default_value="",
+            description='optional prefix for log file name'
+        ),
+    ]
+
+    return LaunchDescription(
+        declared_arguments + [OpaqueFunction(function=launch_setup)]
+    )

--- a/src/ros/rover/nova_bringup/launch/can.launch.py
+++ b/src/ros/rover/nova_bringup/launch/can.launch.py
@@ -55,7 +55,7 @@ def launch_setup(context, *args, **kwargs):
     log_can = LaunchConfiguration('log_can').perform(context)
     log_dir = LaunchConfiguration('log_dir').perform(context)
     log_dir_expanded = expanduser(log_dir)
-    can_log_name = LaunchConfiguration('can_log_name').perform(context)
+    log_name = LaunchConfiguration('log_name').perform(context)
 
     logger = launch.logging.get_logger()
 
@@ -72,8 +72,8 @@ def launch_setup(context, *args, **kwargs):
 
     # generate log file path
     time_stamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    if can_log_name:
-        log_file_name = f"{can_log_name}_{bus}_{time_stamp}.log"
+    if log_name:
+        log_file_name = f"{log_name}_{bus}_{time_stamp}.log"
     else:
         log_file_name = f"{bus}_{time_stamp}.log"
     log_path = PathJoinSubstitution([log_dir_expanded, log_file_name])

--- a/src/ros/rover/nova_bringup/launch/ec_rover.launch.py
+++ b/src/ros/rover/nova_bringup/launch/ec_rover.launch.py
@@ -23,18 +23,20 @@ from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
     scraper_card_type = LaunchConfiguration('scraper_card_type')
+    nova_bringup_dir = FindPackageShare('nova_bringup')
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     log_file = f"/home/nova/logs/{timestamp}_ec.txt"
 
     return [
-        ExecuteProcess(
-            cmd=[
-                "bash",
-                "-c",
-                f"candump can0 > {log_file}",
-            ],
-            output="screen"
+        IncludeLaunchDescription(
+            launch_description_source=PythonLaunchDescriptionSource(
+                PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+            ),
+            launch_arguments={
+                "bus" : "can1",
+                "log_name" : "ec",
+            }.items()
         ),
         Node(
             package='excavation_construction', 

--- a/src/ros/rover/nova_bringup/launch/ec_rover.launch.py
+++ b/src/ros/rover/nova_bringup/launch/ec_rover.launch.py
@@ -34,7 +34,8 @@ def launch_setup(context, *args, **kwargs):
                 PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
             ),
             launch_arguments={
-                "bus" : "can1",
+                "bus" : "can0",
+                "bitrate" : "250000",
                 "log_name" : "ec",
             }.items()
         ),

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -21,12 +21,19 @@ EDITED BY:  Felicity Matthews
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 from launch import LaunchDescription
-from launch.actions import OpaqueFunction, DeclareLaunchArgument
+from launch.actions import OpaqueFunction, DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
+    nova_bringup_dir = PythonExpression([
+        '"', PathJoinSubstitution(['/home/nova/nova/src/ros/rover/nova_bringup/']),
+        '" if "', LaunchConfiguration('local'), '".lower() == "true" else "',
+        FindPackageShare('nova_bringup'), '"'
+    ])
+
     science_params = LaunchConfiguration('science_params')
 
     return [
@@ -95,6 +102,18 @@ def launch_setup(context, *args, **kwargs):
             parameters=[
                 science_params,
             ],
+        ),
+
+        # launch CAN bus
+        IncludeLaunchDescription(
+            launch_description_source=PythonLaunchDescriptionSource(
+                PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+            ),
+            launch_arguments={
+                "bus" : "can1",
+                "bitrate" : "250000",
+                "log_name" : "science-arc",
+            }.items()
         ),
     ]
 

--- a/src/ros/rover/science/science_bringup/launch/urc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/urc.launch.py
@@ -11,12 +11,19 @@ EDITED BY:  <insert authors>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 from launch import LaunchDescription
-from launch.actions import OpaqueFunction, DeclareLaunchArgument
+from launch.actions import OpaqueFunction, DeclareLaunchArgument, IncludeLaunchDescription
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
 from launch_ros.actions import Node
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.substitutions import FindPackageShare
 
 def launch_setup(context, *args, **kwargs):
+    nova_bringup_dir = PythonExpression([
+        '"', PathJoinSubstitution(['/home/nova/nova/src/ros/rover/nova_bringup/']),
+        '" if "', LaunchConfiguration('local'), '".lower() == "true" else "',
+        FindPackageShare('nova_bringup'), '"'
+    ])
+
     science_params = LaunchConfiguration('science_params')
 
     return [
@@ -29,6 +36,16 @@ def launch_setup(context, *args, **kwargs):
             parameters=[
                 science_params,
             ],
+        ),
+        IncludeLaunchDescription(
+            launch_description_source=PythonLaunchDescriptionSource(
+                PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+            ),
+            launch_arguments={
+                "bus" : "can1",
+                "bitrate" : "250000",
+                "log_name" : "science-urc",
+            }.items()
         ),
     ]
 


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Adds `can.launch.py` to nova bringup, which launches and starts logging on a specified can bus

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs
- add `can.launch.py`
- modify drive and payload launch files to include `can.launch.py` _(only modifying current launch files)_

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

1. if not on rover: start vcan: `can start vcan0` (`can.launch.py` won't start vcan)
2. run `ros2 launch nova_bringup can.launch.py bus:=can0 bitrate:=250000 log_name:=test`
3. check can sends to can0 appear in `.nova\log\test_can0_YYYY-MM-DD_HH-MM-SS.log`
4. optional: run launch files of other payloads and check if can is start (if not using vcan) and logging is working

<!-- TAGS START -->
Tags for Notion Integration:
tag:software;tag:rover
<!-- TAGS END -->
