### PR TITLE
Feat/remove nearby in collision goals

### DIFF
--- a/src/ros/rover/auto/auto_bringup/params/nav2_arch/bt_navigator.yaml
+++ b/src/ros/rover/auto/auto_bringup/params/nav2_arch/bt_navigator.yaml
@@ -17,10 +17,10 @@ bt_navigator:
     default_nav_to_pose_bt_xml: /home/nova/nova/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_to_pose.xml
     navigate_through_poses:
       plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
-    default_nav_through_poses_bt_xml: /home/nova/nova/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses.xml
+    default_nav_through_poses_bt_xml: /home/nova/nova/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses_remove_nearby_collision_goals.xml
     plugin_lib_names:
       - nova_blackboard_publisher_bt_node
-      - nova_snap_in_collision_goals_action_bt_node
+      - nova_remove_nearby_in_collision_goals_action_bt_node
 
 bt_navigator_navigate_through_poses_rclcpp_node:
   ros__parameters:

--- a/src/ros/rover/auto/nova_behavior_tree/CMakeLists.txt
+++ b/src/ros/rover/auto/nova_behavior_tree/CMakeLists.txt
@@ -79,6 +79,9 @@ list(APPEND plugin_libs nova_update_urc_goals_action_bt_node)
 add_library(nova_snap_in_collision_goals_action_bt_node SHARED plugins/action/snap_in_collision_goals_action.cpp)
 list(APPEND plugin_libs nova_snap_in_collision_goals_action_bt_node)
 
+add_library(nova_remove_nearby_in_collision_goals_action_bt_node SHARED plugins/action/remove_nearby_in_collision_goals_action.cpp)
+list(APPEND plugin_libs nova_remove_nearby_in_collision_goals_action_bt_node)
+
 # ========================================= CONDITION NODES ========================================= #
 
 add_library(nova_ar_tag_detected_condition_bt_node SHARED plugins/condition/ar_tag_detected_condition.cpp)

--- a/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses_remove_nearby_collision_goals.xml
+++ b/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses_remove_nearby_collision_goals.xml
@@ -6,7 +6,7 @@
         <RateController hz="1.0">
           <Sequence name="ComputeAndSmoothPathThroughPoses">
             <ReactiveSequence>
-              <RemoveNearbyInCollisionGoals input_goals="{goals}" max_distance_threshold="3" global_frame="map" robot_base_frame="base_link" cost_threshold="99.0" output_goals="{goals}"/>
+              <RemoveNearbyInCollisionGoals input_goals="{goals}" max_distance_threshold="5" global_frame="map" robot_base_frame="base_link" cost_threshold="99.0" output_goals="{goals}"/>
               <RemovePassedGoals input_goals="{goals}" output_goals="{goals}" radius="1.0"/>
               <ComputePathThroughPoses goals="{goals}" path="{path}" planner_id="GridBased"/>
             </ReactiveSequence>

--- a/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses_remove_nearby_collision_goals.xml
+++ b/src/ros/rover/auto/nova_behavior_tree/behavior_tree/arch/nav_through_poses_remove_nearby_collision_goals.xml
@@ -1,0 +1,27 @@
+<root BTCPP_format="4" main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <BlackboardPublisher topic_name="blackboard" keys="goals" publish_frequency="1"/>
+        <RateController hz="1.0">
+          <Sequence name="ComputeAndSmoothPathThroughPoses">
+            <ReactiveSequence>
+              <RemoveNearbyInCollisionGoals input_goals="{goals}" max_distance_threshold="3" global_frame="map" robot_base_frame="base_link" cost_threshold="99.0" output_goals="{goals}"/>
+              <RemovePassedGoals input_goals="{goals}" output_goals="{goals}" radius="1.0"/>
+              <ComputePathThroughPoses goals="{goals}" path="{path}" planner_id="GridBased"/>
+            </ReactiveSequence>
+            <SmoothPath unsmoothed_path="{path}" smoothed_path="{path}" smoother_id="savitzky_golay_smoother"/>
+          </Sequence>
+        </RateController>
+        <FollowPath path="{path}" controller_id="RotationShimMPPI" goal_checker_id="goal_checker" progress_checker_id="progress_checker"/>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <Sequence name="ClearingActions">
+          <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+          <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+        </Sequence>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/src/ros/rover/auto/nova_behavior_tree/bt_nodes.xml
+++ b/src/ros/rover/auto/nova_behavior_tree/bt_nodes.xml
@@ -42,6 +42,15 @@
       <output_port name="output_goals">Goals with all in collision goals snapped</output_port>
     </Action>
 
