### PR TITLE
fix: drive telemetry (and game pad rumble)

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveModeWidget/DriveModeDisplayData.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveModeWidget/DriveModeDisplayData.tsx
@@ -2,12 +2,14 @@ import {DetailedReactHTMLElement} from "react";
 import {Maximize2, RefreshCw} from "react-feather";
 import {Image} from "@nextui-org/react";
 import Tank from "../../../assets/tank-icon.svg";
+import {CarFront} from "react-bootstrap-icons";
 
 // Enum to assign meaning to IRosDriveInterfacesDriveInfo.drive_mode values
 export enum DriveMode {
   PIVOT = 1,
   STRAFE = 2,
-  TANK = 3
+  TANK = 3,
+  ACKERMANN = 4
 }
 
 // Data required for displaying a drive mode in the GUI
@@ -30,14 +32,20 @@ export const driveModes : IDriveModeDisplayData[] = [
   { 
     name: "Strafe", 
     icon: <Maximize2 className="StrafeDriveModeIcon"/>, 
-    keybind: "LB",
+    keybind: "X",
     driveMode: DriveMode.STRAFE
   } as IDriveModeDisplayData,
   { 
     name: "Pivot", 
     icon: <RefreshCw className="PivotDriveModeIcon"/>, 
-    keybind: "RB",
+    keybind: "A",
     driveMode: DriveMode.PIVOT
+  } as IDriveModeDisplayData,
+  {
+    name: "Ackermann",
+    icon: <CarFront/>,
+    keybind: "B",
+    driveMode: DriveMode.ACKERMANN
   } as IDriveModeDisplayData,
 ];
 

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveModeWidget/DriveModeWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveModeWidget/DriveModeWidget.tsx
@@ -67,7 +67,7 @@ const DriveModeWidget: React.FC<IDriveModeWidgetProps> = (
       </CardHeader>
       <CardBody className="flex justify-center flex-col content-center">
         <div>
-          <div className="grid grid-flow-col gap-3 auto-cols-fr">
+          <div className="grid grid-flow-row grid-cols-[repeat(auto-fit,_minmax(10em,_1fr))] gap-3">
             {driveModes.map((mode, index) => (
               <DriveModeButton
                 key={index}

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
@@ -34,7 +34,7 @@ const DriveSpeedWidget: React.FC<IDriveWidgetProps> = (
   })
   const averageWheelAngularVelocity = wheelVelocities.reduce(
     (acc: number, velocity: number) => { return acc + velocity; }, 0.0)
-    / wheelVelocities.length;
+    / Math.max(wheelVelocities.length, 1);
 
   useEffect(() => {
     bifrostDrive.syncWithTopic();

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
@@ -22,18 +22,23 @@ const DriveSpeedWidget: React.FC<IDriveWidgetProps> = (
     (state: RootState) => state.driveStore.multiplier
   );
 
-  const bifrostTelemetry = useBifrost({ topic: RosTopic.DRIVE_TELEMETRY });
-  const wheelsData = useSelector(
-    (state: RootState) => state.driveTelemetryStore.wheels
+  const wheelJointNames = ["flw", "frw", "blw", "brw"];
+
+  const bifrostJointStates = useBifrost({ topic: RosTopic.DRIVE_JOINT_STATES });
+  const { name: jointNames, velocity: jointVelocities } = useSelector(
+    (state: RootState) => state.driveJointStateStore
   );
-  const averageWheelAngularVelocity =
-    wheelsData
-      .map((w) => Math.abs(w.rotor_velocity))
-      .reduce((v: number, acc: number) => v + acc, 0) / 4;
+
+  const wheelVelocities = jointVelocities.filter((_velocity: number, index: number) => {
+    wheelJointNames.includes(jointNames[index])
+  })
+  const averageWheelAngularVelocity = wheelVelocities.reduce(
+    (acc: number, velocity: number) => { return acc + velocity; }, 0.0)
+    / wheelVelocities.length;
 
   useEffect(() => {
     bifrostDrive.syncWithTopic();
-  }, [bifrostDrive, bifrostTelemetry]);
+  }, [bifrostDrive, bifrostJointStates]);
 
   // Helper function for creating labels in the driveInfoCardBody
   const createLabelCell = (content: ReactNode) => (

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
@@ -30,10 +30,10 @@ const DriveSpeedWidget: React.FC<IDriveWidgetProps> = (
   );
 
   const wheelVelocities = jointVelocities.filter((_velocity: number, index: number) => {
-    wheelJointNames.includes(jointNames[index])
+    return wheelJointNames.includes(jointNames[index])
   })
   const averageWheelAngularVelocity = wheelVelocities.reduce(
-    (acc: number, velocity: number) => { return acc + velocity; }, 0.0)
+    (acc: number, velocity: number) => { return acc + Math.abs(velocity); }, 0.0)
     / Math.max(wheelVelocities.length, 1);
 
   useEffect(() => {

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveSpeedWidget/DriveSpeedWidget.tsx
@@ -7,6 +7,7 @@ import { RootState } from "../../../redux/RootState.ts";
 import { useSelector } from "react-redux";
 import { DRIVE_VEL_MAX } from "../../../constants.ts";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
+import {getJointVelocity} from "../../../utils.ts";
 
 // Properties for the DriveModeWidget component.
 export interface IDriveWidgetProps extends CardProps {}
@@ -25,16 +26,12 @@ const DriveSpeedWidget: React.FC<IDriveWidgetProps> = (
   const wheelJointNames = ["flw", "frw", "blw", "brw"];
 
   const bifrostJointStates = useBifrost({ topic: RosTopic.DRIVE_JOINT_STATES });
-  const { name: jointNames, velocity: jointVelocities } = useSelector(
+  const jointState = useSelector(
     (state: RootState) => state.driveJointStateStore
   );
 
-  const wheelVelocities = jointVelocities.filter((_velocity: number, index: number) => {
-    return wheelJointNames.includes(jointNames[index])
-  })
-  const averageWheelAngularVelocity = wheelVelocities.reduce(
-    (acc: number, velocity: number) => { return acc + Math.abs(velocity); }, 0.0)
-    / Math.max(wheelVelocities.length, 1);
+  const averageWheelAngularVelocity = wheelJointNames.map((joint: string) => { return getJointVelocity(joint, jointState)})
+    .reduce((acc: number, value: number) => { return acc + Math.abs(value); }, 0.0) / wheelJointNames.length;
 
   useEffect(() => {
     bifrostDrive.syncWithTopic();

--- a/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
@@ -41,7 +41,7 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
   const getEffort = (name: string) => {
     const index = names.indexOf(name)
     if (index >= 0) {
-      return efforts[index];
+      return Math.abs(efforts[index]);
     }
     else {
       return 0;

--- a/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
@@ -13,7 +13,6 @@ import { RootState } from "../../../redux/RootState.ts";
 import { useSelector } from "react-redux";
 import { ChevronUp } from "react-feather";
 import WheelTelemetryWidgetCell, { IWheelTelemetryWidgetCellProps } from "./WheelTelemetryWidgetCell.tsx";
-import { PIVOT_CURRENT_MAX, WHEEL_CURRENT_MAX } from "../../../constants.ts";
 import RoverTopDownImage from "../../../assets/rover-top-down-dark.png";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
 
@@ -28,35 +27,53 @@ export interface IDriveWheelWidgetProps extends CardProps {
 const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
   props: IDriveWheelWidgetProps
 ) => {
-  const bifrost = useBifrost({ topic: RosTopic.DRIVE_TELEMETRY });
+  const pivotEffortMultiplier = 1;
+  const wheelEffortMultiplier = 1;
 
-  const pivots = useSelector((state: RootState) => state.driveTelemetryStore.pivots);
-  const pivotCurrents = pivots.map((p: { q_current: number; }) => Math.abs(p.q_current));
+  const bifrost = useBifrost({ topic: RosTopic.DRIVE_JOINT_STATES });
 
-  const wheels = useSelector((state: RootState) => state.driveTelemetryStore.wheels);
-  const wheelCurrents = wheels.map((w: { q_current: number; }) => Math.abs(w.q_current));
+  const names = useSelector((state: RootState) => state.driveJointStateStore.name);
+  const efforts = useSelector((state: RootState) => state.driveJointStateStore.effort);
 
   useEffect(() => {
     bifrost.syncWithTopic();
   }, [bifrost]);
+
+  const getEffort = (name: string) => {
+    const index = names.indexOf(name)
+    if (index >= 0) {
+      return efforts[index];
+    }
+    else {
+      return -1;
+    }
+  }
 
   // Props to give to each cell. The order of names matches the order of SingleTelemetry entries in the Telemetry arrays
   const cellProps: IWheelTelemetryWidgetCellProps[] = [
     {
       label: <>Front Left</>,
       className: "row-start-1 col-start-1",
+      wheelValue: getEffort("flw"),
+      pivotValue: getEffort("flp"),
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Back Left</>,
       className: "row-start-2 col-start-1",
+      wheelValue: getEffort("blw"),
+      pivotValue: getEffort("blp"),
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Back Right</>,
       className: "row-start-2 col-start-3",
+      wheelValue: getEffort("brw"),
+      pivotValue: getEffort("brp"),
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Front Right</>,
       className: "row-start-1 col-start-3",
+      wheelValue: getEffort("frw"),
+      pivotValue: getEffort("frp"),
     } as IWheelTelemetryWidgetCellProps,
   ];
 
@@ -72,10 +89,10 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
         </div>
         {cellProps.map((cellProp, index) => (
           <WheelTelemetryWidgetCell
-            key={index}
             {...cellProp}
-            wheelValue={wheelCurrents[index] / WHEEL_CURRENT_MAX}
-            pivotValue={pivotCurrents[index] / PIVOT_CURRENT_MAX}
+            key={index}
+            wheelValue={cellProp.wheelValue * wheelEffortMultiplier}
+            pivotValue={cellProp.pivotValue * pivotEffortMultiplier}
           />
         ))}
       </div>

--- a/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
@@ -15,6 +15,7 @@ import { ChevronUp } from "react-feather";
 import WheelTelemetryWidgetCell, { IWheelTelemetryWidgetCellProps } from "./WheelTelemetryWidgetCell.tsx";
 import RoverTopDownImage from "../../../assets/rover-top-down-dark.png";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
+import {PIVOT_CURRENT_MAX, WHEEL_CURRENT_MAX} from "../../../constants.ts";
 
 // Properties for the WheelTelemetryWidget component.
 export interface IDriveWheelWidgetProps extends CardProps {
@@ -27,8 +28,6 @@ export interface IDriveWheelWidgetProps extends CardProps {
 const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
   props: IDriveWheelWidgetProps
 ) => {
-  const pivotEffortMultiplier = 1;
-  const wheelEffortMultiplier = 1;
 
   const bifrost = useBifrost({ topic: RosTopic.DRIVE_JOINT_STATES });
 
@@ -45,7 +44,7 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
       return efforts[index];
     }
     else {
-      return -1;
+      return 0;
     }
   }
 
@@ -91,8 +90,8 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
           <WheelTelemetryWidgetCell
             {...cellProp}
             key={index}
-            wheelValue={cellProp.wheelValue * wheelEffortMultiplier}
-            pivotValue={cellProp.pivotValue * pivotEffortMultiplier}
+            wheelValue={cellProp.wheelValue / WHEEL_CURRENT_MAX}
+            pivotValue={cellProp.pivotValue / PIVOT_CURRENT_MAX}
           />
         ))}
       </div>

--- a/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidget.tsx
@@ -16,6 +16,7 @@ import WheelTelemetryWidgetCell, { IWheelTelemetryWidgetCellProps } from "./Whee
 import RoverTopDownImage from "../../../assets/rover-top-down-dark.png";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
 import {PIVOT_CURRENT_MAX, WHEEL_CURRENT_MAX} from "../../../constants.ts";
+import {getJointEffort} from "../../../utils.ts";
 
 // Properties for the WheelTelemetryWidget component.
 export interface IDriveWheelWidgetProps extends CardProps {
@@ -31,48 +32,37 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
 
   const bifrost = useBifrost({ topic: RosTopic.DRIVE_JOINT_STATES });
 
-  const names = useSelector((state: RootState) => state.driveJointStateStore.name);
-  const efforts = useSelector((state: RootState) => state.driveJointStateStore.effort);
+  const jointState = useSelector((state: RootState) => state.driveJointStateStore);
 
   useEffect(() => {
     bifrost.syncWithTopic();
   }, [bifrost]);
-
-  const getEffort = (name: string) => {
-    const index = names.indexOf(name)
-    if (index >= 0) {
-      return Math.abs(efforts[index]);
-    }
-    else {
-      return 0;
-    }
-  }
 
   // Props to give to each cell. The order of names matches the order of SingleTelemetry entries in the Telemetry arrays
   const cellProps: IWheelTelemetryWidgetCellProps[] = [
     {
       label: <>Front Left</>,
       className: "row-start-1 col-start-1",
-      wheelValue: getEffort("flw"),
-      pivotValue: getEffort("flp"),
+      wheelName: "flw",
+      pivotName: "flp",
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Back Left</>,
       className: "row-start-2 col-start-1",
-      wheelValue: getEffort("blw"),
-      pivotValue: getEffort("blp"),
+      wheelName: "blw",
+      pivotName: "blp",
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Back Right</>,
       className: "row-start-2 col-start-3",
-      wheelValue: getEffort("brw"),
-      pivotValue: getEffort("brp"),
+      wheelName: "brw",
+      pivotName: "brp",
     } as IWheelTelemetryWidgetCellProps,
     {
       label: <>Front Right</>,
       className: "row-start-1 col-start-3",
-      wheelValue: getEffort("frw"),
-      pivotValue: getEffort("frp"),
+      wheelName: "frw",
+      pivotName: "frp",
     } as IWheelTelemetryWidgetCellProps,
   ];
 
@@ -90,8 +80,8 @@ const WheelTelemetryWidget: React.FC<IDriveWheelWidgetProps> = (
           <WheelTelemetryWidgetCell
             {...cellProp}
             key={index}
-            wheelValue={cellProp.wheelValue / WHEEL_CURRENT_MAX}
-            pivotValue={cellProp.pivotValue / PIVOT_CURRENT_MAX}
+            wheelValue={Math.abs(getJointEffort(cellProp.wheelName, jointState)) / WHEEL_CURRENT_MAX}
+            pivotValue={Math.abs(getJointEffort(cellProp.pivotName, jointState)) / PIVOT_CURRENT_MAX}
           />
         ))}
       </div>

--- a/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidgetCell.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/WheelTelemetryWidget/WheelTelemetryWidgetCell.tsx
@@ -11,6 +11,8 @@ import { OverlayedProgress } from "../../shared/components/OverlayedProgress/Ove
 
 // Properties for the DriveWidgetWheelData component.
 export interface IWheelTelemetryWidgetCellProps extends CardProps {
+  wheelName: string,
+  pivotName: string,
   wheelValue: number,
   pivotValue: number,
   label: ReactNode

--- a/src/ros/nova-gui/nova-gui/src/constants.ts
+++ b/src/ros/nova-gui/nova-gui/src/constants.ts
@@ -1,3 +1,7 @@
+// The max current of a motor in the wheel, considered 100% on the progress bar, in amps
+export const WHEEL_CURRENT_MAX = 0.45;
+export const PIVOT_CURRENT_MAX = 0.45;
+
 // The max velocity of the wheels, considered 100% on the progress bar, in rad/s
 export const DRIVE_VEL_MAX = 1.0;
 

--- a/src/ros/nova-gui/nova-gui/src/constants.ts
+++ b/src/ros/nova-gui/nova-gui/src/constants.ts
@@ -1,7 +1,3 @@
-// The max current of a motor in the wheel, considered 100% on the progress bar, in amps
-export const WHEEL_CURRENT_MAX = 0.45;
-export const PIVOT_CURRENT_MAX = 0.45;
-
 // The max velocity of the wheels, considered 100% on the progress bar, in rad/s
 export const DRIVE_VEL_MAX = 1.0;
 

--- a/src/ros/nova-gui/nova-gui/src/constants.ts
+++ b/src/ros/nova-gui/nova-gui/src/constants.ts
@@ -1,6 +1,6 @@
 // The max current of a motor in the wheel, considered 100% on the progress bar, in amps
-export const WHEEL_CURRENT_MAX = 0.45;
-export const PIVOT_CURRENT_MAX = 0.45;
+export const WHEEL_CURRENT_MAX = 0.2;
+export const PIVOT_CURRENT_MAX = 0.2;
 
 // The max velocity of the wheels, considered 100% on the progress bar, in rad/s
 export const DRIVE_VEL_MAX = 1.0;

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -5,8 +5,9 @@ import {RosTopic} from "../ros/topics/rosTopic";
 import {
   IRosCmdInterfacesCmdFeedback,
   IRosCmdInterfacesCmDsFeedback,
+  IRosNovaInterfacesStatusConst,
   IRosScienceInterfacesHydraprobeData,
-  IRosScienceInterfacesNirProbeDataConst, IRosNovaInterfacesStatusConst,
+  IRosScienceInterfacesNirProbeDataConst,
   IRosSensorMsgsRange,
   IRosStdMsgsHeader
 } from "../ros/rosTypes";
@@ -80,6 +81,15 @@ export const reduxStores = {
         voltage: 0,
         temperature: 0,
       })),
+    }
+  ),
+  driveJointStateStore: createBifrostStore(
+    { topic: RosTopic.DRIVE_JOINT_STATES },
+    {
+      name: [],
+      position: [],
+      velocity: [],
+      effort: [],
     }
   ),
 

--- a/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootState.ts
@@ -32,7 +32,7 @@ import {
   IRosNovaInterfacesStatus,
   IRosSensorMsgsNavSatFix,
   IRosArmInterfacesSequencerFeedback,
-  IRosNovaInterfacesRadioStatus,
+  IRosNovaInterfacesRadioStatus, IRosSensorMsgsJointState,
 
 } from "../ros/rosTypes";
 
@@ -58,6 +58,7 @@ export interface RootState {
   // Drive Stores
   driveStore: IRosDriveInterfacesDriveInfo;
   driveTelemetryStore: IRosBlcmdInterfacesTelemetry;
+  driveJointStateStore: IRosSensorMsgsJointState;
 
   // Arm Stores
   armTelemetryStore: IRosCmdInterfacesCmDsFeedback;

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopic.ts
@@ -15,6 +15,7 @@ export enum RosTopic {
   // Drive related topics
   DRIVE_INFO = "/drive/drive_info",
   DRIVE_TELEMETRY = "/drive/telemetry",
+  DRIVE_JOINT_STATES = "/drive/joint_states",
 
   // Arm related topics
   ARM_TELEMETRY = "/cmds/cmd_feedback",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicMessages.ts
@@ -15,6 +15,7 @@ export const rosTopicMessages = {
   // Drive Related
   [RosTopic.DRIVE_INFO]: "drive_interfaces/msg/DriveInfo",
   [RosTopic.DRIVE_TELEMETRY]: "blcmd_interfaces/msg/Telemetry",
+  [RosTopic.DRIVE_JOINT_STATES]: "sensor_msgs/msg/JointState",
 
   // Arm Related
   [RosTopic.ARM_TELEMETRY]: "cmd_interfaces/msg/CMDsFeedback",

--- a/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
+++ b/src/ros/nova-gui/nova-gui/src/ros/topics/rosTopicTypes.ts
@@ -25,6 +25,7 @@ import {
   IRosArmInterfacesSequencerFeedback,
   IRosNovaInterfacesRadioStatus,
   IRosScienceInterfacesEffortStatus,
+  IRosSensorMsgsJointState,
 } from "../rosTypes";
 import { RosTopic } from "./rosTopic";
 
@@ -42,6 +43,7 @@ export interface RosTopicInterfaces {
   // Drive Related
   [RosTopic.DRIVE_INFO]: IRosDriveInterfacesDriveInfo;
   [RosTopic.DRIVE_TELEMETRY]: IRosBlcmdInterfacesTelemetry;
+  [RosTopic.DRIVE_JOINT_STATES]: IRosSensorMsgsJointState;
 
   // Arm Related
   [RosTopic.ARM_TELEMETRY]: IRosCmdInterfacesCmDsFeedback;

--- a/src/ros/nova-gui/nova-gui/src/utils.ts
+++ b/src/ros/nova-gui/nova-gui/src/utils.ts
@@ -1,0 +1,19 @@
+import {IRosSensorMsgsJointState} from "./ros/rosTypes.ts";
+
+const getJointState = (name: string, names: string[], states: number[]) : number => {
+  const index = names.indexOf(name);
+  if (index >= 0) {
+    return states[index];
+  }
+  return 0.0;
+}
+
+export function getJointEffort(joint: string, jointState: IRosSensorMsgsJointState)  {
+  return getJointState(joint, jointState.name, jointState.effort);
+}
+export function getJointVelocity(joint: string, jointState: IRosSensorMsgsJointState)  {
+  return getJointState(joint, jointState.name, jointState.velocity);
+}
+export function getJointPosition(joint: string, jointState: IRosSensorMsgsJointState)  {
+  return getJointState(joint, jointState.name, jointState.position);
+}

--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -85,7 +85,9 @@ def launch_setup(context, *args, **kwargs):
                 Node(
                     package='controller_manager',
                     executable='spawner',
-                    arguments=['joint_state_broadcaster'],
+                    arguments=['joint_state_broadcaster',
+                               '--controller-ros-args', '-r /joint_states:=/drive/joint_states',
+                               '--controller-ros-args', '-r /dynamic_joint_states:=/drive/dynamic_joint_states'],
                     ros_arguments=['--log-level', log_level],
                 ),
                 Node(
@@ -94,8 +96,6 @@ def launch_setup(context, *args, **kwargs):
                     parameters=[params],
                     remappings=[
                         ('/controller_manager/robot_description', '/robot_description'),
-                        ('/joint_states', '/drive/joint_states'),
-                        ('/dynamic_joint_states', '/drive/dynamic_joint_states'),
                     ],
                     ros_arguments=['--log-level', log_level],
                 ),

--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -94,6 +94,8 @@ def launch_setup(context, *args, **kwargs):
                     parameters=[params],
                     remappings=[
                         ('/controller_manager/robot_description', '/robot_description'),
+                        ('/joint_states', '/drive/joint_states'),
+                        ('/dynamic_joint_states', '/drive/dynamic_joint_states'),
                     ],
                     ros_arguments=['--log-level', log_level],
                 ),

--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -86,8 +86,7 @@ def launch_setup(context, *args, **kwargs):
                     package='controller_manager',
                     executable='spawner',
                     arguments=['joint_state_broadcaster',
-                               '--controller-ros-args', '-r /joint_states:=/drive/joint_states',
-                               '--controller-ros-args', '-r /dynamic_joint_states:=/drive/dynamic_joint_states'],
+                               '--controller-ros-args', '-r __ns:=/drive'],
                     ros_arguments=['--log-level', log_level],
                 ),
                 Node(

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -37,8 +37,8 @@ pivot_position_controller:
 joint_state_broadcaster:
   ros__parameters:
     interfaces:
-       ["position",
-      "velocity"]
+      ["position", "velocity",
+       "effort"]
       
     joints:
       ["blp", "brp", "flp", "frp",

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -37,8 +37,8 @@ pivot_position_controller:
 joint_state_broadcaster:
   ros__parameters:
     interfaces:
-       ["position",
-      "velocity"]
+       ["position", "velocity",
+        "effort"]
       
     joints:
       ["blp", "brp", "flp", "frp",

--- a/src/ros/rover/drive/drive_interfaces/msg/DriveInfo.msg
+++ b/src/ros/rover/drive/drive_interfaces/msg/DriveInfo.msg
@@ -14,6 +14,7 @@ bool connected
 byte PIVOT = 1
 byte STRAFE = 2
 byte TANK = 3
+byte ACKERMANN = 4
 
 #current drive mode of the rover
 byte drive_mode 

--- a/src/ros/rover/drive/teleop_drive_joy/CMakeLists.txt
+++ b/src/ros/rover/drive/teleop_drive_joy/CMakeLists.txt
@@ -64,10 +64,11 @@ install(
   DESTINATION include/${PROJECT_NAME}
 )
 
-# Install launch files
-install(
-  DIRECTORY launch/
-  DESTINATION share/${PROJECT_NAME}/launch
+# Install launch and param files
+install(DIRECTORY
+  launch
+  params
+  DESTINATION share/${PROJECT_NAME}
 )
 
 ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
+++ b/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
@@ -31,6 +31,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/joy.hpp>
+#include <sensor_msgs/msg/joy_feedback.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <rcl_interfaces/srv/set_parameters.hpp>
 #include <controller_manager_msgs/srv/switch_controller.hpp>
@@ -193,15 +195,26 @@ private:
    */
   void send_drive_info();
 
+    /**
+   * @brief Callback function for joint state messages.
+   * @param joint_state_msg Shared pointer to the joint state message.
+   */
+  void joint_states_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg);
+
   // Member variables
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_pub_;
   rclcpp::Publisher<drive_interfaces::msg::DriveInfo>::SharedPtr drive_info_pub_;
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
+  rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr joy_feedback_pub_;
+  rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
+
   rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr
     switch_controller_client_;
+
   rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr pivot_drive_client_;
   rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr strafe_client_;
   rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr diff_drive_client_;
+
   std::shared_ptr<ParamListener> param_listener_;
   rclcpp::TimerBase::SharedPtr connection_timer_;
 
@@ -215,6 +228,8 @@ private:
   bool handbrake_pressed_;
   bool autonomous_mode_;
   bool connected_;
+
+  std::optional<rclcpp::Time> start_rumble_;
 };
 
 }  // namespace teleop_drive_joy

--- a/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
+++ b/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
@@ -34,6 +34,7 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <rcl_interfaces/srv/set_parameters.hpp>
 #include <controller_manager_msgs/srv/switch_controller.hpp>
+#include <drive_interfaces/msg/drive_info.hpp>
 
 #include "teleop_drive_joy_parameters.hpp"
 
@@ -79,6 +80,21 @@ inline std::string mode_to_controller(const DriveMode mode)
       return "diff_drive_controller";
     default:
       return "unknown_controller";
+  }
+}
+
+inline uint8_t mode_to_drive_info(const DriveMode mode)
+{
+  switch (mode)
+  {
+  case DriveMode::PIVOT:
+    return drive_interfaces::msg::DriveInfo::PIVOT;
+  case DriveMode::ACKERMANN:
+    return drive_interfaces::msg::DriveInfo::ACKERMANN;
+  case DriveMode::STRAFE:
+    return drive_interfaces::msg::DriveInfo::STRAFE;
+  case DriveMode::DIFF:
+    return drive_interfaces::msg::DriveInfo::TANK;
   }
 }
 
@@ -166,8 +182,20 @@ private:
    */
   void print_controls();
 
+  /**
+   * @brief Updates connection status to game pad
+   * @param connected Whether game pad is connected or not
+   */
+  void set_connected(bool connected);
+
+  /**
+   * @brief Sends current state of teleop drive joy as drive info
+   */
+  void send_drive_info();
+
   // Member variables
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr cmd_vel_pub_;
+  rclcpp::Publisher<drive_interfaces::msg::DriveInfo>::SharedPtr drive_info_pub_;
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
   rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr
     switch_controller_client_;
@@ -175,6 +203,7 @@ private:
   rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr strafe_client_;
   rclcpp::Client<rcl_interfaces::srv::SetParameters>::SharedPtr diff_drive_client_;
   std::shared_ptr<ParamListener> param_listener_;
+  rclcpp::TimerBase::SharedPtr connection_timer_;
 
   Params params_;
   bool sent_lock_msg_;
@@ -184,6 +213,8 @@ private:
   std::map<int, rclcpp::Time> last_button_press_time_;
   std::map<int, std::function<void(const sensor_msgs::msg::Joy::SharedPtr)>> button_callbacks_;
   bool handbrake_pressed_;
+  bool autonomous_mode_;
+  bool connected_;
 };
 
 }  // namespace teleop_drive_joy

--- a/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
+++ b/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
@@ -97,6 +97,8 @@ inline uint8_t mode_to_drive_info(const DriveMode mode)
     return drive_interfaces::msg::DriveInfo::STRAFE;
   case DriveMode::DIFF:
     return drive_interfaces::msg::DriveInfo::TANK;
+  default:
+    return std::numeric_limits<uint8_t>::max();
   }
 }
 

--- a/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
+++ b/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
@@ -19,14 +19,11 @@ def launch_setup(context, *args, **kwargs):
             package='joy',
             executable='game_controller_node',
             name='game_controller_node',
+            namespace='/drive',
             parameters=[
                 {'device_id': device_id,
                  'deadzone': 0.1,
                  'autorepeat_rate': 20.0} | {'device_name': device_name} if device_name else {}
-            ],
-            remappings=[
-                ('/joy', '/drive/joy'),
-                ('/joy/set_feedback', '/drive/joy/set_feedback'),
             ],
         ),
         Node(

--- a/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
+++ b/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
@@ -1,8 +1,9 @@
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction, DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PythonExpression, PathJoinSubstitution
 from launch_ros.actions import Node
-
+from launch_ros.substitutions import FindPackageShare
+from os.path import expanduser
 
 def launch_setup(context, *args, **kwargs):
 
@@ -10,6 +11,7 @@ def launch_setup(context, *args, **kwargs):
     device_id = LaunchConfiguration('device_id')
     device_name = LaunchConfiguration('device_name')
     joy_vel = LaunchConfiguration('joy_vel')
+    teleop_params = LaunchConfiguration('teleop_params')
 
     return [
         # Add Nodes
@@ -22,11 +24,16 @@ def launch_setup(context, *args, **kwargs):
                  'deadzone': 0.1,
                  'autorepeat_rate': 20.0} | {'device_name': device_name} if device_name else {}
             ],
+            remappings=[
+                ('/joy', '/drive/joy'),
+                ('/joy/set_feedback', '/drive/joy/set_feedback'),
+            ],
         ),
         Node(
             package='teleop_drive_joy',
             executable='teleop_drive_joy_node',
             name='teleop_drive_joy_node',
+            parameters=[teleop_params],
             remappings=[
                 ('/cmd_vel', joy_vel),
             ],
@@ -34,7 +41,23 @@ def launch_setup(context, *args, **kwargs):
     ]
 
 def generate_launch_description():
