### PR TITLE
feat: Add locked publisher

### DIFF
--- a/nixfiles/packages/ros/nova-workspace/default.nix
+++ b/nixfiles/packages/ros/nova-workspace/default.nix
@@ -77,6 +77,7 @@
 , nova-science-interfaces ? throw "nova-science-interfaces is needed, but not available!"
 , nova-science-bringup ? throw "nova-science-bringup is needed, but not available!"
 , nova-arm-kinematics ? throw "nova-arm-kinematics is needed, but not available!"
+, nova-locked-publisher
 
 , nova-cameras
 , nova-camera-msgs
@@ -147,6 +148,7 @@
       nova-arm-kinematics
       nova-cameras
       nova-camera-msgs
+      nova-locked-publisher
       ;
     nova-can-sleuth = pythonPackages.nova-can-sleuth;
   }

--- a/src/ros/rover/nova_interfaces/CMakeLists.txt
+++ b/src/ros/rover/nova_interfaces/CMakeLists.txt
@@ -18,6 +18,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/DriveInfo.msg"
   "msg/DriveInput.msg"
   "msg/DriveInputStamped.msg"
+  "msg/LockedStatus.msg"
   "msg/RadioStatus.msg"
   "msg/RoverPoseGPS.msg"
   "msg/Status.msg"

--- a/src/ros/rover/nova_interfaces/msg/LockedStatus.msg
+++ b/src/ros/rover/nova_interfaces/msg/LockedStatus.msg
@@ -1,0 +1,4 @@
+# Reports the locked status of a teleop modular system.
+
+std_msgs/Header header
+bool locked

--- a/src/ros/rover/science/default.nix
+++ b/src/ros/rover/science/default.nix
@@ -6,6 +6,7 @@ with pkgs;
   nova-science = callPackage ./science { };
   nova-science-bringup = callPackage ./science_bringup { };
   nova-legacy-input-mode = callPackage ./science_control_modes/legacy_input_mode { };
+  nova-locked-publisher = callPackage ./science_control_modes/locked_publisher { };
   nova-science-interfaces = callPackage ./science_interfaces { };
   nova-teleop-science = callPackage ./teleop_science { };
 }