+    <Action ID="RemoveNearbyInCollisionGoals">
+      <input_port name="input_goals">A vector of goals to check if in collision</input_port>
+      <input_port name="max_distance_threshold">Maximum distance (m) within which to consider goals for removal</input_port>
+      <input_port name="cost_threshold">Cost threshold for considering a goal in collision</input_port>
+      <input_port name="global_frame">Global frame</input_port>
+      <input_port name="robot_base_frame">Robot base frame</input_port>
+      <output_port name="output_goals">A vector of goals containing only those that are not in collision.</output_port>
+    </Action>
+
     <Action ID="SaveCubePoses">
       <input_port name="cube_poses">List of cube poses</input_port>
       <input_port name="file_path">File to save cube poses to</input_port>

--- a/src/ros/rover/auto/nova_behavior_tree/include/nova_behavior_tree/action/remove_nearby_in_collision_goals_action.hpp
+++ b/src/ros/rover/auto/nova_behavior_tree/include/nova_behavior_tree/action/remove_nearby_in_collision_goals_action.hpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 Nova Rover
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @brief Action node for removing nearby goals that are in collision
+ * Only goals within a certain distance of the rover will be considered for removal, all goals outside of the
+ * specified distance will be kept. This is to avoid removing goals inside obstacles that are very far away, as
+ * we may not yet have the most accurate data about that distant obstacle.
+ * 
+ * @authors Harry Overall
+ */
+
+#ifndef NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_NEARBY_IN_COLLISION_GOALS_ACTION_HPP_
+#define NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_NEARBY_IN_COLLISION_GOALS_ACTION_HPP_
+
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/point.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "nav2_util/geometry_utils.hpp"
+#include "nav2_util/robot_utils.hpp"
+#include "nav2_behavior_tree/bt_utils.hpp"
+
+#include "behaviortree_cpp/action_node.h"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nova_behavior_tree
+{
+
+using namespace geometry_msgs::msg;
+using namespace nav_msgs::msg;
+
+struct GridCell
+{
+  int x, y;
+};
+
+/**
+ * @brief A nav2_behavior_tree::BtServiceNode class that removes goals that are in collision in on the global costmap, but only if the rover is within a specified distance.
+ * @note It will re-initialize when halted.
+ * 
+ * @authors Harry Overall
+ */
+class RemoveNearbyInCollisionGoalsAction : public BT::ActionNodeBase
+{
+public:
+  typedef PoseStamped Goal;
+  typedef std::vector<Goal> Goals;
+
+  /**
+   * @brief A constructor for nav2_behavior_tree::RemoveInCollisionGoals
+   * @param service_node_name Service name this node creates a client for
+   * @param conf BT node configuration
+   */
+  RemoveNearbyInCollisionGoalsAction(
+    const std::string & xml_tag_name,
+    const BT::NodeConfiguration & conf);
+
+  /**
+   * @brief Function to initialize variables,
+   * called only once in the lifecycle of the navigator
+   */
+  void initialize();
+
+  /**
+   * @brief Function to setup variables, called every time
+   * navigation is started
+   */
+  void setup();
+
+  /**
+   * @brief The main override required by a BT node
+   * @return BT::NodeStatus Status of tick execution
+   */
+  BT::NodeStatus tick() override;
+  
+  /**
+   * @brief Function called when the BT is halted,
+   * use to cleanup or reset state
+   */
+  void halt() override;
+
+  /**
+   * @brief Creates list of BT ports
+   * @return BT::PortsList Containing basic ports along with node-specific ports
+   */
+  static BT::PortsList providedPorts()
+  {
+    return {
+        BT::InputPort<double>("max_distance_threshold", 2.0, "Maximum radius (m) for a goal to be considered for removal"),
+        BT::InputPort<Goals>("input_goals", "Original goals to remove if in collision"),
+        BT::InputPort<std::string>("global_frame", "Global reference frame"),
+        BT::InputPort<std::string>("robot_base_frame", "robot base frame"),
+        BT::InputPort<double>("cost_threshold", 99.0, "Cost threshold for considering a goal in collision"),
+        BT::OutputPort<Goals>("output_goals", "Goals with all in collision goals removed"),
+      };
+  }
+
+private:
+
+  double euclidean_distance(const PoseStamped & a, const PoseStamped & b);
+  bool is_goal_in_collision(const PoseStamped & goal);
+  void wait_for_occu_grids();
+  bool remove_goals();
+  bool is_cell_free(const GridCell &global_cell);
+  bool is_cell_free(const GridCell &cell, const OccupancyGrid::SharedPtr &grid);
+  GridCell world_to_grid_cell(const Point &point, const OccupancyGrid::SharedPtr &grid);
+  Point grid_cell_to_world(const GridCell &cell, const OccupancyGrid::SharedPtr &grid);
+
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<OccupancyGrid>::SharedPtr local_occu_grid_sub_;
+  rclcpp::Subscription<OccupancyGrid>::SharedPtr global_occu_grid_sub_;
+  OccupancyGrid::SharedPtr local_occu_grid_;
+  OccupancyGrid::SharedPtr global_occu_grid_;
+
+  std::string global_frame_, robot_base_frame_;
+  std::shared_ptr<tf2_ros::Buffer> tf_;
+  double transform_tolerance_;
+  double max_distance_threshold_;
+  double cost_threshold_;
+  Goals input_goals_;
+
+  bool initialized_ = false;
+  bool set_up_ = false;
+};
+
+}  // namespace nova_behavior_tree
+
+#endif  // NAV2_BEHAVIOR_TREE__PLUGINS__ACTION__REMOVE_NEARBY_IN_COLLISION_GOALS_ACTION_HPP_

