### PR TITLE
remove conflicting v4l-utils with cameras2++ default.nix

### DIFF
--- a/nixfiles/modules/home/nova/default.nix
+++ b/nixfiles/modules/home/nova/default.nix
@@ -115,7 +115,6 @@ in
         cloudcompare
         usbutils
         gpsd
-        v4l-utils
         can-utils
         btop
         nix-output-monitor


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
The one in home manager conflicts with the one in cameras2++'s default.nix.


<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