+    teleop_drive_dir = PythonExpression([
+        '"', PathJoinSubstitution([expanduser("~") + '/nova/src/ros/rover/drive/teleop_drive_joy']),
+        '" if "', LaunchConfiguration('local'), '".lower() == "true" else "',
+        FindPackageShare('teleop_drive_joy'), '"'
+    ])
+
     declared_arguments = [
+        DeclareLaunchArgument(
+            name='local',
+            default_value='False',
+            description='Whether to use the local teleop_drive_joy source directory instead of the nix store for param files.',
+        ),
+        DeclareLaunchArgument(
+            name='teleop_params',
+            default_value=PathJoinSubstitution([teleop_drive_dir, 'params', 'teleop.yaml']),
+            description='The main parameter file to use for teleop_drive_joy_node',
+        ),
         DeclareLaunchArgument(
             name='device_id',
             default_value='0',

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -1,0 +1,52 @@
+# see teleop_drive_joy.yaml for descriptions given to options
+teleop_drive_joy_node:
+  ros__parameters:
+    initial_speed: 0.1
+    max_input_threshold: 0.97
+    handbrake_speed_multiplier: 0.6
+    trigger_pressed_threshold: 0.1
+
+    rumble_delay: 0
+    rumble_joints: [ frw, flw, brw, blw ]
+    rumble_range: [ 0.4, 0.8 ]
+
+    speed_limit_max: 1.0
+    speed_limit_min: 0.05
+    speed_change_coarse_val: 0.1
+    speed_change_fine_val: 0.025
+
+    input_topic: /drive/joy
+    output_topic: /cmd_vel
+    drive_info_topic: /drive/drive_info
+    joint_states_topic: /drive/joint_states
+    joy_feedback_topic: /drive/joy/set_feedback
+
+    controllers:
+      - pivot_drive_controller
+      - ackermann_steering_controller
+      - strafe_drive_controller
+      - diff_drive_controller
+    pivot_drive_controller:
+      limit_angular: 0.999
+      limit_linear: 1.0
+      scale_angular: 1.0
+      scale_linear: 1.0
+    ackermann_steering_controller:
+      limit_angular: 1.0
+      limit_linear: 1.0
+      scale_angular: 1.0
+      scale_linear: 1.0
+    strafe_drive_controller:
+      limit_angular: 1.0
+      limit_linear: 1.0
+      scale_angular: 1.0
+      scale_linear: 1.0
+    diff_drive_controller:
+      limit_angular: 1.0
+      limit_linear: 1.0
+      scale_angular: 1.0
+      scale_linear: 1.0
+
+
+
+

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -6,10 +6,10 @@ teleop_drive_joy_node:
     handbrake_speed_multiplier: 0.6
     trigger_pressed_threshold: 0.1
 
-    rumble_enable: false
-    rumble_delay: 0
+    rumble_enable: true
+    rumble_delay: 100
     rumble_joints: [ frw, flw, brw, blw ]
-    rumble_range: [ 0.4, 0.8 ]
+    rumble_range: [ 0.075, 0.2 ]
 
     speed_limit_max: 1.0
     speed_limit_min: 0.05

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -7,7 +7,9 @@ teleop_drive_joy_node:
     trigger_pressed_threshold: 0.1
 
     rumble_enable: true
-    rumble_delay: 100
+    # rumble is currently updated every 50ms (period that drive joint states is published at),
+    # so rumble_delay is actually ceiling(rumble_delay / 50) * 50
+    rumble_delay: 110
     rumble_joints: [ frw, flw, brw, blw ]
     rumble_range: [ 0.075, 0.2 ]
 

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -10,7 +10,8 @@ teleop_drive_joy_node:
     # rumble is currently updated every 50ms (period that drive joint states is published at),
     # so rumble_delay is actually ceiling(rumble_delay / 50) * 50
     rumble_delay: 110
-    rumble_joints: [ frw, flw, brw, blw ]
+    rumble_joints: [ frw, flw, brw, blw,
+                     frp, flp, brp, blp ]
     rumble_range: [ 0.075, 0.2 ]
 
     speed_limit_max: 1.0

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -6,6 +6,7 @@ teleop_drive_joy_node:
     handbrake_speed_multiplier: 0.6
     trigger_pressed_threshold: 0.1
 
+    rumble_enable: false
     rumble_delay: 0
     rumble_joints: [ frw, flw, brw, blw ]
     rumble_range: [ 0.4, 0.8 ]

--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -30,6 +30,8 @@ teleop_drive_joy_node:
       - strafe_drive_controller
       - diff_drive_controller
     pivot_drive_controller:
+      # angular input is limited to avoid having pivots rotate to their maximum position
+      # (which currently causes them to "wrap around" to their minimum position instead)
       limit_angular: 0.999
       limit_linear: 1.0
       scale_angular: 1.0

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -146,6 +146,10 @@ void TeleopDriveJoy::initialize_interfaces()
     "/diff_drive_controller/set_parameters");
 
   drive_info_pub_ = this->create_publisher<drive_interfaces::msg::DriveInfo>(params_.drive_info_topic, 10);
+
+  joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
+    params_.joint_states_topic, rclcpp::QoS(10), std::bind(&TeleopDriveJoy::joint_states_callback, this, _1));
+  joy_feedback_pub_ = this->create_publisher<sensor_msgs::msg::JoyFeedback>(params_.joy_feedback_topic, 10);
 }
 
 void TeleopDriveJoy::map_button_callbacks()
