### PR TITLE
feat: Basic time of flight sensor controller

### DIFF
--- a/src/ros/rover/science/science/CMakeLists.txt
+++ b/src/ros/rover/science/science/CMakeLists.txt
@@ -79,6 +79,7 @@ install(PROGRAMS
         science/scimbal_cam_old.py
         science/scimbal_cam.py
         science/control_test.py
+        science/time_of_flight.py
         DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -5,17 +5,17 @@ TOF Controller to publish distance data to GUI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 NODE: TimeOfFlightController
 TOPICS:
-  - publisher: /science/analysis-arm Range
+  - publisher: /science/analysis_arm Range
 
 ACTIONS: None
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 STATE INTERFACES:
-  - tof_sensor/distance  [distance in mm]
+  - tof_sensor/distance  [distance]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        python_control2
 AUTHOR(S):      Yahya Muayyiduddin
-CREATION:       24/12/2026
-EDITED:         24/12/2026
+CREATION:       24/12/2025
+EDITED:         04/02/2026
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import rclpy
@@ -71,6 +71,7 @@ class TimeOfFlightController(Controller):
         # self.logger.info(f"Getting \"{self.joint + "/effort"}\"")
         # self.joint_cmd = command_interfaces[self.joint + "/effort"]
         self.distance = state_interfaces["tof_sensor/distance"]
+        return True
 
     def on_update(self, now: float, period: float):
         """ Called on every update. You should read values from state interfaces, and set values on command interfaces

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -25,6 +25,8 @@ from python_control2 import PythonControl, Controller, Contexts, InterfaceCollec
 from python_control2.hardware_interfaces import CMDHardware
 
 
+
+
 class TimeOfFlightController(Controller):
     # Command interfaces
     # joint_cmd: Interface
@@ -45,6 +47,8 @@ class TimeOfFlightController(Controller):
         # self.joint = self.declare_parameter("joint", "j1").value
 
         # Do any setup logic here, save any contexts you want reference to in the future.
+        self.distance = self.declare_parameter("distance", 0).value
+
         
 
     def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
@@ -60,6 +64,7 @@ class TimeOfFlightController(Controller):
         # Save references to interfaces
         # self.logger.info(f"Getting \"{self.joint + "/effort"}\"")
         # self.joint_cmd = command_interfaces[self.joint + "/effort"]
+        self.distance = state_interface["tof/distance"]
 
     def on_update(self, now: float, period: float):
         """ Called on every update. You should read values from state interfaces, and set values on command interfaces
@@ -74,11 +79,11 @@ class TimeOfFlightController(Controller):
 if __name__ == "__main__":
     print("Setting up!")
 
-    rclpy.init()
+    # rclpy.init()
 
-    node = Node("control_test")
-    PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
-        .with_controller("TimeOfFlightController", TimeOfFlightController) \
-        .with_hardware("test_hw", TestHardware) \
-        .with_jcan() \
-        .spin()
+    # node = Node("control_test")
+    # PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
+    #     .with_controller("TimeOfFlightController", TimeOfFlightController) \
+    #     .with_hardware("test_hw", TestHardware) \
+    #     .with_jcan() \
+    #     .spin()

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TOF Controller to publish distance data to GUI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+NODE: TimeOfFlightController
+TOPICS:
+  - publisher: /science/analysis-arm Range
+SERVICES:
+	- service: <service> [<srv type>]
+ACTIONS: None
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        python_control2
+AUTHOR(S):      Yahya Muayyiduddin
+CREATION:       24/12/2026
+EDITED:         24/12/2026
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import rclpy
+import jcan
+from rclpy.node import Node
+from typing import Optional
+from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, HardwareInterface
+
+from python_control2.hardware_interfaces import CMDHardware
+
+
+class TimeOfFlightController(Controller):
+    # Command interfaces
+    # joint_cmd: Interface
+
+    # State interfaces
+    # state: Interface
+
+    def __init__(self, contexts: Contexts):
+        """ Constructor, deferred until the control manager has been spun.
+        If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
+
+        :param contexts: A collection of dependency injection class instances you can index by class type.
+        """
+        super().__init__(contexts)
+        self.logger.info(f"TimeOfFlightController -- I have been __init__ialized")
+
+        # Declare ROS2 parameters here.
+        # self.joint = self.declare_parameter("joint", "j1").value
+
+        # Do any setup logic here, save any contexts you want reference to in the future.
+        
+
+    def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
+        """ Used to set up your Controller. Run once before any other class method.
+        Use this method to get data from self.node, and get references to any command or state interface you need.
+
+        :param command_interfaces: A collection of Interfaces used to send messages to hardware. Get any command
+        interfaces you need from this, then store them in member variables.
+        :param state_interfaces: A collection of Interfaces containing the current state of the robot. Get any state
+        interfaces you need from this, then store them in member variables.
+        :returns: None or True if configured successfully. False otherwise.
+        """
+        # Save references to interfaces
+        # self.logger.info(f"Getting \"{self.joint + "/effort"}\"")
+        # self.joint_cmd = command_interfaces[self.joint + "/effort"]
+
+    def on_update(self, now: float, period: float):
+        """ Called on every update. You should read values from state interfaces, and set values on command interfaces
+            here.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        # Update Command Interfaces
+        # self.cmd.value = 2 * self.state.value
+        # self.logger.info(f"{self.state.value} -> {self.cmd.value}")
+
+if __name__ == "__main__":
+    print("Setting up!")
+
+    rclpy.init()
+
+    node = Node("control_test")
+    PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
+        .with_controller("TimeOfFlightController", TimeOfFlightController) \
+        .with_hardware("test_hw", TestHardware) \
+        .with_jcan() \
+        .spin()

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -6,9 +6,11 @@ TOF Controller to publish distance data to GUI
 NODE: TimeOfFlightController
 TOPICS:
   - publisher: /science/analysis-arm Range
-SERVICES:
-	- service: <service> [<srv type>]
+
 ACTIONS: None
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+STATE INTERFACES:
+  - tof_sensor/distance  [distance in mm]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        python_control2
 AUTHOR(S):      Yahya Muayyiduddin
@@ -93,8 +95,8 @@ if __name__ == "__main__":
             minimum_range = 10,
             maximum_range = 100) \
         .with_hardware("tof_sensor", GenericSensorHardware,
-            can_id = 0x01,
-            interpret_data = lambda data: int.from_bytes(data),
+            can_id = 0x01, # Placeholder
+            interpret_data = lambda data: int.from_bytes(data), # Placeholder
             unit = "distance") \
         .with_jcan() \
         .spin()

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -21,8 +21,8 @@ import jcan
 from rclpy.node import Node
 from typing import Optional
 from python_control2 import PythonControl, Controller, Contexts, InterfaceCollection, Interface, HardwareInterface
-
-from python_control2.hardware_interfaces import CMDHardware
+from sensor_msgs.msg import Range
+from python_control2.hardware_interfaces import CMDHardware, GenericSensorHardware
 
 
 
@@ -34,20 +34,24 @@ class TimeOfFlightController(Controller):
     # State interfaces
     # state: Interface
 
-    def __init__(self, contexts: Contexts):
+    
+
+    def __init__(self, contexts: Contexts, minimum_range: int, maximum_range: int):
         """ Constructor, deferred until the control manager has been spun.
         If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
 
         :param contexts: A collection of dependency injection class instances you can index by class type.
         """
         super().__init__(contexts)
-        self.logger.info(f"TimeOfFlightController -- I have been __init__ialized")
+        self.logger.info(f"TimeOfFlightController Initialised")
 
         # Declare ROS2 parameters here.
         # self.joint = self.declare_parameter("joint", "j1").value
 
         # Do any setup logic here, save any contexts you want reference to in the future.
-        self.distance = self.declare_parameter("distance", 0).value
+        self.tof_publisher = self.create_publisher(Range, "/science/analysis_arm", 10)
+        self.minimum_range = minimum_range
+        self.maximum_range = maximum_range
 
         
 
@@ -64,7 +68,7 @@ class TimeOfFlightController(Controller):
         # Save references to interfaces
         # self.logger.info(f"Getting \"{self.joint + "/effort"}\"")
         # self.joint_cmd = command_interfaces[self.joint + "/effort"]
-        self.distance = state_interface["tof/distance"]
+        self.distance = state_interfaces["tof_sensor/distance"]
 
     def on_update(self, now: float, period: float):
         """ Called on every update. You should read values from state interfaces, and set values on command interfaces
@@ -72,18 +76,25 @@ class TimeOfFlightController(Controller):
         :param now: The current time, in seconds
         :param period: The time elapsed since the last update, in seconds.
         """
-        # Update Command Interfaces
-        # self.cmd.value = 2 * self.state.value
-        # self.logger.info(f"{self.state.value} -> {self.cmd.value}")
+        msg = Range()
+        msg.range = float(self.distance.value)
+        msg.min_range = float(self.minimum_range)
+        msg.max_range = float(self.maximum_range)
+        self.tof_publisher.publish(msg)
 
 if __name__ == "__main__":
     print("Setting up!")
 
-    # rclpy.init()
+    rclpy.init()
 
-    # node = Node("control_test")
-    # PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
-    #     .with_controller("TimeOfFlightController", TimeOfFlightController) \
-    #     .with_hardware("test_hw", TestHardware) \
-    #     .with_jcan() \
-    #     .spin()
+    node = Node("control_test")
+    PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
+        .with_controller("TimeOfFlightController", TimeOfFlightController, 
+        minimum_range = 10,
+        maximum_range = 100) \
+        .with_hardware("tof_sensor", GenericSensorHardware,
+        can_id = "",
+        interpret_data = "",
+        unit = "distance") \
+        .with_jcan() \
+        .spin()

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -87,14 +87,14 @@ if __name__ == "__main__":
 
     rclpy.init()
 
-    node = Node("control_test")
-    PythonControl("time_of_flight", update_rate=5, can_bus="can1") \
+    node = Node("time_of_flight")
+    PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller("TimeOfFlightController", TimeOfFlightController, 
-        minimum_range = 10,
-        maximum_range = 100) \
+            minimum_range = 10,
+            maximum_range = 100) \
         .with_hardware("tof_sensor", GenericSensorHardware,
-        can_id = "",
-        interpret_data = "",
-        unit = "distance") \
+            can_id = 0x01,
+            interpret_data = lambda data: int.from_bytes(data),
+            unit = "distance") \
         .with_jcan() \
         .spin()

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -43,7 +43,7 @@ class TimeOfFlightController(Controller):
 
 
         # Do any setup logic here, save any contexts you want reference to in the future.
-        self.tof_publisher = self.create_publisher(Range, "/science/analysis_arm", 10)
+        self.tof_publisher = self.node.create_publisher(Range, "/science/analysis_arm", 10)
         self.minimum_range = self.declare_parameter("minimum_range", minimum_range).value
         self.maximum_range = self.declare_parameter("maximum_range", maximum_range).value
 

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -15,7 +15,7 @@ STATE INTERFACES:
 PACKAGE:        python_control2
 AUTHOR(S):      Yahya Muayyiduddin
 CREATION:       24/12/2025
-EDITED:         04/02/2026
+EDITED:         14/02/2026
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import rclpy
@@ -30,13 +30,7 @@ from python_control2.hardware_interfaces import CMDHardware, GenericSensorHardwa
 
 
 class TimeOfFlightController(Controller):
-    # Command interfaces
-    # joint_cmd: Interface
 
-    # State interfaces
-    # state: Interface
-
-    
 
     def __init__(self, contexts: Contexts, minimum_range: int, maximum_range: int):
         """ Constructor, deferred until the control manager has been spun.
@@ -47,13 +41,11 @@ class TimeOfFlightController(Controller):
         super().__init__(contexts)
         self.logger.info(f"TimeOfFlightController Initialised")
 
-        # Declare ROS2 parameters here.
-        # self.joint = self.declare_parameter("joint", "j1").value
 
         # Do any setup logic here, save any contexts you want reference to in the future.
         self.tof_publisher = self.create_publisher(Range, "/science/analysis_arm", 10)
-        self.minimum_range = minimum_range
-        self.maximum_range = maximum_range
+        self.minimum_range = self.declare_parameter("minimum_range", minimum_range).value
+        self.maximum_range = self.declare_parameter("maximum_range", maximum_range).value
 
         
 
@@ -67,9 +59,6 @@ class TimeOfFlightController(Controller):
         interfaces you need from this, then store them in member variables.
         :returns: None or True if configured successfully. False otherwise.
         """
-        # Save references to interfaces
-        # self.logger.info(f"Getting \"{self.joint + "/effort"}\"")
-        # self.joint_cmd = command_interfaces[self.joint + "/effort"]
         self.distance = state_interfaces["tof_sensor/distance"]
         return True
 
@@ -92,7 +81,7 @@ if __name__ == "__main__":
 
     node = Node("time_of_flight")
     PythonControl(node, update_rate=5, can_bus="can1") \
-        .with_controller("TimeOfFlightController", TimeOfFlightController, 
+        .with_controller("TimeOfFlightController", TsimeOfFlightController, 
             minimum_range = 10,
             maximum_range = 100) \
         .with_hardware("tof_sensor", GenericSensorHardware,

--- a/src/ros/rover/science/science/science/time_of_flight.py
+++ b/src/ros/rover/science/science/science/time_of_flight.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 
     node = Node("time_of_flight")
     PythonControl(node, update_rate=5, can_bus="can1") \
-        .with_controller("TimeOfFlightController", TsimeOfFlightController, 
+        .with_controller("TimeOfFlightController", TimeOfFlightController,
             minimum_range = 10,
             maximum_range = 100) \
         .with_hardware("tof_sensor", GenericSensorHardware,

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -39,16 +39,6 @@ def launch_setup(context, *args, **kwargs):
     return [
         # Analysis Arm - Nodes for components on the analysis arm
         Node(
-            name='time_of_flight_sensor',
-            package='science',
-            executable='time_of_flight.py',
-            output='screen',
-            emulate_tty=True,
-            parameters=[
-                science_params
-            ],
-        ),
-        Node(
             name='analysis_arm',
             package='science',
             executable='analysis_arm_stepper.py',
@@ -66,6 +56,16 @@ def launch_setup(context, *args, **kwargs):
             emulate_tty=True,
             parameters=[
                 science_params,
+            ],
+        ),
+        Node(
+            name='time_of_flight_sensor',
+            package='science',
+            executable='time_of_flight.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params
             ],
         ),
 

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -39,6 +39,16 @@ def launch_setup(context, *args, **kwargs):
     return [
         # Analysis Arm - Nodes for components on the analysis arm
         Node(
+            name='time_of_flight_sensor',
+            package='science',
+            executable='time_of_flight.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params
+            ],
+        ),
+        Node(
             name='analysis_arm',
             package='science',
             executable='analysis_arm_stepper.py',
@@ -58,16 +68,6 @@ def launch_setup(context, *args, **kwargs):
                 science_params,
             ],
         ),
-        Node(
-            name='time_of_flight_sensor',
-            package='science',
-            executable='time_of_flight.py',
-            output='screen',
-            emulate_tty=True,
-            parameters=[
-                science_params
-            ],
-        )
 
         # CBeam - Nodes for components on the CBeam
         Node(
@@ -141,6 +141,7 @@ def launch_setup(context, *args, **kwargs):
             ],
         ),
 
+        
         # Misc - Nodes for misc components
         Node(
             name='scimbal_cam',

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -58,6 +58,16 @@ def launch_setup(context, *args, **kwargs):
                 science_params,
             ],
         ),
+        Node(
+            name='time_of_flight_sensor',
+            package='science',
+            executable='time_of_flight.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params
+            ],
+        )
 
         # CBeam - Nodes for components on the CBeam
         Node(
@@ -91,7 +101,6 @@ def launch_setup(context, *args, **kwargs):
             ],
         ),
         Node(
-
             name='water_pump',
             package='science',
             executable='water_pump.py',
@@ -131,7 +140,7 @@ def launch_setup(context, *args, **kwargs):
                 science_params,
             ],
         ),
-        
+
         # Misc - Nodes for misc components
         Node(
             name='scimbal_cam',

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -31,7 +31,7 @@ tool_rotator:
         function_id: 0x00
         angular_limit: 360.0
 
-time_of_flighr_sensor:
+time_of_flight_sensor:
   ros__parameters:
     can_bus: "can1"
     update_rate: 5

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -31,6 +31,19 @@ tool_rotator:
         function_id: 0x00
         angular_limit: 360.0
 
+time_of_flighr_sensor:
+  ros__parameters:
+    can_bus: "can1"
+    update_rate: 5
+    controllers:
+      controller:
+        minimum_range: 10
+        maximum_range: 100
+    hardware:
+      tof_sensor:
+        can_id: 0x01
+        unit: "distance"
+
 
 # CBeam - Nodes for components on the CBeam
 
@@ -39,10 +52,10 @@ auger:
     can_bus: "can1"
     active: true
     active_button: "activate_auger"
-    inactive_button_pool: [ "activate_cbeam" ]
+    inactive_button_pool: ["activate_cbeam"]
     hardware:
       actuation:
-        can_id: 0x0D1
+        can_id: 0x0C2
         max_effort: 1.0
         reversed: false
       drill:
@@ -99,7 +112,7 @@ water_pump:
     hardware:
       cooling:
         can_id: 0xD2
-        
+
 diaphragm_pump:
   ros__parameters:
     can_bus: "can1"

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -52,10 +52,10 @@ auger:
     can_bus: "can1"
     active: true
     active_button: "activate_auger"
-    inactive_button_pool: ["activate_cbeam"]
+    inactive_button_pool: [ "activate_cbeam" ]
     hardware:
       actuation:
-        can_id: 0x0C2
+        can_id: 0x0D1
         max_effort: 1.0
         reversed: false
       drill:


### PR DESCRIPTION
## Description
Simple MVP controller for the time of flight sensor. Publishes TOF data to the GUI.
Can_ID and data format are still placeholders

#837 

## Changelogs
- Added time_of_flight.py controller
- Modified science/CMakeLists.txt to include time_of_flight.py


## Screenshots

## ROS
Topics:
- /science/analysis-arm

## Steps to Test


## Memes

