### PR TITLE
fix: driving after comms

### DIFF
--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
@@ -211,7 +211,7 @@ private:
   // Timeout to consider cmd_vel commands old
   rclcpp::Duration cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(0.5);
   rclcpp::Duration cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(0.5);
-  rclcpp::Time last_commanded_time_;
+  rclcpp::Time last_received_time_;
 
   // Subscriber and realtime buffer for received TwistStamped messages
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_subscriber_;

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
@@ -209,7 +209,9 @@ private:
   std::unique_ptr<Odometry> odometry_;
 
   // Timeout to consider cmd_vel commands old
-  rclcpp::Duration cmd_vel_timeout_ = rclcpp::Duration::from_seconds(0.5);
+  rclcpp::Duration cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(0.5);
+  rclcpp::Duration cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(0.5);
+  rclcpp::Time last_commanded_time_;
 
   // Subscriber and realtime buffer for received TwistStamped messages
   rclcpp::Subscription<geometry_msgs::msg::TwistStamped>::SharedPtr twist_subscriber_;

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -169,12 +169,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
   // ####################### Process input ###############################
   Commands cmds;
 
-  if (last_commanded_time_.nanoseconds() == 0)
-  {
-    last_commanded_time_ = get_node()->now();
-  }
-  
-  const auto age_of_last_command = time - last_commanded_time_;
+  const auto age_of_last_command = time - last_received_time_;
   if (age_of_last_command > cmd_vel_command_timeout_)
   {
     cmds.linear_velocity_x = 0.0;
@@ -188,7 +183,6 @@ controller_interface::return_type NovaDriveControllerBase::update(
   else
   {
     cmds = twist_to_commands(command_msg_ptr->twist, base_params_->autonomous_mode, period);
-    last_commanded_time_ = get_node()->now();
   }
 
   // ################### Update and publish odometry #####################
@@ -425,6 +419,8 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
           rclcpp::Time(msg->header.stamp).seconds(), current_time_diff.seconds(),
           cmd_vel_receive_timeout_.seconds());
       }
+
+      last_received_time_ = get_node()->now();
     });
 
   return controller_interface::CallbackReturn::SUCCESS;

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -161,7 +161,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
             std::isnan(command_msg_ptr->twist.angular.z)))
   {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
-      logger, *get_node()->get_clock(), cmd_vel_timeout_.seconds() * 1000,
+      logger, *get_node()->get_clock(), cmd_vel_receive_timeout_.seconds() * 1000,
       "Command message contains NaNs. Not updating reference interfaces.");
     return controller_interface::return_type::OK;
   }
@@ -169,8 +169,13 @@ controller_interface::return_type NovaDriveControllerBase::update(
   // ####################### Process input ###############################
   Commands cmds;
 
-  const auto age_of_last_command = time - command_msg_ptr->header.stamp;
-  if (age_of_last_command > cmd_vel_timeout_)
+  if (last_commanded_time_.nanoseconds() == 0)
+  {
+    last_commanded_time_ = get_node()->now();
+  }
+  
+  const auto age_of_last_command = time - last_commanded_time_;
+  if (age_of_last_command > cmd_vel_command_timeout_)
   {
     cmds.linear_velocity_x = 0.0;
     cmds.linear_velocity_y = 0.0;
@@ -307,6 +312,8 @@ controller_interface::return_type NovaDriveControllerBase::update(
     commanded_twist_command.twist.angular.z = cmds.angular_velocity;
     realtime_commanded_twist_publisher_->unlockAndPublish();
   }
+  
+  last_commanded_time_ = get_node()->now();
 
   return controller_interface::return_type::OK;
 }
@@ -346,7 +353,8 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  cmd_vel_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_timeout);
+  cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_receive_timeout);
+  cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_receive_timeout);
 
   limiter_drive_ = SpeedLimiter(
     base_params_->drive.has_velocity_limits, base_params_->drive.has_acceleration_limits,
@@ -404,8 +412,8 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
       const auto current_time_diff = get_node()->now() - msg->header.stamp;
 
       if (
-        cmd_vel_timeout_ == rclcpp::Duration::from_seconds(0.0) ||
-        current_time_diff < cmd_vel_timeout_)
+        cmd_vel_receive_timeout_ == rclcpp::Duration::from_seconds(0.0) ||
+        current_time_diff < cmd_vel_receive_timeout_)
       {
         received_twist_msg_ptr_.writeFromNonRT(msg);
       }
@@ -416,7 +424,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
           "Ignoring the received message (timestamp %.10f) because it is older than "
           "the current time by %.10f seconds, which exceeds the allowed timeout (%.4f)",
           rclcpp::Time(msg->header.stamp).seconds(), current_time_diff.seconds(),
-          cmd_vel_timeout_.seconds());
+          cmd_vel_receive_timeout_.seconds());
       }
     });
 

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -97,6 +97,8 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_init()
   // Initialise odometry
   odometry_ = std::make_unique<Odometry>(get_node(), base_params_);
 
+  last_received_time_ = rclcpp::Time(0, 0, get_node()->get_clock()->get_clock_type());
+
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -347,7 +349,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
   }
 
   cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_receive_timeout);
-  cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_receive_timeout);
+  cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_command_timeout);
 
   limiter_drive_ = SpeedLimiter(
     base_params_->drive.has_velocity_limits, base_params_->drive.has_acceleration_limits,
@@ -409,6 +411,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
         current_time_diff < cmd_vel_receive_timeout_)
       {
         received_twist_msg_ptr_.writeFromNonRT(msg);
+        last_received_time_ = get_node()->now();
       }
       else
       {
@@ -419,8 +422,6 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
           rclcpp::Time(msg->header.stamp).seconds(), current_time_diff.seconds(),
           cmd_vel_receive_timeout_.seconds());
       }
-
-      last_received_time_ = get_node()->now();
     });
 
   return controller_interface::CallbackReturn::SUCCESS;

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -188,6 +188,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
   else
   {
     cmds = twist_to_commands(command_msg_ptr->twist, base_params_->autonomous_mode, period);
+    last_commanded_time_ = get_node()->now();
   }
 
   // ################### Update and publish odometry #####################
@@ -313,8 +314,6 @@ controller_interface::return_type NovaDriveControllerBase::update(
     realtime_commanded_twist_publisher_->unlockAndPublish();
   }
   
-  last_commanded_time_ = get_node()->now();
-
   return controller_interface::return_type::OK;
 }
 

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -104,10 +104,15 @@ nova_drive_controller_base:
     default_value: true
     description: "Publish transformation between ``odom_frame_id`` and ``base_frame_id``."
 
-  cmd_vel_timeout:
+  cmd_vel_receive_timeout:
     type: double
     default_value: 999.0 # Seconds
-    description: "Timeout on cmd_vel command."
+    description: "Timeout to receive cmd_vel commands from base."
+
+  cmd_vel_command_timeout:
+    type: double
+    default_value: 0.5 # Seconds
+    description: "Timeout since last commanded velocity from cmd_vel."
 
   publish_commanded_velocities:
     type: bool


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

Thank you @tytia for doing this! (not my work). Rover should stop driving if it doesn't receive a commanded velocity after some time (e.g. if disconnected from base).


## Steps to Test

[Run drive in sim](https://www.notion.so/Drive-Operator-Guide-30bb7139617180c58dccee88003be777?source=copy_link#318b71396171809292add7b0c11bd8d6), and stop drive teleop whilst the rover is moving. It should then stop. Also, restarting teleop allows the rover to be commanded again.