@@ -430,6 +434,55 @@ void TeleopDriveJoy::send_drive_info()
 
   drive_info_pub_->publish(msg);
 }
+
+void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg)
+{
+  // get max effort of joints in rumble_joints
+  double max_effort = 0;
+  const std::vector<std::string>& names = joint_state_msg->name;
+  for (std::string& joint_name : params_.rumble_joints)
+  {
+    auto iterator = std::find(names.begin(), names.end(), joint_name);
+    if (iterator != names.end())
+    {
+      const double effort = joint_state_msg->effort[std::distance(names.begin(), iterator)];
+      if (effort > max_effort)
+      {
+        max_effort = effort;
+      }
+    }
+  }
+
+  // map max_effort to values from 0 to 1, assuming its min = rumble_range[0] and max = rumble_range[1]
+  const double rumble_intensity = std::clamp((max_effort - params_.rumble_range[0])
+    / (params_.rumble_range[1] - params_.rumble_range[0]), 0.0, 1.0);
+
+  if (rumble_intensity > 0)
+  {
+    if (not start_rumble_)
+    {
+      start_rumble_ = this->now();
+    }
+  }
+  else
+  {
+    start_rumble_.reset();
+  }
+
+  RCLCPP_DEBUG(this->get_logger(), "Game pad rumble calculations: rumble_intensity = %.2f, max_effort = %.2f", rumble_intensity, max_effort);
+
+  // only actually rumble if already rumbling for rumble_delay seconds
+  if (start_rumble_ and start_rumble_.value()
+    <= this->now() - rclcpp::Duration(std::chrono::milliseconds(params_.rumble_delay)))
+  {
+    sensor_msgs::msg::JoyFeedback msg {};
+    msg.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
+    msg.id = 0;
+    msg.intensity = static_cast<float>(rumble_intensity);
+    joy_feedback_pub_->publish(msg);
+  }
+}
+
 }  // namespace teleop_drive_joy
 
 int main(int argc, char* argv[])

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -444,14 +444,14 @@ void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::S
   // get max effort of joints in rumble_joints
   const auto joint_effort = [joint_state_msg](const std::string& joint) -> double
   {
-    for (int i = 0; i <= joint_state_msg->name.size(); ++i)
+    for (int i = 0; i < joint_state_msg->name.size(); ++i)
     {
       if (joint_state_msg->name[i] == joint)
       {
         return joint_state_msg->effort[i];
       }
     }
-    return -1.0;
+    return 0.0;
   };
 
   double max_effort = 0;

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -416,11 +416,11 @@ void TeleopDriveJoy::set_connected(const bool connected)
 
       if (connected_)
       {
-        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad connected" << C_END);
+        RCLCPP_INFO_STREAM(this->get_logger(), C_INFO << "Gamepad connected" << C_END);
       }
       else
       {
-        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad disconnected" << C_END);
+        RCLCPP_INFO_STREAM(this->get_logger(), C_INFO << "Gamepad disconnected" << C_END);
       }
     }
 }

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -415,11 +415,11 @@ void TeleopDriveJoy::set_connected(const bool connected)
 
       if (connected_)
       {
-        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad " << C_SUCCESS << "connected." << C_END);
+        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad connected" << C_END);
       }
       else
       {
-        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad " << C_FAIL << "disconnected." << C_END);
+        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad disconnected" << C_END);
       }
     }
 }

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -147,9 +147,12 @@ void TeleopDriveJoy::initialize_interfaces()
 
   drive_info_pub_ = this->create_publisher<drive_interfaces::msg::DriveInfo>(params_.drive_info_topic, 10);
 
