### PR TITLE
fix: make game pad rumble much less sensitive

### DIFF
--- a/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/params/teleop.yaml
@@ -10,9 +10,8 @@ teleop_drive_joy_node:
     # rumble is currently updated every 50ms (period that drive joint states is published at),
     # so rumble_delay is actually ceiling(rumble_delay / 50) * 50
     rumble_delay: 110
-    rumble_joints: [ frw, flw, brw, blw,
-                     frp, flp, brp, blp ]
-    rumble_range: [ 0.075, 0.2 ]
+    rumble_joints: [ frw, flw, brw, blw ]
+    rumble_range: [ 0.15, 0.45 ]
 
     speed_limit_max: 1.0
     speed_limit_min: 0.05


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

Urgent change to stop game pad from constantly rumbling (which is extremely distracting and makes drive much more difficult to operate).