### PR TITLE
[low priority] blcmd_status_monitor for taipan

### DIFF
--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -97,6 +97,11 @@ def launch_setup(context, *args, **kwargs):
                     arguments=['nova_end_effector_velocity_controller', '--inactive', "-c", "/arm/controller_manager"],
                     additional_env=show_colours_additional_env,
                 ),
+            ]
+        ),
+        GroupAction(
+            condition=UnlessCondition(use_mock_hardware),
+            actions=[
                 IncludeLaunchDescription(
                     launch_description_source=PythonLaunchDescriptionSource(
                         PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
@@ -110,6 +115,18 @@ def launch_setup(context, *args, **kwargs):
                         ),
                         "log_name" : "arm",
                     }.items()
+                ),
+                Node(
+                    package='blcmd_utils',
+                    executable='status_monitor',
+                    output='screen',
+                    parameters=[{
+                        "prefix": "/arm/blcmds",
+                        "num_blcmds": 6,
+                        "canbus": "can1"
+                        }],
+                    emulate_tty=True,
+                    ros_arguments=['--log-level', log_level],
                 ),
             ]
         ),

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -33,14 +33,16 @@ class BLCMDStatusMonitor(Node):
 
     def __init__(self):
         super().__init__("blcmd_status_monitor")
-        #publisher to publish the status of the blcmd
-        self.publisher = self.create_publisher(BLCMDStatusArray, "/blcmds/blcmd_status", 10)
-        #service to reset the blcmd
-        self.reset_service = self.create_service(BLCMDReset, "/blcmds/blcmd_reset", self.reset)
 
         #declare parameters
+        self.declare_parameter("prefix", "/blcmds")
         self.declare_parameter("num_blcmds", 8)
         self.declare_parameter("canbus", "can0")
+
+        #publisher to publish the status of the blcmd
+        self.publisher = self.create_publisher(BLCMDStatusArray, self.get_parameter("prefix").value+"/blcmd_status", 10)
+        #service to reset the blcmd
+        self.reset_service = self.create_service(BLCMDReset, self.get_parameter("prefix").value+"/blcmd_reset", self.reset)
 
         #initialise blcmd status array and fault times dict
         self.blcmds_status = []
@@ -93,7 +95,7 @@ class BLCMDStatusMonitor(Node):
                 self.get_logger().info(f'Reset resolver on BLCMD {req.id}')
             res.success = True
         except :
-            self.get_logger.error('BLCMD Reset or Resolver Reset Failed');
+            self.get_logger().error('BLCMD Reset or Resolver Reset Failed');
             res.success = False
         return res
 


### PR DESCRIPTION
it is set up so it publishes to a /arm/blcmds/xxxxx for arm and the /blcmds/xx for drive (same as previous). the gui only uses the drive one, it didn't look trivial to make a second copy of the widget in the navbar to do arm so I haven't looked into it much.

add it to control.launch.py in arm_bringup when not using mock hardware also move the can launch stuff to only be when not using mock hardware

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