-  joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
-    params_.joint_states_topic, rclcpp::QoS(10), std::bind(&TeleopDriveJoy::joint_states_callback, this, _1));
-  joy_feedback_pub_ = this->create_publisher<sensor_msgs::msg::JoyFeedback>(params_.joy_feedback_topic, 10);
+  if (params_.rumble_enable)
+  {
+    joint_state_sub_ = this->create_subscription<sensor_msgs::msg::JointState>(
+      params_.joint_states_topic, rclcpp::QoS(10), std::bind(&TeleopDriveJoy::joint_states_callback, this, _1));
+    joy_feedback_pub_ = this->create_publisher<sensor_msgs::msg::JoyFeedback>(params_.joy_feedback_topic, 10);
+  }
 }
 
 void TeleopDriveJoy::map_button_callbacks()

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -145,7 +145,8 @@ void TeleopDriveJoy::initialize_interfaces()
   diff_drive_client_ = this->create_client<rcl_interfaces::srv::SetParameters>(
     "/diff_drive_controller/set_parameters");
 
-  drive_info_pub_ = this->create_publisher<drive_interfaces::msg::DriveInfo>(params_.drive_info_topic, 10);
+  drive_info_pub_ = this->create_publisher<drive_interfaces::msg::DriveInfo>(
+    params_.drive_info_topic, rclcpp::QoS(1).transient_local());
 
   if (params_.rumble_enable)
   {

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -442,18 +442,25 @@ void TeleopDriveJoy::send_drive_info()
 void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg)
 {
   // get max effort of joints in rumble_joints
+  const auto joint_effort = [joint_state_msg](const std::string& joint) -> double
+  {
+    for (int i = 0; i <= joint_state_msg->name.size(); ++i)
+    {
+      if (joint_state_msg->name[i] == joint)
+      {
+        return joint_state_msg->effort[i];
+      }
+    }
+    return -1.0;
+  };
+
   double max_effort = 0;
-  const std::vector<std::string>& names = joint_state_msg->name;
   for (std::string& joint_name : params_.rumble_joints)
   {
-    auto iterator = std::find(names.begin(), names.end(), joint_name);
-    if (iterator != names.end())
+    double effort = std::abs(joint_effort(joint_name));
+    if (effort > max_effort)
     {
-      const double effort = std::abs(joint_state_msg->effort[std::distance(names.begin(), iterator)]);
-      if (effort > max_effort)
-      {
-        max_effort = effort;
-      }
+      max_effort = effort;
     }
   }
 

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -445,7 +445,7 @@ void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::S
     auto iterator = std::find(names.begin(), names.end(), joint_name);
     if (iterator != names.end())
     {
-      const double effort = joint_state_msg->effort[std::distance(names.begin(), iterator)];
+      const double effort = std::abs(joint_state_msg->effort[std::distance(names.begin(), iterator)]);
       if (effort > max_effort)
       {
         max_effort = effort;

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -454,7 +454,7 @@ void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::S
   }
 
   // map max_effort to values from 0 to 1, assuming its min = rumble_range[0] and max = rumble_range[1]
-  const double rumble_intensity = std::clamp((max_effort - params_.rumble_range[0])
+  double rumble_intensity = std::clamp((max_effort - params_.rumble_range[0])
     / (params_.rumble_range[1] - params_.rumble_range[0]), 0.0, 1.0);
 
   if (rumble_intensity > 0)
@@ -471,16 +471,18 @@ void TeleopDriveJoy::joint_states_callback(const sensor_msgs::msg::JointState::S
 
   RCLCPP_DEBUG(this->get_logger(), "Game pad rumble calculations: rumble_intensity = %.2f, max_effort = %.2f", rumble_intensity, max_effort);
 
-  // only actually rumble if already rumbling for rumble_delay seconds
-  if (start_rumble_ and start_rumble_.value()
-    <= this->now() - rclcpp::Duration(std::chrono::milliseconds(params_.rumble_delay)))
+  // don't rumble if rumble_delay has not yet passed
+  if (not start_rumble_ or start_rumble_.value()
+    > this->now() - rclcpp::Duration(std::chrono::milliseconds(params_.rumble_delay)))
   {
-    sensor_msgs::msg::JoyFeedback msg {};
-    msg.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
-    msg.id = 0;
-    msg.intensity = static_cast<float>(rumble_intensity);
-    joy_feedback_pub_->publish(msg);
+    rumble_intensity = 0;
   }
+
+  sensor_msgs::msg::JoyFeedback msg {};
+  msg.type = sensor_msgs::msg::JoyFeedback::TYPE_RUMBLE;
+  msg.id = 0;
+  msg.intensity = static_cast<float>(rumble_intensity);
+  joy_feedback_pub_->publish(msg);
 }
 
 }  // namespace teleop_drive_joy

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -35,6 +35,8 @@ TeleopDriveJoy::TeleopDriveJoy(const rclcpp::NodeOptions& options)
   , locked_(true)
   , drive_mode_(DriveMode::PIVOT)
   , handbrake_pressed_(false)
+  , autonomous_mode_(false) // assume (maybe incorrectly) until set_autonomous_mode_for_controllers is called
+  , connected_(false)
 {
 }
 
@@ -89,6 +91,9 @@ void TeleopDriveJoy::set_autonomous_mode_for_controllers(bool enable)
     static_cast<void>(client->async_send_request(request));
   }
 
+  autonomous_mode_ = enable;
+  send_drive_info();
+
 }  // namespace teleop_drive_joy
 
 void TeleopDriveJoy::initialize()
