### PR TITLE
feat: Add NIR CSV button

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
@@ -1,0 +1,61 @@
+import {useNIRSiteData} from "../useNIRSiteData.ts";
+import {Button} from "@nextui-org/react";
+import {Download} from "react-feather";
+import {NIRProbeReadingType} from "../SpaceResourcesSiteType.tsx";
+import {useCallback} from "react";
+
+/**
+ * Button to download nir readings to a csv file
+ * @constructor
+ */
+export const NIRProbeCSVDownloadButton = () => {
+  const [readings, _] = useNIRSiteData();
+
+  const downloadCSV = useCallback(() => {
+    const headers = ["label", "type", "data"];
+
+    const allReadings = [
+      ...readings[NIRProbeReadingType.PD1],
+      ...readings[NIRProbeReadingType.PD2],
+    ];
+
+    const csvRows = allReadings.map(row => formatRow(row, headers));
+
+    const csvContent = [headers.join(","), ...csvRows].join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement("a");
+    link.href = url;
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[:.]/g, "-");
+    link.download = `data_${timestamp}.csv`;
+    link.click();
+  }, [readings])
+
+  return (
+    <Button
+      isIconOnly
+      variant={"light"}
+      onPressStart={downloadCSV}>
+      <Download/>
+    </Button>
+  )
+
+}
+
+// Formats the row based on the headers.
+const formatRow = (row, headers) =>
+  headers
+    .map(field => {
+      let value = row[field] ?? "";
+
+      if (typeof value === "object") {
+        value = JSON.stringify(value);
+      }
+
+      return `"${String(value).replace(/"/g, '""')}"`;
+    })
+    .join(",")

--- a/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
@@ -52,6 +52,11 @@ const formatRow = (row, headers) =>
     .map(field => {
       let value = row[field] ?? "";
 
+      // Remove "auto_" prefix from label only
+      if (field === "label" && typeof value === "string") {
+        value = value.replace(/^auto_/, "");
+      }
+
       if (typeof value === "object") {
         value = JSON.stringify(value);
       }

--- a/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
@@ -31,7 +31,7 @@ export const NIRProbeCSVDownloadButton = () => {
     const timestamp = new Date()
       .toISOString()
       .replace(/[:.]/g, "-");
-    link.download = `data_${timestamp}.csv`;
+    link.download = `nir-probe-data_${timestamp}.csv`;
     link.click();
   }, [readings])
 

--- a/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeCSVDownloadButton.tsx
@@ -1,7 +1,7 @@
 import {useNIRSiteData} from "../useNIRSiteData.ts";
 import {Button} from "@nextui-org/react";
 import {Download} from "react-feather";
-import {NIRProbeReadingType} from "../SpaceResourcesSiteType.tsx";
+import {ISpaceResourcesEntry, NIRProbeReadingType} from "../SpaceResourcesSiteType.tsx";
 import {useCallback} from "react";
 
 /**
@@ -47,10 +47,10 @@ export const NIRProbeCSVDownloadButton = () => {
 }
 
 // Formats the row based on the headers.
-const formatRow = (row, headers) =>
+const formatRow = (row: ISpaceResourcesEntry, headers: string[]) =>
   headers
     .map(field => {
-      let value = row[field] ?? "";
+      let value = row[field as keyof ISpaceResourcesEntry] ?? "";
 
       // Remove "auto_" prefix from label only
       if (field === "label" && typeof value === "string") {

--- a/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeFileTableWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/NIRProbe/NIRProbeFileTable/NIRProbeFileTableWidget.tsx
@@ -10,6 +10,7 @@ import NIRProbeFileTable from "./NIRProbeFileTable.tsx";
 import {MoreHorizontal} from "react-feather";
 import {NIRSettingsModalProps} from "./NIRCalibrationSettingsModal.tsx";
 import {NIRProbeReadingTypeInfo} from "../SpaceResourcesSiteType.tsx";
+import {NIRProbeCSVDownloadButton} from "./NIRProbeCSVDownloadButton.tsx";
 
 export interface NIRProbeFileTableWidgetProps extends CardProps {
   Modal?: React.FC<NIRSettingsModalProps>
@@ -32,8 +33,9 @@ const NIRProbeFileTableWidget: React.FC<NIRProbeFileTableWidgetProps> = ({
 
   return (
     <Card {...cardProps}>
-      <CardHeader className="pb-0 flex flex-row justify-center">
+      <CardHeader className="pb-0 flex flex-row justify-center gap-3">
         <div className="grow">NIR Probe File Table</div>
+        <NIRProbeCSVDownloadButton/>
         {Modal &&
           <Button
             variant={"light"}


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Adds a button to the nir proble file widget to be able to save the saved readings to a csv file which will hopefully allow science to be able to use this data with their calibration and analysis.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->
- Added a new `NIRProbeCSVDownloadButton` component.

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->
<img width="1872" height="1063" alt="Screenshot From 2026-02-26 17-48-26" src="https://github.com/user-attachments/assets/58db6022-6518-47b4-a99a-82110fed837d" />


<img width="1066" height="165" alt="image" src="https://github.com/user-attachments/assets/577112d9-2eae-4dd4-b4c6-c85a3ce89345" />


## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

Open the gui, add some nir data and try to save it.

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<img width="800" height="450" alt="image" src="https://github.com/user-attachments/assets/270e8db2-bd7c-4d59-bcba-6d05dac5166d" />
