### PR TITLE
feat: peltier and diaphragm pump control

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortControl.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortControl.tsx
@@ -1,0 +1,98 @@
+import React, {useEffect, useState} from "react";
+import {Button, Slider, Tooltip} from "@nextui-org/react";
+import {Power, Square} from "react-feather";
+import {isArray} from "lodash";
+
+export interface EffortControlProps {
+  controlName: string
+  currentStatus: boolean
+  setStatus: (x : boolean) => void
+  currentEffort: number
+  setEffort: (x: number) => void
+}
+
+/**
+ * Controls for turning the effort system on/off and adjusting the effort level
+ * @param controlName the name of the effort system
+ * @param currentStatus the current state of the effort system (on/off)
+ * @param setStatus request the effort system to change state
+ * @param currentEffort the current effort
+ * @param setEffort request a change in effort
+ * @constructor
+ */
+const EffortControl: React.FC<EffortControlProps> = ({controlName, currentStatus, setStatus, currentEffort, setEffort}) => {
+  const [effortInput, setTargetInput] = useState<number>(currentEffort)
+
+  useEffect(() => {
+    setTargetInput(currentEffort)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentEffort]);
+
+const systemStatus = (
+  <div className="flex flex-row items-stretch gap-3">
+    <Button
+      isDisabled
+      className={`flex-1 opacity-100 ${currentStatus ? "bg-success" : "bg-content3"}`}>
+      {currentStatus ? "POWERED ON" : "POWERED OFF"}
+    </Button>
+    <Button
+      className="shrink-0 text-h1"
+      color="primary"
+      onPress={() => setStatus(!currentStatus)}>
+      {currentStatus ? `STOP ${controlName.toUpperCase()}` : `START ${controlName.toUpperCase()}`}
+      {currentStatus ? <Square size="15" fill="white" /> : <Power size="15" />}
+    </Button>
+  </div>
+);
+
+  const targetSlider = (
+    <Slider
+      value={effortInput}
+      onChange={v => isArray(v) ? setTargetInput(v[0]) : setTargetInput(v)}
+      onChangeEnd={(v) => isArray(v) ? setEffort(v[0]) : setEffort(v)}
+      size="lg"
+      classNames={{
+        label: "text-medium",
+      }}
+      color="primary"
+      label={`${controlName}`}
+      maxValue={100}
+      minValue={0}
+      step={1}
+      renderValue={({children, ...props}) => (
+        <output {...props}>
+          <Tooltip
+            className="text-tiny text-default-500 rounded-md"
+            content="Press Enter to confirm"
+            placement="left"
+          >
+            <input
+              aria-label="Effort value"
+              className="px-1 py-0.5 w-14 text-right text-small text-default-700 font-medium bg-default-100 outline-none transition-colors rounded-small border-medium border-transparent hover:border-primary focus:border-primary"
+              type="number"
+              value={effortInput}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const v = Number(e.target.value);
+                setTargetInput(Math.min(100, Math.max(0, v)));
+              }}
+              onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+                if (e.key === "Enter" && !isNaN(Number(effortInput))) {
+                  setEffort(Number(effortInput));
+                }
+              }}
+            />
+          </Tooltip>
+        </output>
+      )}
+    />
+  )
+
+  return (
+    <div className="flex flex-col gap-3">
+      {targetSlider}
+      {systemStatus}
+    </div>
+  );
+}
+
+export default EffortControl;

--- a/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortControl.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortControl.tsx
@@ -12,7 +12,7 @@ export interface EffortControlProps {
 }
 
 /**
- * Controls for turning the effort system on/off and adjusting the effort level
+ * Controls for turning the effort system on/off and adjusting the effort level (repurposed from HeaterControl.tsx)
  * @param controlName the name of the effort system
  * @param currentStatus the current state of the effort system (on/off)
  * @param setStatus request the effort system to change state

--- a/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortWidget.tsx
@@ -1,0 +1,56 @@
+import React, {useEffect} from "react";
+import {useBifrost} from "../../../redux/actions/bifrost/useBifrostAction.ts";
+import {Card, CardBody, CardProps} from "@nextui-org/react";
+import {RosService} from "../../../ros/services/rosService.ts";
+import {RosTopic} from "../../../ros/topics/rosTopic.ts";
+import {useSelector} from "react-redux";
+import {RootState} from "../../../redux/RootState.ts";
+import EffortControl from "./EffortControl.tsx";
+import {useGenericStore} from "../../../hooks/useGenericStore.ts";
+import { IRosScienceInterfacesEffortStatus } from "../../../ros/rosTypes.ts";
+
+export interface EffortWidgetWidgetProps extends CardProps {
+  label: string
+  topic: RosTopic
+  service: RosService
+  statusSelector: (state: RootState) => IRosScienceInterfacesEffortStatus
+  storeName: string
+}
+
+/**
+ * Effort control widget.
+ * @param props
+ * @constructor
+ */
+const EffortWidget: React.FC<EffortWidgetWidgetProps> = (props) => {
+  const bifrost = useBifrost({topic: props.topic, service: props.service});
+  const effortStatus = useSelector(props.statusSelector);
+  const [currentEffort, setEffort] = useGenericStore<number>(props.storeName);
+
+  const sendCommand = (state: boolean, effort: number) => bifrost.callService({state: state, level: effort/100});
+
+  useEffect(() => {
+    bifrost.syncWithTopic();
+  }, [bifrost]);
+
+  const updateEffort = (effort: number) => {
+    setEffort(effort)
+    sendCommand(effortStatus.state, effort)
+  }
+
+  const setEffortStatus = (state: boolean) => sendCommand(state, currentEffort)
+
+  return <Card {...props}>
+    <CardBody>
+      <EffortControl
+        controlName={props.label}
+        currentStatus={effortStatus.state}
+        setStatus={setEffortStatus}
+        currentEffort={currentEffort}
+        setEffort={updateEffort}
+      />
+    </CardBody>
+  </Card>
+}
+
+export default EffortWidget

--- a/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/EffortWidget/EffortWidget.tsx
@@ -18,7 +18,7 @@ export interface EffortWidgetWidgetProps extends CardProps {
 }
 
 /**
- * Effort control widget.
+ * Effort control widget (repurposed from HeaterWidget.tsx)
  * @param props
  * @constructor
  */

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -133,10 +133,10 @@ export const reduxStores = {
   ),
 
   // Science Reducers