@@ -97,6 +102,14 @@ void TeleopDriveJoy::initialize()
   initialize_interfaces();
   map_button_callbacks();
   print_controls();
+
+  // initialize connection timer
+  connection_timer_ = this->create_timer(0.5s, [this]()
+  {
+    set_connected(false);
+    connection_timer_->cancel();
+  });
+
   RCLCPP_INFO_STREAM(
     this->get_logger(), C_INFO << "Initialized with control mode: " << C_MODE
                                << pretty_print_mode(drive_mode_) << C_END ", " << C_SPEED
@@ -131,6 +144,8 @@ void TeleopDriveJoy::initialize_interfaces()
     "/strafe_drive_controller/set_parameters");
   diff_drive_client_ = this->create_client<rcl_interfaces::srv::SetParameters>(
     "/diff_drive_controller/set_parameters");
+
+  drive_info_pub_ = this->create_publisher<drive_interfaces::msg::DriveInfo>(params_.drive_info_topic, 10);
 }
 
 void TeleopDriveJoy::map_button_callbacks()
@@ -141,6 +156,7 @@ void TeleopDriveJoy::map_button_callbacks()
     {
       locked_ = false;
       RCLCPP_INFO_STREAM(this->get_logger(), C_SUCCESS << "Gamepad unlocked" << C_END);
+      send_drive_info();
     }
   };
   button_callbacks_[params_.button_lock] = [this](const sensor_msgs::msg::Joy::SharedPtr joy_msg)