--- a/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
+++ b/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
@@ -241,7 +241,8 @@ bool RemoveNearbyInCollisionGoalsAction::is_cell_free(const GridCell &cell, cons
         return true; // treat out-of-bounds cells as free
     }
     int index = cell.y * (*grid).info.width + cell.x;
-    return (*grid).data[index] <= cost_threshold_;
+    RCLCPP_INFO(node_->get_logger(), "Cost of cell is %d", (*grid).data[index]);
+    return (*grid).data[index] < cost_threshold_;
 }
 
 /**

--- a/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
+++ b/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2024 Angsa Robotics
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include <array>
+#include <cmath>
+#include <queue>
+#include <chrono>
+#include <thread>
+
+#include "nav2_util/geometry_utils.hpp"
+#include "rclcpp/logging.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/point.hpp"
+#include "tf2/utils.h"
+#include "nav2_behavior_tree/bt_utils.hpp"
+#include "nav_msgs/msg/path.hpp"
+#include "behaviortree_cpp/decorator_node.h"
+
+#include "nova_behavior_tree/action/remove_nearby_in_collision_goals_action.hpp"
+#include "nova_behavior_tree/nav2_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace nova_behavior_tree
+{
+
+using namespace nav2_util::geometry_utils;
+using namespace geometry_msgs::msg;
+using namespace nav_msgs::msg;
+
+RemoveNearbyInCollisionGoalsAction::RemoveNearbyInCollisionGoalsAction(
+  const std::string & name,
+  const BT::NodeConfiguration & conf)
+: BT::ActionNodeBase(name, conf)
+{
+}
+
+void RemoveNearbyInCollisionGoalsAction::initialize()
+{
+  node_ = config().blackboard->get<rclcpp::Node::SharedPtr>("node");
+  
+  // Get vars for figuring out current pose
+  tf_ = config().blackboard->get<std::shared_ptr<tf2_ros::Buffer>>("tf_buffer");
+  node_->get_parameter("transform_tolerance", transform_tolerance_);
+  global_frame_ = BT::deconflictPortAndParamFrame<std::string>(
+    node_, "global_frame", this);
+  robot_base_frame_ = BT::deconflictPortAndParamFrame<std::string>(
+    node_, "robot_base_frame", this);
+
+  // Get input params
+  getInput("max_distance_threshold", max_distance_threshold_);
+  getInput("cost_threshold", cost_threshold_);
+
+  // Subscribe to local and global costmaps' occupancy grids
+  local_occu_grid_sub_ = node_->create_subscription<OccupancyGrid>(
+        "/local_costmap/costmap", 1,
+        [this](const OccupancyGrid::SharedPtr msg) -> void
+        {
+          local_occu_grid_ = msg;
+          RCLCPP_DEBUG(node_->get_logger(), "Received local costmap");
+      }
+  );
+  global_occu_grid_sub_ = node_->create_subscription<OccupancyGrid>(
+      "/global_costmap/costmap", 1,
+      [this](const OccupancyGrid::SharedPtr msg) -> void
+      {
+          global_occu_grid_ = msg;
+          RCLCPP_DEBUG(node_->get_logger(), "Received global costmap");
+      }
+  );
+
+  wait_for_occu_grids();
+  RCLCPP_INFO(node_->get_logger(), "RemoveNearbyInCollisionGoals successfully initialized!");
+  initialized_ = true;
+}
+
+void RemoveNearbyInCollisionGoalsAction::setup()
+{
+  if (!initialized_)
+  {
+    initialize();
+  }
+  
+  if (!local_occu_grid_ || !global_occu_grid_)
+  {
+    wait_for_occu_grids();
+  }
+
+  RCLCPP_INFO(node_->get_logger(), "RemoveNearbyInCollisionGoals successfully set up!");
+        
+  set_up_ = true;
+}
+
+void RemoveNearbyInCollisionGoalsAction::halt()
+{
+  set_up_ = false;
+}
+
+inline BT::NodeStatus RemoveNearbyInCollisionGoalsAction::tick()
+{
+  if (!set_up_)
+  {
+      setup();
+  }
+
+  // at this point, we should already have the occupancy grids
+  // however, this is just a safeguard
+  if (!local_occu_grid_ || !global_occu_grid_)
+  {
+      wait_for_occu_grids();
+  }
+  
+  getInput("input_goals", input_goals_);
+
+  // this is necessary to receive updates on the occupancy grids
+  rclcpp::spin_some(node_);
+
+  // remove goals
+  if (remove_goals())
+  {
+      return BT::NodeStatus::SUCCESS;
+  }
+
+  // On failure, just return input goals
+  RCLCPP_ERROR(node_->get_logger(), "RemoveNearbyInCollisionGoals Failed remove nearby goals, goals remain unchanged.");
+  setOutput("output_goals", input_goals_);
+  return BT::NodeStatus::FAILURE;
+}
+
+
+bool RemoveNearbyInCollisionGoalsAction::remove_goals()
+{
+  // Get the current pose of the rover
+  geometry_msgs::msg::PoseStamped current_pose;
+  
+  if (!nav2_util::getCurrentPose(current_pose, *tf_, global_frame_, robot_base_frame_, transform_tolerance_))
+  {
+    RCLCPP_WARN(node_->get_logger(), "Current robot pose is not available.");
+    return false;
+  }
+  
+  Goals output_goals_;
+  for (size_t i=0; i < input_goals_.size(); i++)
+  {
+    Goal goal = input_goals_[i];
+    
+    // Keep goal if it is outside max distance to consider for removal
+    const double dist = euclidean_distance(current_pose, goal);
+    if (dist > max_distance_threshold_)
+    {
+      output_goals_.push_back(goal);
+    } 
+    
+    // Otherwise check if costmap where goal is at is too high
+    else 
+    {
+      if (!is_goal_in_collision(goal))
+      {
+        output_goals_.push_back(goal);
+      }
+      else 
+      {
+        RCLCPP_INFO(node_->get_logger(), "RemoveNearbyInCollisionGoals goal %zu is within distance threshold and above cost threshold, removing", i);
+      }
+    }
+  }
+  setOutput("output_goals", output_goals_);
+  return true;
+}
+
+void RemoveNearbyInCollisionGoalsAction::wait_for_occu_grids()
+{
+    // measure time to initialize
+    auto start = std::chrono::high_resolution_clock::now();
+    while (!local_occu_grid_ || !global_occu_grid_)
+    {
+        rclcpp::spin_some(node_);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    RCLCPP_INFO(
+        node_->get_logger(), "RemoveNearbyInCollisionGoals waited %.2fms for occupancy grids",
+        std::chrono::duration<double, std::milli>(end - start).count()
+    );
+}
+
+/**
+ * @brief Returns the 2D Euclidean distance between two poses.
+ */
+double RemoveNearbyInCollisionGoalsAction::euclidean_distance(
+    const PoseStamped & a,
+    const PoseStamped & b)
+{
+    const double dx = a.pose.position.x - b.pose.position.x;
+    const double dy = a.pose.position.y - b.pose.position.y;
+    return std::sqrt(dx * dx + dy * dy);
+}
+
+bool RemoveNearbyInCollisionGoalsAction::is_goal_in_collision(const PoseStamped & goal)
+{
+    GridCell global_cell = world_to_grid_cell(goal.pose.position, global_occu_grid_);
+    return !is_cell_free(global_cell);
+}
+
+/** Methods from SnapInCollisionGoals */
+ 
+/**
+ * @brief Check if a cell is free in both the local and global occupancy grids
+ * 
+ * @param global_cell A cell with reference to the global occupancy grid
+ */
+bool RemoveNearbyInCollisionGoalsAction::is_cell_free(const GridCell &global_cell)
+{
+    GridCell local_cell = world_to_grid_cell(grid_cell_to_world(global_cell, global_occu_grid_), local_occu_grid_);
+    return is_cell_free(global_cell, global_occu_grid_) && is_cell_free(local_cell, local_occu_grid_);
+}
+
+/**
+ * @brief Check if a cell is free in a given occupancy grid
+ * 
+ * @param cell A cell with reference to the occupancy grid
+ * @param grid The occupancy grid to check
+ */
+bool RemoveNearbyInCollisionGoalsAction::is_cell_free(const GridCell &cell, const OccupancyGrid::SharedPtr &grid)
+{
+    if (cell.x < 0 || cell.x >= static_cast<int>((*grid).info.width) ||
+        cell.y < 0 || cell.y >= static_cast<int>((*grid).info.height))
+    {
+        return true; // treat out-of-bounds cells as free
+    }
+    int index = cell.y * (*grid).info.width + cell.x;
+    return (*grid).data[index] <= cost_threshold_;
+}
+
+/**
+ * @brief Convert a world point to a grid cell in the specified occupancy grid
+ * 
+ * @param point The point to convert
+ * @param grid The occupancy grid to use for conversion
+ */
+GridCell RemoveNearbyInCollisionGoalsAction::world_to_grid_cell(const Point &point, const OccupancyGrid::SharedPtr &grid)
+{
+    GridCell cell;
+    cell.x = static_cast<int>(std::round((point.x - (*grid).info.origin.position.x) / (*grid).info.resolution));
+    cell.y = static_cast<int>(std::round((point.y - (*grid).info.origin.position.y) / (*grid).info.resolution));
+    return cell;
+}
+
+/**
+ * @brief Convert a grid cell in the specified occupancy grid to a world point
+ * 
+ * @param cell The cell to convert
+ * @param grid The occupancy grid the cell is in
+ */
+Point RemoveNearbyInCollisionGoalsAction::grid_cell_to_world(const GridCell &cell, const OccupancyGrid::SharedPtr &grid)
+{
+    Point point;
+    point.x = (*grid).info.origin.position.x + (cell.x * (*grid).info.resolution);
+    point.y = (*grid).info.origin.position.y + (cell.y * (*grid).info.resolution);
+    return point;
+}
+
+}   // namespace nova_behavior_tree
+
+#include "behaviortree_cpp/bt_factory.h"
+BT_REGISTER_NODES(factory)
+{
+  factory.registerNodeType<nova_behavior_tree::RemoveNearbyInCollisionGoalsAction>("RemoveNearbyInCollisionGoals");
+}

