### PR TITLE
gui: nix: filter out node_modules, dist

### DIFF
--- a/src/ros/nova-gui/nix/packages/gui/default.nix
+++ b/src/ros/nova-gui/nix/packages/gui/default.nix
@@ -34,7 +34,7 @@ mkYarnPackage {
   src = builtins.path rec {
     name = "gui";
     path = ../../../nova-gui;
-    filter = lib.novaSourceFilter [ ] path;
+    filter = lib.novaSourceFilter [ "node_modules" "dist" ] path;
   };
 
   ROS_TS_DEFINITIONS = (ros-typescript-definitions.override {


### PR DESCRIPTION
these folders make gui-shell rebuild a different nova-gui-modules derivation even if the actual source is the same. this means that it doesn't get the build from hydra and is slower. filtering out these makes it not do that

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