@@ -149,6 +165,7 @@ void TeleopDriveJoy::map_button_callbacks()
     {
       locked_ = true;
       RCLCPP_INFO_STREAM(this->get_logger(), C_FAIL << "Gamepad locked" << C_END);
+      send_drive_info();
     }
   };
   button_callbacks_[params_.button_autonomous_mode] =
@@ -192,6 +209,7 @@ void TeleopDriveJoy::map_button_callbacks()
         speed_ + speed_change,
         params_.speed_limit_min, params_.speed_limit_max);
       RCLCPP_INFO_STREAM(this->get_logger(), C_SPEED << "Speed: " << speed_ << C_END);
+      send_drive_info();
     }
   };
   button_callbacks_[params_.button_speed_decrease_fine] =
@@ -228,6 +246,10 @@ void TeleopDriveJoy::joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg
   {
     send_halt_command();
   }
+
+  // update connection status
+  connection_timer_->reset();
+  set_connected(true);
 }
 
 void TeleopDriveJoy::handle_button_callbacks(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
@@ -274,6 +296,7 @@ void TeleopDriveJoy::send_drive_command(const sensor_msgs::msg::Joy::SharedPtr j
 	{
 	  handbrake_pressed_ = true;
 	  RCLCPP_INFO_STREAM(this->get_logger(), C_SUCCESS << "Handbrake activated" << C_END);
+	  send_drive_info();
 	}
     linear.first *= params_.handbrake_speed_multiplier;
     linear.second *= params_.handbrake_speed_multiplier;
@@ -282,6 +305,7 @@ void TeleopDriveJoy::send_drive_command(const sensor_msgs::msg::Joy::SharedPtr j
   {
     handbrake_pressed_ = false;
     RCLCPP_INFO_STREAM(this->get_logger(), C_FAIL << "Handbrake deactivated" << C_END);
+    send_drive_info();
   }
 
   // force zeros to be positive zero so ackermann drive assumes rover will move
@@ -350,6 +374,8 @@ void TeleopDriveJoy::switch_controller(const DriveMode requested_control_mode)
 
   drive_mode_ = requested_control_mode;
   RCLCPP_INFO_STREAM(this->get_logger(), C_MODE << pretty_print_mode(drive_mode_) << C_END);
+
+  send_drive_info();
 }
 
 void TeleopDriveJoy::print_controls()
@@ -373,6 +399,37 @@ void TeleopDriveJoy::print_controls()
   // clang-format on
 }
 
+void TeleopDriveJoy::set_connected(const bool connected)
+{
+    if (connected != connected_)
+    {
+      connected_ = connected;
+      send_drive_info();
+
+      if (connected_)
+      {
+        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad " << C_SUCCESS << "connected." << C_END);
+      }
+      else
+      {
+        RCLCPP_ERROR_STREAM(this->get_logger(), C_INFO << "Gamepad " << C_FAIL << "disconnected." << C_END);
+      }
+    }
+}
+
+void TeleopDriveJoy::send_drive_info()
+{
+  drive_interfaces::msg::DriveInfo msg {};
+
+  msg.autonomous_mode = autonomous_mode_;
+  msg.connected = connected_;
+  msg.drive_mode = mode_to_drive_info(drive_mode_);
+  msg.handbrake = handbrake_pressed_;
+  msg.locked = locked_;
+  msg.multiplier = static_cast<float>(speed_);
+
+  drive_info_pub_->publish(msg);
+}
 }  // namespace teleop_drive_joy
 
 int main(int argc, char* argv[])

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
@@ -10,6 +10,10 @@ teleop_drive_joy:
     type: string
     default_value: "/cmd_vel"
     description: "Output Topic for Twist Commands"