--- a/src/ros/rover/science/science_control_modes/locked_publisher/CMakeLists.txt
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/CMakeLists.txt
@@ -1,0 +1,81 @@
+cmake_minimum_required(VERSION 3.8)
+project(locked_publisher)
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  rclcpp
+  rclcpp_lifecycle
+  pluginlib
+  control_mode
+  nova_interfaces
+)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+include_directories(
+  include
+)
+
+# -- Libraries
+
+add_library(${PROJECT_NAME}
+  src/locked_publisher.cpp
+)
+
+add_library(locked_publisher::locked_publisher ALIAS locked_publisher)
+target_compile_features(locked_publisher PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_include_directories(locked_publisher PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+
+ament_target_dependencies(${PROJECT_NAME} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "LOCKED_PUBLISHER_BUILDING_LIBRARY")
+
+pluginlib_export_plugin_description_file(teleop_modular plugins.xml)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+if(BUILD_TESTING)
+  # find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  # set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  # set(ament_cmake_cpplint_FOUND TRUE)
+  # ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_include_directories(
+  "include/${PROJECT_NAME}"
+)
+ament_export_libraries(
+  locked_publisher
+)
+ament_export_targets(
+  export_${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/ros/rover/science/science_control_modes/locked_publisher/README.md
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/README.md
@@ -1,0 +1,34 @@
+# locked_publisher/LockedPublisher
+
+Control Mode that publishes the locked status of Teleop Modular.
+
+Publishes [teleop_msgs/LockedStatus](../../teleop_msgs/msg/LockedStatus.msg) messages.
+
+Created using [control_mode_template](https://github.com/BaileyChessum/control_mode_template).
+
+### Parameters
+
+*TODO: Describe your parameters here*
+
+- `topic : string` The topic name to send messages to (Required)
+- `qos : int` The ROS2 topic Quality of Service value to use in the publisher (Optional, defaults to 10) 
+
+```yaml
+# Example parameter file
+teleop_node:
+  ros__parameters:
+    control_modes:
+      names: [ "locked_publisher" ]
+      locked_publisher:
+        type: "locked_publisher/LockedPublisher"
+
+locked_publisher:
+  ros__parameters:
+    # Topic to send messages to (Required)
+    topic: "/turtle1/cmd_vel"
+    
+    # The ROS2 topic Quality of Service value to use in the publisher (Optional, defaults to 1, reliable)
+    qos:
+      depth: 1
+      reliable: false   #< do this to use best_effort
+```

--- a/src/ros/rover/science/science_control_modes/locked_publisher/README.md
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/README.md
@@ -2,7 +2,7 @@
 
 Control Mode that publishes the locked status of Teleop Modular.
 
-Publishes [teleop_msgs/LockedStatus](../../teleop_msgs/msg/LockedStatus.msg) messages.
+Publishes [nova_interfaces/msg/LockedStatus](../../../nova_interfaces/msg/LockedStatus.msg) messages.
 
 Created using [control_mode_template](https://github.com/BaileyChessum/control_mode_template).
 

--- a/src/ros/rover/science/science_control_modes/locked_publisher/default.nix
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/default.nix
@@ -1,0 +1,49 @@
+# You only need to use this file if you use nix to build your packages.
+# If you don't, feel free to delete this.
+
+{ lib
+, pkg-config
+, buildRosPackage
+, ament-cmake
+, ament-cmake-gtest
+, ament-lint-auto
+, gtest
+, rclcpp
+, pluginlib
+, teleop-modular-control-mode
+, nova-interfaces
+, rclcpp-lifecycle
+}:
+
+buildRosPackage {
+  name = "locked-publisher";
+  buildType = "ament_cmake";
+
+  src = builtins.path rec {
+    name = "locked-publisher-source";
+    path = ./.;
+  };
+
+  nativeBuildInputs = [
+    ament-cmake
+    pkg-config
+    ament-cmake-gtest
+    ament-lint-auto
+    gtest
+  ];
+
+  buildInputs = [
+    rclcpp
+    rclcpp-lifecycle
+    pluginlib
+    teleop-modular-control-mode
+  ];
+
+  propagatedBuildInputs = [
+    # Add message packages here
+     nova-interfaces
+  ];
+
+  # Enable running tests during build?
+  # doCheck = true;
+}

--- a/src/ros/rover/science/science_control_modes/locked_publisher/include/locked_publisher/locked_publisher.hpp
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/include/locked_publisher/locked_publisher.hpp
@@ -1,0 +1,66 @@
+#ifndef LOCKED_PUBLISHER__LOCKED_PUBLISHER_HPP_
+#define LOCKED_PUBLISHER__LOCKED_PUBLISHER_HPP_
+
+#include <rclcpp/time.hpp>
+#include <string>
+#include "control_mode/control_mode.hpp"
+#include "locked_publisher/visibility_control.h"
+#include "nova_interfaces/msg/locked_status.hpp"
+
+namespace locked_publisher
+{
+
+using namespace control_mode;
+
+/**
+ * Control Mode that publishes the locked status of Teleop Modular.
+ */
+class LOCKED_PUBLISHER_PUBLIC LockedPublisher : public ControlMode
+{
+public:
+  LockedPublisher();
+
+  return_type on_init() override;
+  CallbackReturn on_configure(const State & previous_state) override;
+  void on_configure_inputs(Inputs inputs) override;
+
+  /**
+   * \brief Publishes a message to tell the control system to do nothing. Used when the control mode is locked, and
+   * called once when deactivated.
+   *
+   * \param[in] now The time to associate with the 'halt' message.
+   */
+  void publish_halt_message(const rclcpp::Time & now) const;
+
+  CallbackReturn on_activate(const State & previous_state) override;
+  return_type on_update(const rclcpp::Time & now, const rclcpp::Duration & period) override;
+
+  CallbackReturn on_deactivate(const State & previous_state) override;
+  CallbackReturn on_cleanup(const State & previous_state) override;
+  CallbackReturn on_error(const State & previous_state) override;
+  CallbackReturn on_shutdown(const State & previous_state) override;
+
+protected:
+  ~LockedPublisher() override;
+
+private:
+  /// Helper struct to hold parameters used by the control mode.
+  struct Params {
+    /// The topic name to send messages to.
+    std::string topic = "";
+
+    /// The ROS2 topic Quality of Service depth value to use in publisher_.
+    int qos_depth = 1;
+    /// The ROS2 topic Quality of Service's reliability to use in publisher_. Uses 'reliable' when true.
+    bool qos_reliable = false;
+  };
+
+  /// Stores current parameter values
+  Params params_;
+
+  rclcpp::Publisher<nova_interfaces::msg::LockedStatus>::SharedPtr publisher_;
+};
+
+}  // namespace locked_publisher
+
+#endif  // LOCKED_PUBLISHER__LOCKED_PUBLISHER_HPP_

--- a/src/ros/rover/science/science_control_modes/locked_publisher/include/locked_publisher/visibility_control.h
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/include/locked_publisher/visibility_control.h
@@ -1,0 +1,35 @@
+#ifndef LOCKED_PUBLISHER__VISIBILITY_CONTROL_H_
+#define LOCKED_PUBLISHER__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define LOCKED_PUBLISHER_EXPORT __attribute__ ((dllexport))
+    #define LOCKED_PUBLISHER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define LOCKED_PUBLISHER_EXPORT __declspec(dllexport)
+    #define LOCKED_PUBLISHER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef LOCKED_PUBLISHER_BUILDING_LIBRARY
+    #define LOCKED_PUBLISHER_PUBLIC LOCKED_PUBLISHER_EXPORT
+  #else
+    #define LOCKED_PUBLISHER_PUBLIC LOCKED_PUBLISHER_IMPORT
+  #endif
+  #define LOCKED_PUBLISHER_PUBLIC_TYPE LOCKED_PUBLISHER_PUBLIC
+  #define LOCKED_PUBLISHER_LOCAL
+#else
+  #define LOCKED_PUBLISHER_EXPORT __attribute__ ((visibility("default")))
+  #define LOCKED_PUBLISHER_IMPORT
+  #if __GNUC__ >= 4
+    #define LOCKED_PUBLISHER_PUBLIC __attribute__ ((visibility("default")))
+    #define LOCKED_PUBLISHER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define LOCKED_PUBLISHER_PUBLIC
+    #define LOCKED_PUBLISHER_LOCAL
+  #endif
+  #define LOCKED_PUBLISHER_PUBLIC_TYPE
+#endif
+
+#endif  // LOCKED_PUBLISHER__VISIBILITY_CONTROL_H_

--- a/src/ros/rover/science/science_control_modes/locked_publisher/package.xml
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>locked_publisher</name>
+  <version>0.1.0</version>
+  <description>Control Mode that publishes the locked status of Teleop Modular.</description>
+  <maintainer email="author@example.com">Felicity Matthews</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>teleop_msgs</depend>
+
+  <build_depend>control_mode</build_depend>
+  <build_export_depend>control_mode</build_export_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros/rover/science/science_control_modes/locked_publisher/plugins.xml
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/plugins.xml
@@ -1,0 +1,6 @@
+<library path="locked_publisher">
+    <!-- Control Modes -->
+    <class name="locked_publisher/LockedPublisher" type="locked_publisher::LockedPublisher" base_class_type="control_mode::ControlMode">
+        <description>Control Mode that publishes the locked status of Teleop Modular.</description>
+    </class>
+</library>

--- a/src/ros/rover/science/science_control_modes/locked_publisher/src/locked_publisher.cpp
+++ b/src/ros/rover/science/science_control_modes/locked_publisher/src/locked_publisher.cpp
@@ -1,0 +1,130 @@
+#include "locked_publisher/locked_publisher.hpp"
+
+namespace locked_publisher
+{
+
+LockedPublisher::LockedPublisher() = default;
+
+LockedPublisher::~LockedPublisher() = default;
+
+return_type LockedPublisher::on_init()
+{
+  auto node = get_node();
+
+  // Do any initialization logic here!
+  // This effectively replaces the constructor for anything that depends on get_node()
+
+  // Declare parameters here! Or consider using something like generate_parameter_library instead.
+  node->declare_parameter<std::string>("topic", "");
+  node->declare_parameter<int>("qos.depth", 1);
+  node->declare_parameter<bool>("qos.reliable", true);  //< TODO: Check your subscribers use best_effort before making
+                                                        //        false, but its better for teleop to use best_effort
+  return return_type::OK;
+}
+
+CallbackReturn LockedPublisher::on_configure(const State &)
+{
+  auto node = get_node();
+  const auto logger = get_node()->get_logger();
+
+  // Use this callback method to get any parameters for your control mode!
+  params_ = Params();
+  node->get_parameter<std::string>("topic", params_.topic);
+  node->get_parameter<int>("qos.depth", params_.qos_depth);
+  node->get_parameter<bool>("qos.reliable", params_.qos_reliable);
+
+  // Create the publishers based on the params we just got
+  if (params_.topic.empty()) {
+    // You've probably made a mistake if the topic isn't set!
+    RCLCPP_ERROR(logger, "The \"topic\" parameter must be set to a valid topic name!");
+    return CallbackReturn::ERROR;
+  }
+
+  // Build QoS profile from params
+  rclcpp::QoS qos_profile = rclcpp::QoS(rclcpp::KeepLast(params_.qos_depth));
+  if (params_.qos_reliable)
+    qos_profile.reliable();
+  else
+    qos_profile.best_effort();
+
+  publisher_ = get_node()->create_publisher<nova_interfaces::msg::LockedStatus>(params_.topic, qos_profile);
+
+  RCLCPP_INFO(logger, "Locked Publisher configured, publishing to %s", params_.topic);
+
+  return CallbackReturn::SUCCESS;
+}
+
+void LockedPublisher::on_configure_inputs(Inputs inputs)
+{
+}
+
+CallbackReturn LockedPublisher::on_activate(const State &)
+{
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn LockedPublisher::on_deactivate(const State &)
+{
+  publish_halt_message(get_node()->now());
+  return CallbackReturn::SUCCESS;
+}
+
+void LockedPublisher::publish_halt_message(const rclcpp::Time & now) const
+{
+  // System is locked, publish locked = true message
+  auto msg = std::make_unique<nova_interfaces::msg::LockedStatus>();
+  msg->header.stamp = now;
+  msg->locked = true;
+  publisher_->publish(std::move(msg));
+}
+
+return_type LockedPublisher::on_update(const rclcpp::Time & now, const rclcpp::Duration & period)
+{
+  const auto logger = get_node()->get_logger();
+
+  // Don't move when locked
+  if (is_locked()) {
+    publish_halt_message(now);
+    return return_type::OK;
+  }
+
+ // System is unlocked, publish locked = false message
+  auto msg = std::make_unique<nova_interfaces::msg::LockedStatus>();
+  msg->header.stamp = now;
+  msg->locked = false;
+  publisher_->publish(std::move(msg));
+
+  return return_type::OK;
+}
+
+CallbackReturn LockedPublisher::on_error(const State &)
+{
+  // Called when any callback function returns CallbackReturn::ERROR
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn LockedPublisher::on_cleanup(const State &)
+{
+  // Clear all state and return the control mode to a functionally equivalent state as after on_init() was first called.
+
+  // Reset any held shared pointers
+  publisher_.reset();
+
+  params_ = Params();
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn LockedPublisher::on_shutdown(const State &)
+{
+  // Clean up anything from on_init()
+
+  return CallbackReturn::SUCCESS;
+}
+
+}  // namespace locked_publisher
+
+#include <pluginlib/class_list_macros.hpp>
+
+PLUGINLIB_EXPORT_CLASS(locked_publisher::LockedPublisher, control_mode::ControlMode);

--- a/src/ros/rover/science/teleop_science/default.nix
+++ b/src/ros/rover/science/teleop_science/default.nix
@@ -12,6 +12,7 @@
 , teleop-modular-twist
 , teleop-modular-joy
 , nova-legacy-input-mode
+, nova-locked-publisher
 }:
 
 buildRosPackage {
@@ -39,5 +40,6 @@ buildRosPackage {
     teleop-modular-twist
     teleop-modular-joy
     nova-legacy-input-mode
+    nova-locked-publisher
   ];
 }

--- a/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
+++ b/src/ros/rover/science/teleop_science/params/arc/teleop.yaml
@@ -11,13 +11,21 @@ teleop_science:
     control_modes:
       names: [
         # First in the list gets activated at startup
-        "input_publisher_mode"
+        "input_publisher_mode",
+        "locked_publisher"
       ]
 
       # Declare types for the modes
+      # Publishes input from teleop
       input_publisher_mode:
         display_name: "Input Publisher Control Mode"
         type: "input_publisher_mode/InputPublisherMode"
+        active: true
+
+      # Publishes the current locked status
+      locked_publisher:
+        display_name: "Locked Status Publisher"
+        type: "locked_publisher/LockedPublisher"
         active: true
 
     # Add lock and unlock commands
@@ -48,6 +56,10 @@ teleop_science:
         on: "locked/up"
         type: log
         message: "Unlocked"
+
+locked_publisher:
+  ros__parameters:
+    topic: "/science/locked"
 
 input_publisher_mode:
   ros__parameters:


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

A very simple teleop control mode that publishes whether or not the teleop system is locked or not.

This is a quick way of implementing:
https://github.com/BaileyChessum/teleop_modular/pull/60

Since I think it is too close to comp now to be messing with teleop.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Added a new `LockedPublisher` control mode
- Added it to `teleop_science` so that it publishes the locked status.

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

<img width="1656" height="879" alt="image" src="https://github.com/user-attachments/assets/1e5896ba-0cb0-4859-8882-0d8cec0acbb1" />

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

1. build the workspace
2. run teleop science `ros2 launch teleop_science teleop.launch.py`
3. echo the topic `ros2 topic echo /science/locked`

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
<img width="1357" height="758" alt="image" src="https://github.com/user-attachments/assets/7e019d18-a330-41c5-ae6f-ad1e6a08cca1" />
