### PR TITLE
Fix/can sleuth usability

### DIFF
--- a/nixfiles/doc/rover-help.md
+++ b/nixfiles/doc/rover-help.md
@@ -150,6 +150,31 @@ Put the .mbtiles in ~/maps. Then run:
 
 ---------------------------
 
+# Tracing CAN bus
+
+## Using can sleuth
+
+examples: `can_sleuth taipan` `can_sleuth drive`
+
+Run it without specifying a payload to see usage instructions.
+
+You can also run it from a build:
+
+`~/Builds/master/bin/can_sleuth`
+
+If you do `can_sleuth -e taipan` it will emulate the payload
+and send fake telemetry messages. You probably only want this
+on vcan.
+
+## Using can viewer:
+
+`can_viewer can0`
+
+or `~/Builds/master/bin/can_viewer -i socketcan -c can0`
+
+
+---------------------------
+
 # Launch Scripts [WIP]
 
 There are WIP launch scripts under nixfiles/modules/home/macros/launch which when the system is built can be run by calling them from the build/launch directory

--- a/nixfiles/doc/rover-help.md
+++ b/nixfiles/doc/rover-help.md
@@ -15,7 +15,10 @@ N2: ssh nova@10.0.2.12
 N3: ssh nova@10.0.2.13
 
 Radios (Jetson): ssh nvidia@10.0.0.10
-Radios (Orin): ssh nova@10.0.0.11
+Radios (Orin SSD1): ssh nova@10.0.0.11
+Radios (Orin SSD2): ssh nova@10.0.0.12
+
+The orin SSDs have printed labels on them with their IP address.
 
 ---------------------------
 

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -197,6 +197,14 @@ in
           ducket-neg = "cansend can0 0C1#9000";
           ducket = "cansend can0 0C1#7000";
           ducketn = "cansend can0 0C1#9000";
+
+          # can
+          can-sleuth = "can_sleuth";
+          can_sleuth = "~/Builds/master/bin/can_sleuth";
+
+          # use this as `can_viewer can0` for example to get "-c can0"
+          can-viewer = "can_viewer";
+          can_viewer = "~/Builds/master/bin/can_viewer -i socketcan -c";
         }
       ];
 

--- a/src/other/can_sleuth/can_sleuth/devices/candevice.py
+++ b/src/other/can_sleuth/can_sleuth/devices/candevice.py
@@ -14,6 +14,7 @@ EDITED BY: Orlando Chamberlain
 
 import jcan
 from typing import List
+import struct
 
 from . import device
 
@@ -88,9 +89,12 @@ class CanDevice(device.Device):
             position = 0
             for field in self._fields:
                 length = field.getByteLength()
-                field.updateBytesValue(
-                        bytes(frame.data[position:position+length])
-                    )
+                try:
+                    field.updateBytesValue(
+                            bytes(frame.data[position:position+length])
+                        )
+                except struct.error:
+                    pass # message didn't have all the data :/ maybe old firmware?
                 position += length
 
     def addCallback(self, canId, callback):

--- a/src/other/can_sleuth/can_sleuth/devices/device.py
+++ b/src/other/can_sleuth/can_sleuth/devices/device.py
@@ -57,6 +57,7 @@ class Device(abc.ABC):
         height: int = 1
         units: str = ""
         priority: Priority = Priority.INFO # can change at runtime
+        lastUpdated: float = 0
 
         @property
         def value(self):
@@ -67,6 +68,7 @@ class Device(abc.ABC):
         @value.setter
         def value(self, value):
             self._value = value
+            self.lastUpdated = time.time()
 
         @property
         def raw(self):
@@ -94,9 +96,8 @@ class Device(abc.ABC):
 
             self._byteLength = struct.calcsize(self._bytesFmt)
 
-            self.updateBytesValue(bytes(self._byteLength)) # all zeros
+            _, exampleOutput = self.formatBytesValue(bytes(self._byteLength)) # all zeros
 