+  drive_info_topic:
+    type: string
+    default_value: "/drive/drive_info"
+    description: "Output topic for drive teleop telemetry"
   
   # Deadzone already exists as an input parameter to the joy node (teleop.launch.py)
 

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
@@ -31,9 +31,10 @@ teleop_drive_joy:
     type: double_array
     default_value: [0.4, 0.8]
     description: >
-      Game pad rumble linearly increases from none to max as wheel effort increase in range. 
-      If less than range, game pad will not rumble. 
-      If greater than range, game pad will have maximum rumble.
+      Game pad rumble intensity increases proportionally to increases in wheel effort within rumble range. 
+      If effort is less than rumble range, game pad will not rumble. 
+      If effort is greater than rumble range, game pad will have maximum rumble.
+      Both rumble intensity and wheel effort can vary from 0 to 1.
   rumble_joints:
     type: string_array
     default_value: ["frw", "flw", "brw", "blw"]

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
@@ -23,6 +23,10 @@ teleop_drive_joy:
     default_value: "/drive/joy/set_feedback"
     description: "Output topic for game pad feedback (e.g. rumble)"
 
+  rumble_enable:
+    type: bool
+    default_value: true
+    description: "Enable controller rumbling if wheel effort is sufficiently high"
   rumble_range:
     type: double_array
     default_value: [0.4, 0.8]

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
@@ -4,7 +4,7 @@
 teleop_drive_joy:
   input_topic:
     type: string
