### PR TITLE
nixfiles: don't wrap qt apps twice

### DIFF
--- a/nixfiles/default.nix
+++ b/nixfiles/default.nix
@@ -52,6 +52,9 @@ let
       #   url = "https://github.com/lopsided98/nix-ros-overlay/compare/6d04148eac0727be34e5333f6e12cfc7e86673c3...eca9687ce15335bbb2d4b7b14fbf74ce0e957f43.patch";
       #   hash = "sha256-c6DD2U6Lo2dcs0APxEHg9l0bz1Ioa5aX5FoATajXYAc=";
       # })
+
+      # speed up ws-build by avoiding wrapping qt apps twice.
+      ./overlay/ros/patches/0001-don-t-wrap-qt-apps-for-the-whole-env.patch
     ];
   });
 

--- a/nixfiles/overlay/ros/patches/0001-don-t-wrap-qt-apps-for-the-whole-env.patch
+++ b/nixfiles/overlay/ros/patches/0001-don-t-wrap-qt-apps-for-the-whole-env.patch
@@ -1,0 +1,23 @@
+From ffe7713ba1b2378d2fc2a487bf3fbb0b35f23ee6 Mon Sep 17 00:00:00 2001
+From: Monash Nova Rover <novaroverteam@monash.edu>
+Date: Thu, 29 Jan 2026 15:20:46 +1100
+Subject: [PATCH 1/1] don't wrap qt apps for the whole env
+
+---
+ distros/build-env/default.nix | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/distros/build-env/default.nix b/distros/build-env/default.nix
+index bcf5bcaf..537041a1 100644
+--- a/distros/build-env/default.nix
++++ b/distros/build-env/default.nix
+@@ -110,5 +110,6 @@ let
+     dontGzipMan = true;
+     dontPatchShebangs = true;
+     dontMoveLib64 = true;
++    dontWrapQtApps = true;
+   });
+ in env
+-- 
+2.51.2
+


### PR DESCRIPTION
avoid wrapping everything in the nova workspace with qt's env vars. this saves about 15-20 seconds in ws-build. the apps using qt already have the qt env vars set in their individual package's wrapping step.

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