-            exampleOutput = self._getValue()
             if isinstance(exampleOutput, str):
                 outputHeight = 1
                 outputWidth = len(exampleOutput)
@@ -107,34 +108,36 @@ class Device(abc.ABC):
             self._bytesValue: bytes = None
             self._unpackedValue: int = None
 
-            super().__init__(name, self._getValue, outputWidth, self._getRaw, outputHeight, units)
+            super().__init__(name, "", outputWidth, "", outputHeight, units)
+
+        def formatBytesValue(self, bytesValue: bytes):
+            """update the binary (bytes) representation of this attribute
+            """
+
+            raw = "0x"+bytesValue.hex()
+
+            val = struct.unpack(self._bytesFmt, bytesValue)
+            if len(val) == 1:
+                val = val[0]
+            else:
+                val = val
+                
+
+            if self._toHumanReadable is None:
+                value = raw
+            else: 
+                value = self._toHumanReadable(val)
+            return raw, value
 
         def updateBytesValue(self, bytesValue: bytes):
             """update the binary (bytes) representation of this attribute
             """
             self._bytesValue = bytesValue
-            val = struct.unpack(self._bytesFmt, self._bytesValue)
-            if len(val) == 1:
-                self._unpackedValue = val[0]
-            else:
-                self._unpackedValue = val
-                
+            self.raw, self.value = self.formatBytesValue(bytesValue)
 
         def getByteLength(self):
             # Check how many bytes this attribute uses.
             return self._byteLength
-
-        def _getRaw(self):
-            if self._bytesValue is None:
-                return ""
-            return "0x"+self._bytesValue.hex()
-
-        def _getValue(self):
-            if self._unpackedValue is None:
-                return ""
-            if self._toHumanReadable is None:
-                return self._getRaw()
-            return self._toHumanReadable(self._unpackedValue)
 
     def getName(self):
         return self.name

--- a/src/other/can_sleuth/can_sleuth/outputs/__init__.py
+++ b/src/other/can_sleuth/can_sleuth/outputs/__init__.py
@@ -16,11 +16,7 @@ from . import gui
 from . import terminal_out
 
 def default_output():
-    try:
-        return gui.GUI()
-    except RuntimeError:
-        print("Graphical output not availible, defaulting to terminal output.")
-        return tui.TUI()
+    return tui.TUI()
 
 # List of everything for help message:
 allOutputs = {

--- a/src/other/can_sleuth/can_sleuth/outputs/tui.py
+++ b/src/other/can_sleuth/can_sleuth/outputs/tui.py
@@ -12,6 +12,7 @@ EDITED BY: Orlando Chamberlain, Will Middlewick
 ''' 
 
 import curses
+import time
 
 from . import output
 
@@ -90,6 +91,12 @@ class TUI(output.Output):
                 height = 1
                 encoder_err = False
                 for attr in dev.attrs:
+                    # make attr values that are old dim
+                    age = time.time() - attr.lastUpdated
+                    if age > 0.2: #TODO: paramaterise this value
+                        value_style = curses.A_DIM
+                    else:
+                        value_style = base_style
 
                     label = f"{attr.name}: "
 
@@ -106,7 +113,7 @@ class TUI(output.Output):
                             1 + len(label), # x pos
                             lines[y] + " " * max_x, # text
                             max_x - 2 - len(label), # max chars to print
-                            self._colours.get(attr.priority, curses.A_NORMAL) | base_style
+                            self._colours.get(attr.priority, curses.A_NORMAL) | value_style
                         )
 
                     height += attr.height


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
- make tui default
- don't die if messages with wrong length are received
- make values dim if they are old
- add aliases and doc in rover-help


<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->
can start vcan1
./result/bin/can_sleuth -e taipan

# simulate resolver error:
cansend can1 410#0002


it should go dim after a second so you know the error is gone.

# message with unexpected length:
cansend can1 414#00000000

should not crash
<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