--- a/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
+++ b/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
@@ -176,6 +176,15 @@ bool RemoveNearbyInCollisionGoalsAction::remove_goals()
       }
     }
   }
+
+   if (output_goals_.size() == 0)
+  {
+    RCLCPP_INFO(node_->get_logger(),
+                "All goals have been removed, doing scuffed solution >:D");
+
+    output_goals_.push_back(current_pose);
+  }
+  
   setOutput("output_goals", output_goals_);
   return true;
 }

--- a/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
+++ b/src/ros/rover/auto/nova_behavior_tree/plugins/action/remove_nearby_in_collision_goals_action.cpp
@@ -177,14 +177,13 @@ bool RemoveNearbyInCollisionGoalsAction::remove_goals()
     }
   }
 
-   if (output_goals_.size() == 0)
+  // If all goals have been removed, add the rovers current position as final goal
+  if (output_goals_.size() == 0)
   {
-    RCLCPP_INFO(node_->get_logger(),
-                "All goals have been removed, doing scuffed solution >:D");
-
+    RCLCPP_INFO(node_->get_logger(), "All goals have been removed, doing scuffed solution >:D");
     output_goals_.push_back(current_pose);
   }
-  
+
   setOutput("output_goals", output_goals_);
   return true;
 }


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->
Node takes input param of distance and cost threshold. CURRENTLY any point inside an obstacle as well as the inflated (cyan) layer around it has a cost value of 99. The darker blue layer the interpolates between 99 and 0 the further away it is from the cyan.

By default, this is set up with a threshold of 99 (exclusive). So will not remove any points below this value. You can lower this to preferentially delete nodes that are "too close" to the cyan inflated layer, eg by setting it to 80 or something.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