-  peltierStatus: createBifrostStore(
-    { topic: RosTopic.PELTIER_STATUS },
+  waterPumpStatus: createBifrostStore(
+    { topic: RosTopic.WATER_PUMP_STATUS },
     {
-      state: false, // current status of Peltier: True if On
+      state: false, // current status of Water Pump: True if On
     }
   ),
   diaphragmPumpStatus: createBifrostStore(
@@ -340,7 +340,7 @@ export const reduxStores = {
   counter: createGenericStore("counter", 0),
   scimbalStepSize: createGenericStore("scimbalStepSize", "1"),
   targetTemp: createGenericStore("targetTemp", 150),
-  peltierEffort: createGenericStore("peltierEffort", 0),
+  waterPumpEffort: createGenericStore("waterPumpEffort", 0),
   diaphragmPumpEffort: createGenericStore("diaphragmPumpEffort", 0),
   theta360CompassHeading: createGenericStore("theta360CompassHeading",180),
   theta360InputDistance: createGenericStore("theta360InputDistance",""),

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -133,6 +133,18 @@ export const reduxStores = {
   ),
 
   // Science Reducers
+  peltierStatus: createBifrostStore(
+    { topic: RosTopic.PELTIER_STATUS },
+    {
+      state: false, // current status of Peltier: True if On
+    }
+  ),
+  diaphragmPumpStatus: createBifrostStore(
+    { topic: RosTopic.DIAPHRAGM_PUMP_STATUS },
+    {
+      state: false, // current status of Diaphragm Pump: True if On
+    }
+  ),
   kilnData: createBifrostStore(
     { topic: RosTopic.KILN_DATA },
     {
@@ -328,6 +340,8 @@ export const reduxStores = {
   counter: createGenericStore("counter", 0),
   scimbalStepSize: createGenericStore("scimbalStepSize", "1"),
   targetTemp: createGenericStore("targetTemp", 150),
+  peltierEffort: createGenericStore("peltierEffort", 0),
+  diaphragmPumpEffort: createGenericStore("diaphragmPumpEffort", 0),
   theta360CompassHeading: createGenericStore("theta360CompassHeading",180),
   theta360InputDistance: createGenericStore("theta360InputDistance",""),
   rgbLedStore: createGenericStore("rgbLedStore", { r: "0", g: "0", b: "0" }),

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -3,6 +3,7 @@ import {
   IRosCameraMsgsGetIpListResponse,
   IRosBlcmdInterfacesBlcmdStatusArray,
   IRosDriveInterfacesDriveInfo,
+  IRosScienceInterfacesEffortStatus,
   IRosScienceInterfacesMicroscopeServoInfo,
   IRosScienceInterfacesMoveMicroscopeServoResponse,
   IRosScienceInterfacesNirProbeData,
@@ -80,6 +81,8 @@ export interface RootState {
   // Science Stores
   tofStore: IRosSensorMsgsRange;
   nirStore: IRosScienceInterfacesNirProbeData;
+  peltierStatus: IRosScienceInterfacesEffortStatus;
+  diaphragmPumpStatus: IRosScienceInterfacesEffortStatus;
   kilnData: IRosScienceInterfacesKilnData;
   kilnCommand: IRosScienceInterfacesKilnCommandResponse;
   uvVisSpecStore: IRosScienceInterfacesUvVisSpecData;
@@ -112,6 +115,8 @@ export interface RootState {
   rgbLedStore: GenericStoreState<{ r: string; g: string; b: string }>;
   scimbalStepSize : GenericStoreState<string>;
   targetTemp : GenericStoreState<number>;
+  peltierEffort: GenericStoreState<number>,
+  diaphragmPumpEffort: GenericStoreState<number>,
   theta360CompassHeading : GenericStoreState<number>;
   uvVisBlankStore : GenericStoreState<number[]>;
   clickAndHold : GenericStoreState<boolean>;

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -81,7 +81,7 @@ export interface RootState {
   // Science Stores
   tofStore: IRosSensorMsgsRange;
   nirStore: IRosScienceInterfacesNirProbeData;
-  peltierStatus: IRosScienceInterfacesEffortStatus;
+  waterPumpStatus: IRosScienceInterfacesEffortStatus;
   diaphragmPumpStatus: IRosScienceInterfacesEffortStatus;
   kilnData: IRosScienceInterfacesKilnData;
   kilnCommand: IRosScienceInterfacesKilnCommandResponse;
@@ -115,7 +115,7 @@ export interface RootState {
   rgbLedStore: GenericStoreState<{ r: string; g: string; b: string }>;
   scimbalStepSize : GenericStoreState<string>;
   targetTemp : GenericStoreState<number>;
-  peltierEffort: GenericStoreState<number>,
+  waterPumpEffort: GenericStoreState<number>,
   diaphragmPumpEffort: GenericStoreState<number>,
   theta360CompassHeading : GenericStoreState<number>;
   uvVisBlankStore : GenericStoreState<number[]>;

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosService.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosService.ts
@@ -22,7 +22,7 @@ export enum RosService {
   // Science Related
   MIXERS = "/science/mixers",
   KILN_COMMAND = "/science/kiln_command",
-  PELTIER_COMMAND = "/science/peltier_command",
+  WATER_PUMP_COMMAND = "/science/water_pump_command",
   DIAPHRAGM_PUMP_COMMAND = "/science/diaphragm_pump_command",
   SCIMBAL_COMMAND = "/science/scimbal_cam_service",
   HYDRAPROBE_COMMAND = "/science/move_hydraprobe",

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosService.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosService.ts
@@ -22,6 +22,8 @@ export enum RosService {
   // Science Related
   MIXERS = "/science/mixers",
   KILN_COMMAND = "/science/kiln_command",
+  PELTIER_COMMAND = "/science/peltier_command",
+  DIAPHRAGM_PUMP_COMMAND = "/science/diaphragm_pump_command",
   SCIMBAL_COMMAND = "/science/scimbal_cam_service",
   HYDRAPROBE_COMMAND = "/science/move_hydraprobe",
   TAKE_NIR_PROBE_READING = "/science/take_nir_probe_reading",

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceMessages.ts
@@ -19,6 +19,8 @@ export const rosServiceMessages = {
   // Science Related
   [RosService.MIXERS]: "std_srvs/srv/SetBool",
   [RosService.KILN_COMMAND]: "science_interfaces/srv/KilnCommand",
+  [RosService.PELTIER_COMMAND]: "science_interfaces/srv/EffortCommand",
+  [RosService.DIAPHRAGM_PUMP_COMMAND]: "science_interfaces/srv/EffortCommand",
   [RosService.SCIMBAL_COMMAND]: 'science_interfaces/srv/MoveScimbalCam',
   [RosService.HYDRAPROBE_COMMAND]: 'science_interfaces/srv/MoveHydraprobe',
   [RosService.TAKE_NIR_PROBE_READING]: "science_interfaces/srv/TakeNIRProbeReading",

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceMessages.ts
@@ -19,7 +19,7 @@ export const rosServiceMessages = {
   // Science Related
   [RosService.MIXERS]: "std_srvs/srv/SetBool",
   [RosService.KILN_COMMAND]: "science_interfaces/srv/KilnCommand",
-  [RosService.PELTIER_COMMAND]: "science_interfaces/srv/EffortCommand",
+  [RosService.WATER_PUMP_COMMAND]: "science_interfaces/srv/EffortCommand",
   [RosService.DIAPHRAGM_PUMP_COMMAND]: "science_interfaces/srv/EffortCommand",
   [RosService.SCIMBAL_COMMAND]: 'science_interfaces/srv/MoveScimbalCam',
   [RosService.HYDRAPROBE_COMMAND]: 'science_interfaces/srv/MoveHydraprobe',

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceTypes.ts
@@ -10,6 +10,8 @@ import {
   IRosStdSrvsTriggerResponse,
   IRosScienceInterfacesKilnCommandRequest,
   IRosScienceInterfacesKilnCommandResponse,
+  IRosScienceInterfacesEffortCommandRequest,
+  IRosScienceInterfacesEffortCommandResponse,
   IRosScienceInterfacesRamanSpecRequest,
   IRosScienceInterfacesRamanSpecResponse,
   IRosScienceInterfacesRamanMechRequest,
@@ -41,7 +43,7 @@ interface EmptyMessage {}
 
 export interface RosServiceInterface {
   [RosService.NULL_SERVICE]: RosServiceMessage<EmptyMessage, EmptyMessage>;
-  
+
   // Arm related
   [RosService.READ_RFID]: RosServiceMessage<
     EmptyMessage,
@@ -85,6 +87,14 @@ export interface RosServiceInterface {
     IRosScienceInterfacesKilnCommandRequest,
     IRosScienceInterfacesKilnCommandResponse
   >;
+  [RosService.PELTIER_COMMAND]: RosServiceMessage<
+    IRosScienceInterfacesEffortCommandRequest,
+    IRosScienceInterfacesEffortCommandResponse
+  >;
+  [RosService.DIAPHRAGM_PUMP_COMMAND]: RosServiceMessage<
+    IRosScienceInterfacesEffortCommandRequest,
+    IRosScienceInterfacesEffortCommandResponse
+  >;
   [RosService.TAKE_NIR_PROBE_READING]: RosServiceMessage<
     IRosScienceInterfacesTakeNirProbeReadingRequest,
     IRosScienceInterfacesTakeNirProbeReadingResponse
@@ -102,7 +112,7 @@ export interface RosServiceInterface {
     IRosScienceInterfacesMoveMicroscopeServoResponse
   >;
   [RosService.THETA_360_CAM_CAPTURE]: RosServiceMessage<
-    EmptyMessage, 
+    EmptyMessage,
     IRosStdSrvsTriggerResponse
   >;
   [RosService.CALL_RAMAN_SPEC]: RosServiceMessage<
@@ -134,8 +144,8 @@ export interface RosServiceInterface {
     IRosScienceInterfacesKilnCommandResponse
   >;
   [RosService.REQUEST_HYDRAPROBE_READING]: RosServiceMessage<
-      EmptyMessage,
-      IRosStdSrvsTriggerResponse
+    EmptyMessage,
+    IRosStdSrvsTriggerResponse
   >;
   [RosService.CAROUSEL]: RosServiceMessage<
     IRosScienceInterfacesKilnCommandRequest,
@@ -143,8 +153,8 @@ export interface RosServiceInterface {
   >;
 
   [RosService.RGBInput]: RosServiceMessage<
-      IRosNovaInterfacesRgbInputRequest,
-      IRosNovaInterfacesRgbInputResponse
+    IRosNovaInterfacesRgbInputRequest,
+    IRosNovaInterfacesRgbInputResponse
   >;
 
   // Autonomous Related

--- a/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/services/rosServiceTypes.ts
@@ -87,7 +87,7 @@ export interface RosServiceInterface {
     IRosScienceInterfacesKilnCommandRequest,
     IRosScienceInterfacesKilnCommandResponse
   >;
-  [RosService.PELTIER_COMMAND]: RosServiceMessage<
+  [RosService.WATER_PUMP_COMMAND]: RosServiceMessage<
     IRosScienceInterfacesEffortCommandRequest,
     IRosScienceInterfacesEffortCommandResponse
   >;

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
@@ -31,6 +31,8 @@ export enum RosTopic {
   // Science Related topics
   TOF = "/science/analysis_arm",
   KILN_DATA = "/science/kiln_data",
+  PELTIER_STATUS = "/science/peltier_status",
+  DIAPHRAGM_PUMP_STATUS = "/science/diaphragm_pump_status",
   NIR_DATA = "/science/nir_probe_data",
   MICROSCOPE_SERVO = "/science/microscope_servo_info",
   UV_VIS_SPEC = "/science/uv_vis_spec_data",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
@@ -31,7 +31,7 @@ export enum RosTopic {
   // Science Related topics
   TOF = "/science/analysis_arm",
   KILN_DATA = "/science/kiln_data",
-  PELTIER_STATUS = "/science/peltier_status",
+  WATER_PUMP_STATUS = "/science/water_pump_status",
   DIAPHRAGM_PUMP_STATUS = "/science/diaphragm_pump_status",
   NIR_DATA = "/science/nir_probe_data",
   MICROSCOPE_SERVO = "/science/microscope_servo_info",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
@@ -31,7 +31,7 @@ export const rosTopicMessages = {
   // Science Related
   [RosTopic.TOF]: "sensor_msgs/msg/Range",
   [RosTopic.KILN_DATA]: "science_interfaces/msg/KilnData",
-  [RosTopic.PELTIER_STATUS]: "science_interfaces/msg/EffortStatus",
+  [RosTopic.WATER_PUMP_STATUS]: "science_interfaces/msg/EffortStatus",
   [RosTopic.DIAPHRAGM_PUMP_STATUS]: "science_interfaces/msg/EffortStatus",
   [RosTopic.NIR_DATA]: "science_interfaces/msg/NIRProbeData",
   [RosTopic.MICROSCOPE_SERVO]: "science_interfaces/msg/MicroscopeServoInfo",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
@@ -31,6 +31,8 @@ export const rosTopicMessages = {
   // Science Related
   [RosTopic.TOF]: "sensor_msgs/msg/Range",
   [RosTopic.KILN_DATA]: "science_interfaces/msg/KilnData",
+  [RosTopic.PELTIER_STATUS]: "science_interfaces/msg/EffortStatus",
+  [RosTopic.DIAPHRAGM_PUMP_STATUS]: "science_interfaces/msg/EffortStatus",
   [RosTopic.NIR_DATA]: "science_interfaces/msg/NIRProbeData",
   [RosTopic.MICROSCOPE_SERVO]: "science_interfaces/msg/MicroscopeServoInfo",
   [RosTopic.UV_VIS_SPEC]: "science_interfaces/msg/UVVisSpecData",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
@@ -58,7 +58,7 @@ export interface RosTopicInterfaces {
   // Science Related
   [RosTopic.TOF]: IRosSensorMsgsRange;
   [RosTopic.KILN_DATA]: IRosScienceInterfacesKilnData;
-  [RosTopic.PELTIER_STATUS]: IRosScienceInterfacesEffortStatus;
+  [RosTopic.WATER_PUMP_STATUS]: IRosScienceInterfacesEffortStatus;
   [RosTopic.DIAPHRAGM_PUMP_STATUS]: IRosScienceInterfacesEffortStatus;
   [RosTopic.NIR_DATA]: IRosScienceInterfacesNirProbeData;
   [RosTopic.MICROSCOPE_SERVO]: IRosScienceInterfacesMicroscopeServoInfo;

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
@@ -24,6 +24,7 @@ import {
   IRosSensorMsgsNavSatFix,
   IRosArmInterfacesSequencerFeedback,
   IRosNovaInterfacesRadioStatus,
+  IRosScienceInterfacesEffortStatus,
 } from "../rosTypes";
 import { RosTopic } from "./rosTopic";
 
@@ -57,6 +58,8 @@ export interface RosTopicInterfaces {
   // Science Related
   [RosTopic.TOF]: IRosSensorMsgsRange;
   [RosTopic.KILN_DATA]: IRosScienceInterfacesKilnData;
+  [RosTopic.PELTIER_STATUS]: IRosScienceInterfacesEffortStatus;
+  [RosTopic.DIAPHRAGM_PUMP_STATUS]: IRosScienceInterfacesEffortStatus;
   [RosTopic.NIR_DATA]: IRosScienceInterfacesNirProbeData;
   [RosTopic.MICROSCOPE_SERVO]: IRosScienceInterfacesMicroscopeServoInfo;
   [RosTopic.RAMAN_SPEC_MSG]: IRosScienceInterfacesRamanSpectrum;

--- a/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
@@ -4,20 +4,30 @@ import DriveSpeedWidget from "../../components/drive/DriveSpeedWidget/DriveSpeed
 import TOFHeight from "../../components/science/AnalysisPlatformHeight/AnalysisPlatformHeight.tsx";
 import KilnWidget from "../../components/science/KilnWidget/KilnWidget.tsx";
 import MicroscopeWidget from "../../components/science/MicroscopeThresholdWidget/MicroscopeWidget.tsx";
+import EffortWidget from "../../components/science/EffortWidget/EffortWidget.tsx";
+import { RosService } from "../../ros/services/rosService.ts";
+import { RosTopic } from "../../ros/topics/rosTopic.ts";
+import { RootState } from "../../redux/RootState.ts";
 
 export const ARCMicroscopeView = () => {
   return (
     <div className="p-3 max-h-full">
       <div className="grid grid-flow-col auto-cols-fr justify-between items-stretch gap-3 ">
-        <div className="flex flex-col flex-grow col-span-3">
+        <div className="flex flex-col flex-grow gap-3 col-span-3">
           <MicroscopeWidget cameraSerial="science_microscope" />
+          <EffortWidget
+            label="Peltier"
+            topic={RosTopic.PELTIER_STATUS}
+            service={RosService.PELTIER_COMMAND}
+            statusSelector={(state: RootState) => state.peltierStatus}
+            storeName="peltierEffort" />
         </div>
         <div className="flex flex-col gap-3 col-span-3">
           <KilnWidget />
           <DriveModeWidget />
           <WheelTelemetryWidget />
           <DriveSpeedWidget />
-          <TOFHeight/>
+          <TOFHeight />
         </div>
       </div>
     </div>

--- a/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
@@ -15,12 +15,20 @@ export const ARCMicroscopeView = () => {
       <div className="grid grid-flow-col auto-cols-fr justify-between items-stretch gap-3 ">
         <div className="flex flex-col flex-grow gap-3 col-span-3">
           <MicroscopeWidget cameraSerial="science_microscope" />
-          <EffortWidget
-            label="Peltier"
-            topic={RosTopic.PELTIER_STATUS}
-            service={RosService.PELTIER_COMMAND}
-            statusSelector={(state: RootState) => state.peltierStatus}
-            storeName="peltierEffort" />
+          <div className="grid grid-cols-[1fr_1.1fr] gap-3">
+            <EffortWidget
+              label="Peltier"
+              topic={RosTopic.PELTIER_STATUS}
+              service={RosService.PELTIER_COMMAND}
+              statusSelector={(state: RootState) => state.peltierStatus}
+              storeName="peltierEffort" />
+            <EffortWidget
+              label="Diaphragm Pump"
+              topic={RosTopic.DIAPHRAGM_PUMP_STATUS}
+              service={RosService.DIAPHRAGM_PUMP_COMMAND}
+              statusSelector={(state: RootState) => state.diaphragmPumpStatus}
+              storeName="diaphragmPumpEffort" />
+          </div>
         </div>
         <div className="flex flex-col gap-3 col-span-3">
           <KilnWidget />

--- a/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/arc/ARCMicroscopeView.tsx
@@ -17,11 +17,11 @@ export const ARCMicroscopeView = () => {
           <MicroscopeWidget cameraSerial="science_microscope" />
           <div className="grid grid-cols-[1fr_1.1fr] gap-3">
             <EffortWidget
-              label="Peltier"
-              topic={RosTopic.PELTIER_STATUS}
-              service={RosService.PELTIER_COMMAND}
-              statusSelector={(state: RootState) => state.peltierStatus}
-              storeName="peltierEffort" />
+              label="Water Pump"
+              topic={RosTopic.WATER_PUMP_STATUS}
+              service={RosService.WATER_PUMP_COMMAND}
+              statusSelector={(state: RootState) => state.waterPumpStatus}
+              storeName="waterPumpEffort" />
             <EffortWidget
               label="Diaphragm Pump"
               topic={RosTopic.DIAPHRAGM_PUMP_STATUS}

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortCommandController.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortCommandController.py
@@ -71,7 +71,7 @@ class EffortCommandController(Controller):
         self.effort_cmd = command_interfaces[f"{self.hardware_name}/effort"]
 
         # Create status publisher
-        self.publisher = self.node.create_publisher(EffortStatus, self.topic_name, 5)
+        self.publisher = self.node.create_publisher(EffortStatus, self.topic_name, 10)
         self.publisher_timer = self.node.create_timer(1 / self.publish_rate, self.publish_data)
 
         # Create effort service
@@ -97,7 +97,7 @@ class EffortCommandController(Controller):
         self.is_on = request.state
         self.effort_level = request.level
 
-        response.applied = True
+        response.success = True
         return response
     
     def on_update(self, now: float, period: float):

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortCommandController.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortCommandController.py
@@ -26,7 +26,7 @@ from science_interfaces.msg import EffortStatus
 from science_interfaces.srv import EffortCommand
 
 
-class EffortController(Controller):
+class EffortCommandController(Controller):
     # Command interfaces
     effort_cmd: Interface
 
@@ -46,7 +46,7 @@ class EffortController(Controller):
 
         """
         super().__init__(contexts)
-        self.logger.info(f"EffortController -- I have been __init__ialized")
+        self.logger.info(f"EffortCommandController -- I have been __init__ialized")
 
         self.hardware_name = self.declare_parameter("hardware_name", hardware_name).value
         self.service_name: str = self.declare_parameter("service_name", service_name).value
@@ -84,7 +84,7 @@ class EffortController(Controller):
         data_msg.state = self.is_on
         self.publisher.publish(data_msg)
 
-        self.logger.debug(f"EffortController {self.name} published EffortStatus: {data_msg}")
+        self.logger.debug(f"EffortCommandController {self.name} published EffortStatus: {data_msg}")
 
     def command_callback(self, request: EffortCommand.Request, response: EffortCommand.Response):
         """ Uses request to update effort system's settings and send system status
@@ -92,7 +92,7 @@ class EffortController(Controller):
         :param request: Specified settings for effort system control (state, effort_level).
         :param response: Whether or not these settings were applied successfully (applied).
         """
-        self.logger.info(f"EffortController {self.name} received EffortCommand request: (state={request.state}, level={request.level:.2f})")
+        self.logger.info(f"EffortCommandController {self.name} received EffortCommand request: (state={request.state}, level={request.level:.2f})")
 
         self.is_on = request.state
         self.effort_level = request.level

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortController.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortController.py
@@ -15,7 +15,7 @@ COMMAND INTERFACES:
 PACKAGE:        python_control2
 AUTHOR(S):      Jonathan Jia, Binuda Kalugalage
 CREATION:       31/01/26
-EDITED:         01/02/26
+EDITED:         04/02/26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 from typing import Optional
@@ -92,7 +92,7 @@ class EffortController(Controller):
         :param request: Specified settings for effort system control (state, effort_level).
         :param response: Whether or not these settings were applied successfully (applied).
         """
-        self.logger.info(f"EffortController {self.name} received request: (state={request.state}, level={request.level:.2f})")
+        self.logger.info(f"EffortController {self.name} received EffortCommand request: (state={request.state}, level={request.level:.2f})")
 
         self.is_on = request.state
         self.effort_level = request.level

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortController.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/EffortController.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Controller for effort-based systems which receive 
+effort input from a service.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+TOPICS:
+    - publisher: <topic_name> [EffortStatus]
+SERVICES:
+	- service: <service_name> [EffortCommand]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - <hardware_name>/effort    [value between 0 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        python_control2
+AUTHOR(S):      Jonathan Jia, Binuda Kalugalage
+CREATION:       31/01/26
+EDITED:         01/02/26
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+from typing import Optional
+from ..controller_manager.Interface import Interface, InterfaceCollection
+from ..controller_manager.Contexts import Contexts
+from .Controller import Controller
+from science_interfaces.msg import EffortStatus
+from science_interfaces.srv import EffortCommand
+
+
+class EffortController(Controller):
+    # Command interfaces
+    effort_cmd: Interface
+
+    def __init__(self, contexts: Contexts, 
+                 hardware_name: str = "hardware_name",
+                 service_name: str = "",
+                 topic_name: str = "",
+                 publish_rate: int = 5):
+        """ Constructor, deferred until the control manager has been spun.
+        If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
+
+        :param contexts: A collection of dependency injection class instances you can index by class type.
+        :param hardware_name: Name of hardware interface being used.
+        :param service_name: Name of service used to receive effort level and send system status.
+        :param topic_name: Name of topic which system status is published to.
+        :param publish_rate: Frequency at which system status is published.
+
+        """
+        super().__init__(contexts)
+        self.logger.info(f"EffortController -- I have been __init__ialized")
+
+        self.hardware_name = self.declare_parameter("hardware_name", hardware_name).value
+        self.service_name: str = self.declare_parameter("service_name", service_name).value
+        self.topic_name: str = self.declare_parameter("topic_name", topic_name).value
+        self.publish_rate: int =  self.declare_parameter("publish_rate", publish_rate).value
+
+        self.is_on = False
+        self.effort_level = 0
+
+    def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection) -> Optional[bool]:
+        """ Used to set up your Controller. Run once before any other class method.
+        Use this method to get data from self.node, and get references to any command or state interface you need.
+
+        :param command_interfaces: A collection of Interfaces used to send messages to hardware. Get any command
+        interfaces you need from this, then store them in member variables.
+        :param state_interfaces: A collection of Interfaces containing the current state of the robot. Get any state
+        interfaces you need from this, then store them in member variables.
+        :returns: None or True if configured successfully. False otherwise.
+        """
+        # Save references to interfaces
+        self.logger.info(f"Getting {self.hardware_name}/effort")
+        self.effort_cmd = command_interfaces[f"{self.hardware_name}/effort"]
+
+        # Create status publisher
+        self.publisher = self.node.create_publisher(EffortStatus, self.topic_name, 5)
+        self.publisher_timer = self.node.create_timer(1 / self.publish_rate, self.publish_data)
+
+        # Create effort service
+        self.command_service = self.node.create_service(EffortCommand, self.service_name, self.command_callback)
+
+    def publish_data(self):
+        """ Publishes status of system """
+
+        data_msg = EffortStatus()
+        data_msg.state = self.is_on
+        self.publisher.publish(data_msg)
+
+        self.logger.debug(f"EffortController {self.name} published EffortStatus: {data_msg}")
+
+    def command_callback(self, request: EffortCommand.Request, response: EffortCommand.Response):
+        """ Uses request to update effort system's settings and send system status
+
+        :param request: Specified settings for effort system control (state, effort_level).
+        :param response: Whether or not these settings were applied successfully (applied).
+        """
+        self.logger.info(f"EffortController {self.name} received request: (state={request.state}, level={request.level:.2f})")
+
+        self.is_on = request.state
+        self.effort_level = request.level
+
+        response.applied = True
+        return response
+    
+    def on_update(self, now: float, period: float):
+        """ Called on every update. You should read values from state interfaces, and set values on command interfaces
+            here.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+
+        # Update effort
+        self.effort_cmd.value = self.is_on * self.effort_level

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/__init__.py
@@ -1,4 +1,4 @@
 from .Controller import Controller
 from .ActuateController import ActuateController
 from .PresetTwitchController import PresetTwitchController
-from .EffortController import EffortController
+from .EffortCommandController import EffortCommandController

--- a/src/ros/rover/nova_generic/python_control2/python_control2/controllers/__init__.py
+++ b/src/ros/rover/nova_generic/python_control2/python_control2/controllers/__init__.py
@@ -1,3 +1,4 @@
 from .Controller import Controller
 from .ActuateController import ActuateController
 from .PresetTwitchController import PresetTwitchController
+from .EffortController import EffortController

--- a/src/ros/rover/science/science/CMakeLists.txt
+++ b/src/ros/rover/science/science/CMakeLists.txt
@@ -54,6 +54,7 @@ install(PROGRAMS
         science/arc/kiln.py
         science/arc/kiln_old.py
         science/arc/peltier.py
+        science/arc/diaphragm_pump.py
         science/urc/hydraprobe_trigger_node.py
         science/urc/urc_bme_sensor.py
         science/urc/urc_cache.py

--- a/src/ros/rover/science/science/CMakeLists.txt
+++ b/src/ros/rover/science/science/CMakeLists.txt
@@ -53,7 +53,7 @@ install(PROGRAMS
         science/arc/arc_sweeper_servo.py
         science/arc/kiln.py
         science/arc/kiln_old.py
-        science/arc/peltier.py
+        science/arc/water_pump.py
         science/arc/diaphragm_pump.py
         science/urc/hydraprobe_trigger_node.py
         science/urc/urc_bme_sensor.py

--- a/src/ros/rover/science/science/CMakeLists.txt
+++ b/src/ros/rover/science/science/CMakeLists.txt
@@ -53,6 +53,7 @@ install(PROGRAMS
         science/arc/arc_sweeper_servo.py
         science/arc/kiln.py
         science/arc/kiln_old.py
+        science/arc/peltier.py
         science/urc/hydraprobe_trigger_node.py
         science/urc/urc_bme_sensor.py
         science/urc/urc_cache.py

--- a/src/ros/rover/science/science/science/arc/diaphragm_pump.py
+++ b/src/ros/rover/science/science/science/arc/diaphragm_pump.py
@@ -19,7 +19,7 @@ import rclpy
 from rclpy.node import Node
 from python_control2 import PythonControl
 from python_control2.controller_manager import Interface, InterfaceCollection, Contexts
-from python_control2.controllers import EffortController
+from python_control2.controllers import EffortCommandController
 from python_control2.hardware_interfaces import HardwareInterface
 
 from struct import pack
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller(
             "controller",
-            EffortController,
+            EffortCommandController,
             hardware_name="flow",
             service_name="/science/diaphragm_pump_command",
             topic_name="/science/diaphragm_pump_status"

--- a/src/ros/rover/science/science/science/arc/diaphragm_pump.py
+++ b/src/ros/rover/science/science/science/arc/diaphragm_pump.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+System for the science Diaphragm Pump which
+creates a movement of air through the condenser.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - flow/effort    [value between 0 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        science
+AUTHOR(S):      Binuda Kalugalage
+CREATION:       01/02/2026
+EDITED:         04/02/2026
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import jcan
+
+import rclpy
+from rclpy.node import Node
+from python_control2 import PythonControl
+from python_control2.controller_manager import Interface, InterfaceCollection, Contexts
+from python_control2.controllers import EffortController
+from python_control2.hardware_interfaces import HardwareInterface
+
+from struct import pack
+
+class DiaphragmPumpHardware(HardwareInterface):
+    effort_cmd: Interface
+    can_id: int
+
+    def __init__(self, contexts: Contexts,
+                 can_id: int=0x0E5,
+                 max_effort: float=1.0,
+                 min_effort_can: int=0x00,
+                 max_effort_can: int=0xFF):
+        """ Constructor, deferred until the control manager has been spun.
+        If you override this method, and want to add your own arguments, just make sure contexts is the FIRST arg
+
+        :param contexts: A collection of dependency injection class instances you can index by class type.
+        """
+        super().__init__(contexts)
+
+        self.bus = contexts[jcan.Bus]
+
+        self.last = None
+
+        self.declare_parameter("can_id", can_id, "CAN ID of the diaphragm pump")
+        self.declare_parameter("max_effort", max_effort, "Max percentage of output to send")
+        self.declare_parameter("min_effort_can", min_effort_can, "Min CAN message value that can be sent")
+        self.declare_parameter("max_effort_can", max_effort_can, "Max CAN message value that can be sent")
+
+    def on_configure(self, command_interfaces: InterfaceCollection, state_interfaces: InterfaceCollection):
+        """ Used to set up your HardwareInterface. Run once before any other class method.
+        Use this method to get data from self.node, and get references to any command or state interface you need.
+
+        :param command_interfaces: A collection of Interfaces used to send messages to hardware. Get any command
+        interfaces you need from this, then store them in member variables.
+        :param state_interfaces: A collection of Interfaces containing the current state of the robot. Get any state
+        interfaces you need from this, then store them in member variables.
+        :returns: None or True if configured successfully. False otherwise.
+        """
+        # Update params
+        self.can_id: int = self.get_parameter("can_id").value
+        self.max_effort: float = self.get_parameter("max_effort").value
+        self.min_effort_can = self.get_parameter("min_effort_can").value
+        self.max_effort_can = self.get_parameter("max_effort_can").value
+
+        # Get command interfaces
+        self.effort_cmd = command_interfaces[self.name + "/effort"]
+
+        # Validate command interface configuration
+        if not self.effort_cmd:
+            self.logger.warn(f'DiaphragmPumpHardware "{self.name}" has no populated command interface '
+                             f'("{self.name}/effort")')
+
+        # Validate effort range
+        if self.max_effort_can <= self.min_effort_can:
+            self.logger.error(f'DiaphragmPumpHardware {self.name} has invalid CAN effort range ' 
+                              f'min_effort_can={self.min_effort_can}, max_effort_can={self.max_effort_can}')
+            return False
+
+        return True
+
+    def on_read(self, now: float, period: float):
+        """ Called to read values from hardware, and put them into stored state interfaces.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        pass
+
+    def on_write(self, now: float, period: float):
+        """ Called to write to hardware using values stored in command interfaces.
+        :param now: The current time, in seconds
+        :param period: The time elapsed since the last update, in seconds.
+        """
+        if self.effort_cmd:
+            self.bus.send(self.construct_frame())
+
+    def construct_frame(self) -> jcan.Frame:
+        """ Construct the jcan Frame based on current command interface """
+        # Convert effort to CAN data using max CAN effort
+        data = int(self.effort_cmd.value * self.max_effort * self.max_effort_can)
+
+        # Clamp to bounds
+        if data > self.max_effort_can:
+            data = self.max_effort_can
+        elif data < self.min_effort_can:
+            data = self.min_effort_can
+      
+        # Return the constructed frame
+        return jcan.Frame(self.can_id, [data])
+
+if __name__ == "__main__":
+    print("Setting up!") 
+
+    rclpy.init()
+
+    node = Node("diaphragm_pump")
+
+    PythonControl(node, update_rate=5, can_bus="can1") \
+        .with_controller(
+            "controller",
+            EffortController,
+            hardware_name="flow",
+            service_name="/science/diaphragm_pump_command",
+            topic_name="/science/diaphragm_pump_status"
+        ) \
+        .with_hardware("flow", DiaphragmPumpHardware) \
+        .with_jcan() \
+        .spin()

--- a/src/ros/rover/science/science/science/arc/diaphragm_pump.py
+++ b/src/ros/rover/science/science/science/arc/diaphragm_pump.py
@@ -42,8 +42,6 @@ class DiaphragmPumpHardware(HardwareInterface):
 
         self.bus = contexts[jcan.Bus]
 
-        self.last = None
-
         self.declare_parameter("can_id", can_id, "CAN ID of the diaphragm pump")
         self.declare_parameter("max_effort", max_effort, "Max percentage of output to send")
         self.declare_parameter("min_effort_can", min_effort_can, "Min CAN message value that can be sent")

--- a/src/ros/rover/science/science/science/arc/diaphragm_pump.py
+++ b/src/ros/rover/science/science/science/arc/diaphragm_pump.py
@@ -22,8 +22,6 @@ from python_control2.controller_manager import Interface, InterfaceCollection, C
 from python_control2.controllers import EffortCommandController
 from python_control2.hardware_interfaces import HardwareInterface
 
-from struct import pack
-
 class DiaphragmPumpHardware(HardwareInterface):
     effort_cmd: Interface
     can_id: int

--- a/src/ros/rover/science/science/science/arc/peltier.py
+++ b/src/ros/rover/science/science/science/arc/peltier.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
 
     node = Node("peltier")
 
-    PythonControl(node, update_rate=10, can_bus="can1") \
+    PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller(
             "controller",
             EffortCommandController,

--- a/src/ros/rover/science/science/science/arc/peltier.py
+++ b/src/ros/rover/science/science/science/arc/peltier.py
@@ -16,7 +16,7 @@ EDITED:         01/02/2026
 import rclpy
 from rclpy.node import Node
 from python_control2 import PythonControl
-from python_control2.controllers import EffortController
+from python_control2.controllers import EffortCommandController
 from python_control2.hardware_interfaces import QCMDHardware
 
 if __name__ == "__main__":
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     PythonControl(node, update_rate=10, can_bus="can1") \
         .with_controller(
             "controller",
-            EffortController,
+            EffortCommandController,
             hardware_name="cooling",
             service_name="/science/peltier_command",
             topic_name="/science/peltier_status"

--- a/src/ros/rover/science/science/science/arc/peltier.py
+++ b/src/ros/rover/science/science/science/arc/peltier.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+System for the science Peltier which cools the
+condenser.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+COMMAND INTERFACES:
+  - cooling/effort    [value between 0 and 1]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+PACKAGE:        science
+AUTHOR(S):      Binuda Kalugalage
+CREATION:       01/02/2026
+EDITED:         01/02/2026
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+import rclpy
+from rclpy.node import Node
+from python_control2 import PythonControl
+from python_control2.controllers import EffortController
+from python_control2.hardware_interfaces import QCMDHardware
+
+if __name__ == "__main__":
+    print("Setting up!")
+
+    rclpy.init()
+
+    node = Node("peltier")
+
+    PythonControl(node, update_rate=10, can_bus="can1") \
+        .with_controller(
+            "controller",
+            EffortController,
+            hardware_name="cooling",
+            service_name="/science/peltier_command",
+            topic_name="/science/peltier_status"
+        ) \
+        .with_hardware("cooling", QCMDHardware, can_id=0xD2) \
+        .with_jcan() \
+        .spin()

--- a/src/ros/rover/science/science/science/arc/water_pump.py
+++ b/src/ros/rover/science/science/science/arc/water_pump.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-System for the science Peltier which cools the
+System for the science Water Pump which cools the
 condenser.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 COMMAND INTERFACES:
@@ -24,15 +24,15 @@ if __name__ == "__main__":
 
     rclpy.init()
 
-    node = Node("peltier")
+    node = Node("water_pump")
 
     PythonControl(node, update_rate=5, can_bus="can1") \
         .with_controller(
             "controller",
             EffortCommandController,
             hardware_name="cooling",
-            service_name="/science/peltier_command",
-            topic_name="/science/peltier_status"
+            service_name="/science/water_pump_command",
+            topic_name="/science/water_pump_status"
         ) \
         .with_hardware("cooling", QCMDHardware, can_id=0xD2) \
         .with_jcan() \

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -91,9 +91,9 @@ def launch_setup(context, *args, **kwargs):
             ],
         ),
         Node(
-            name='peltier',
+            name='water_pump',
             package='science',
-            executable='peltier.py',
+            executable='water_pump.py',
             output='screen',
             emulate_tty=True,
             parameters=[

--- a/src/ros/rover/science/science_bringup/launch/arc.launch.py
+++ b/src/ros/rover/science/science_bringup/launch/arc.launch.py
@@ -91,6 +91,26 @@ def launch_setup(context, *args, **kwargs):
             ],
         ),
         Node(
+            name='peltier',
+            package='science',
+            executable='peltier.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
+            name='diaphragm_pump',
+            package='science',
+            executable='diaphragm_pump.py',
+            output='screen',
+            emulate_tty=True,
+            parameters=[
+                science_params,
+            ],
+        ),
+        Node(
             name='chute',
             package='science',
             executable='chute.py',

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -88,6 +88,31 @@ kiln:
         max_effort: 1.0
         reversed: false
 
+peltier:
+  ros__parameters:
+    can_bus: "can1"
+    controllers:
+      controller:
+        hardware_name: "cooling"
+        service_name: "/science/peltier_command"
+        topic_name: "/science/peltier_status"
+    hardware:
+      cooling:
+        can_id: 0xD2
+        
+diaphragm_pump:
+  ros__parameters:
+    can_bus: "can1"
+    controllers:
+      controller:
+        hardware_name: "flow"
+        service_name: "/science/diaphragm_pump_command"
+        topic_name: "/science/diaphragm_pump_status"
+    hardware:
+      cooling:
+        can_id: 0x0E5
+
+
 # Misc - Nodes for misc components
 scimbal_cam:
   ros__parameters:

--- a/src/ros/rover/science/science_bringup/params/arc.yaml
+++ b/src/ros/rover/science/science_bringup/params/arc.yaml
@@ -88,14 +88,14 @@ kiln:
         max_effort: 1.0
         reversed: false
 
-peltier:
+water_pump:
   ros__parameters:
     can_bus: "can1"
     controllers:
       controller:
         hardware_name: "cooling"
-        service_name: "/science/peltier_command"
-        topic_name: "/science/peltier_status"
+        service_name: "/science/water_pump_command"
+        topic_name: "/science/water_pump_status"
     hardware:
       cooling:
         can_id: 0xD2

--- a/src/ros/rover/science/science_interfaces/CMakeLists.txt
+++ b/src/ros/rover/science/science_interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/DistanceData.msg"
   "msg/EMCData.msg"
   "msg/HydraprobeData.msg"
+  "msg/EffortStatus.msg"
   "msg/KilnData.msg"
   "msg/MicroscopeServoInfo.msg"
   "msg/NIRProbeData.msg"
@@ -30,6 +31,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
 
   # Service definitions
   "srv/CacheCommand.srv"
+  "srv/EffortCommand.srv"
   "srv/KilnCommand.srv"
   "srv/MoveHydraprobe.srv"
   "srv/MoveMicroscopeServo.srv"

--- a/src/ros/rover/science/science_interfaces/msg/EffortStatus.msg
+++ b/src/ros/rover/science/science_interfaces/msg/EffortStatus.msg
@@ -1,0 +1,3 @@
+# for sending effort system status
+
+bool state

--- a/src/ros/rover/science/science_interfaces/srv/EffortCommand.srv
+++ b/src/ros/rover/science/science_interfaces/srv/EffortCommand.srv
@@ -1,0 +1,8 @@
+# Turn system on and off
+bool state
+
+# Set level of effort
+float32 level
+
+---
+bool applied

--- a/src/ros/rover/science/science_interfaces/srv/EffortCommand.srv
+++ b/src/ros/rover/science/science_interfaces/srv/EffortCommand.srv
@@ -5,4 +5,4 @@ bool state
 float32 level
 
 ---
-bool applied
+bool success


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
Adds control for the peltier and diaphragm pump (#746) using a generic effort controller controlled through the gui.  Peltier CAN id is a placeholder.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs
- add EffortController used by both peltier and diaphragm pump
- add generic EffortWidget in gui
- created DiaphragmPumpHardware
- add to ARC launch and param files

## Screenshots

<img width="2102" height="590" alt="image" src="https://github.com/user-attachments/assets/0a62f980-bec3-404b-b8e3-26db972e2ea8" />

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->
topics: 
- /science/peltier_status
- /science/diaphragm_pump_status

services: 
- /science/peltier_command
- /science/diaphragm_pump_command

## Steps to Test
1. launch gui and rosbridge
2. `can start vcan1`
3. `ros2 launch science_bringup arc.launch.py` or `ros2 run science <peltier/diaphragm_pump>.py`
4. change effort using the widgets in the microscope page under ARC Space Resources
5. `candump can1` 

<!--- ## Memes --->

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:software;tag:science;tag:ready_for_review
<!-- TAGS END -->