-    default_value: "/joy"
+    default_value: "/drive/joy"
     description: "Input Topic for Joy Messages"
   output_topic:
     type: string
@@ -14,6 +14,30 @@ teleop_drive_joy:
     type: string
     default_value: "/drive/drive_info"
     description: "Output topic for drive teleop telemetry"
+  joint_states_topic:
+    type: string
+    default_value: "/drive/joint_states"
+    description: "Input topic for wheel/pivot states"
+  joy_feedback_topic:
+    type: string
+    default_value: "/drive/joy/set_feedback"
+    description: "Output topic for game pad feedback (e.g. rumble)"
+
+  rumble_range:
+    type: double_array
+    default_value: [0.4, 0.8]
+    description: >
+      Game pad rumble linearly increases from none to max as wheel effort increase in range. 
+      If less than range, game pad will not rumble. 
+      If greater than range, game pad will have maximum rumble.
+  rumble_joints:
+    type: string_array
+    default_value: ["frw", "flw", "brw", "blw"]
+    description: "Joint names used to derive wheel effort from joint states for rumble_range"
+  rumble_delay:
+    type: int
+    default_value: 0
+    description: "Duration in milliseconds before controller actually starts rumbling"
   
   # Deadzone already exists as an input parameter to the joy node (teleop.launch.py)
 
@@ -60,12 +84,6 @@ teleop_drive_joy:
     limit_angular:
       type: double
       default_value: 1.0
-      description: "A limit parameter applied on angular velocity"
-
-  pivot_drive_controller:
-    limit_angular:
-      type: double
-      default_value: 0.999
       description: "A limit parameter applied on angular velocity"
   
   axis_linear_x:

--- a/src/ros/rover/rover_description/banksia/urdf/ros2_control.xacro
+++ b/src/ros/rover/rover_description/banksia/urdf/ros2_control.xacro
@@ -42,6 +42,10 @@
                 <state_interface name="position"> 
                     <param name="initial_value">0.0</param>
                 </state_interface>
+
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 
@@ -86,6 +90,9 @@
                     <param name="initial_value">0.0</param>
                 </state_interface>
 
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 
@@ -129,6 +136,9 @@
                     <param name="initial_value">0.0</param>
                 </state_interface>
 
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 
@@ -172,6 +182,9 @@
                     <param name="initial_value">0.0</param>
                 </state_interface>
 
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 
@@ -217,6 +230,10 @@
                 <state_interface name="position">
                     <param name="inital_value">0.0</param>
                     <param name="max">1.57079632679</param>    
+                </state_interface>
+
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>
         </ros2_control>
@@ -264,6 +281,10 @@
                 <state_interface name="position">
                     <param name="initial_value">0.0</param>
                     <param name="max">1.57079632679</param>
+                </state_interface>
+
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>
         </ros2_control>
@@ -313,6 +334,10 @@
                     <param name="initial_value">0.0</param>
                     <param name="max">1.57079632679</param>
                 </state_interface>
+
+                <state_interface name="effort">
+                    <param name="initial_value">0.0</param>
+                </state_interface>
             </joint>
         </ros2_control>
 
@@ -357,6 +382,10 @@
 
                 <state_interface name="position">
                     <param name="max">1.57079632679</param>
+                    <param name="initial_value">0.0</param>
+                </state_interface>
+
+                <state_interface name="effort">
                     <param name="initial_value">0.0</param>
                 </state_interface>
             </joint>


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

Enables and fixes drive telemetry for the current state of new drive, and adds a feature where sufficiently high wheel effort (current) rumbles the game pad to warn operators and give them better situational awareness.

resolves #807 

## Changelogs

- make gui use joint state broadcaster instead of topic published by old drive
- add ackermann drive to gui
- configure joint state broadcaster to publish effort state interfaces (with addition of said interfaces to the urdf)
- make teleop drive joy publish to drive_info when teleop state is updated (including when game pad is disconnected via a timer)
- add ros__parameters (not generate parameter library) for teleop drive joy so params can be modified without rebuilding by modifying this file and passing local:=true to teleop.launch.py 
- add game pad rumble feature via joint state callback in teleop drive

## Steps to Test

Tested on rover and works; rumble is currently disabled but you can test with rumble_enable = true in teleop.yaml.

1. run drive, teleop drive (via vcan; could not get gazebo to output effort) and gui
2. report max current to front left wheel with cansend can0 411#7FFF7FFF (change 411 to 4?1 where ? is the id of the drive blcmd)
3. see changes in gui (exceeding 100% is expected, as we assume 0.45 is max, whereas effort could be reported up to 1; serves as effective "max")
4. if rumble_enable = true in teleop.yaml: controller should be rumbling