### PR TITLE
feat: auto blcmd reset

### DIFF
--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -125,14 +125,7 @@ def launch_setup(context, *args, **kwargs):
                     output='screen', 
                     emulate_tty=True,
                     ros_arguments=['--log-level', log_level],
-                    parameters=[
-                        { "enable_auto_blcmd_reset" : IfElseSubstitution(
-                            condition=auto,
-                            if_value="true",
-                            else_value="false",
-                        ),
-                        }
-                    ]
+                    parameters=[params]
                 ),
                 IncludeLaunchDescription(
                     launch_description_source=PythonLaunchDescriptionSource(

--- a/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
+++ b/src/ros/rover/drive/drive_bringup/launch/drive.launch.py
@@ -125,6 +125,14 @@ def launch_setup(context, *args, **kwargs):
                     output='screen', 
                     emulate_tty=True,
                     ros_arguments=['--log-level', log_level],
+                    parameters=[
+                        { "enable_auto_blcmd_reset" : IfElseSubstitution(
+                            condition=auto,
+                            if_value="true",
+                            else_value="false",
+                        ),
+                        }
+                    ]
                 ),
                 IncludeLaunchDescription(
                     launch_description_source=PythonLaunchDescriptionSource(

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -134,3 +134,22 @@ ackermann_steering_controller:
     wheelbase: 0.95752883 # 0.875 for Waratah
     front_wheels_radius: 0.15692321 # 0.15 for Waratah
     rear_wheels_radius: 0.15692321 # 0.15 for Waratah
+
+blcmd_status_monitor:
+  ros__parameters:
+
+    # auto blcmd reset parameters
+    enable_auto_blcmd_reset: true
+    max_resets: 5
+    reset_timeout: 5
+    auto_reset_drive_blmcd_ids: [1, 2, 3, 4]
+    auto_reset_pivot_blmcd_ids: []
+
+    blcmd_zero_response_timeout: 3
+    canbus: can0
+    error_active_duration: 2
+    log_gate_driver_condition: false
+    num_blcmds: 8
+    output_max_frequency: 1
+    publish_log_max_frequency: 10
+    publish_status_frequency: 2

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -135,3 +135,22 @@ ackermann_steering_controller:
     wheelbase: 0.95752883 # 0.875 for Waratah
     front_wheels_radius: 0.15692321 # 0.15 for Waratah
     rear_wheels_radius: 0.15692321 # 0.15 for Waratah
+
+blcmd_status_monitor:
+  ros__parameters:
+
+    # auto blcmd reset parameters
+    enable_auto_blcmd_reset: false
+    max_resets: 5
+    reset_timeout: 5
+    auto_reset_drive_blmcd_ids: [1, 2, 3, 4]
+    auto_reset_pivot_blmcd_ids: []
+
+    blcmd_zero_response_timeout: 3
+    canbus: can0
+    error_active_duration: 2
+    log_gate_driver_condition: false
+    num_blcmds: 8
+    output_max_frequency: 1
+    publish_log_max_frequency: 10
+    publish_status_frequency: 2

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -119,7 +119,11 @@ class BLCMDStatusMonitor(Node):
         self.max_resets = self.declare_parameter("max_resets", 5).value # set to 0 for no limit
         self.reset_timeout = self.declare_parameter("reset_timeout", 5).value # in seconds; set to 0 for no timeout
         self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", [1, 2, 3, 4]).value # which drive blcmds are allowed to be reset (by id)
+        if self.auto_reset_drive_blmcd_ids is None:
+            self.auto_reset_drive_blmcd_ids = []
         self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", []).value # which pivot blcmds are allowed to be reset (by id)
+        if self.auto_reset_pivot_blmcd_ids is None:
+            self.auto_reset_pivot_blmcd_ids = []
 
         self.blcmd_zero_response_timeout = self.declare_parameter("blcmd_zero_response_timeout", 3).value # in seconds (only used for pivots)
 

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -24,6 +24,7 @@ from rclpy.node import Node
 from rclpy.time import Time
 from rclpy.duration import Duration
 import jcan
+from collections.abc import Callable
 
 # import custom messages
 from blcmd_interfaces.msg import BLCMDStatus, BLCMDStatusArray, BLCMDLog
@@ -113,6 +114,21 @@ class BLCMDStatusMonitor(Node):
         # see gateDriver.c in blcmd firmware
         self.gate_driver_registers = []
 
+        # parameters for auto blcmd reset feature
+        self.enable_auto_blcmd_reset = self.declare_parameter("enable_auto_blcmd_reset", False).value
+        self.max_resets = self.declare_parameter("max_resets", 5).value # set to 0 for no limit
+        self.reset_timeout = self.declare_parameter("reset_timeout", 5).value # in seconds; set to 0 for no timeout
+        self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", [1, 2, 3, 4]).value
+        self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", []).value
+
+        # keep track of when blcmd was last reset and total number of resets sent
+        self.blcmd_reset_times = {}
+        self.blcmd_reset_count = {}
+
+        # list of functions to call after bus.spin()
+        # workaround required due to inability to call bus.send in a can callback
+        self.deferred_functions: list[Callable[[], None]] = []
+
         #create reset_time variable to prevent multiple resets in a short time
         self.reset_time = self.get_clock().now()
 
@@ -125,11 +141,18 @@ class BLCMDStatusMonitor(Node):
             self.bus.add_callback(0x400 | (i + 1) << 4, self.get_callback(i))
 
         #create timers
-        self.can_spin_timer = self.create_timer(0.01, self.bus.spin)
+        self.run_callbacks_timer = self.create_timer(0.01, self.run_callbacks)
         self.publish_status_timer = self.create_timer(self.publish_status_period, self.publish_blcmd_status)
 
         #open the can bus
         self.bus.open(self.get_parameter("canbus").value)
+
+    def run_callbacks(self):
+        self.bus.spin()
+
+        for function in self.deferred_functions:
+            function()
+        self.deferred_functions = []
 
     def reset(self,req,res):
         """
@@ -149,10 +172,63 @@ class BLCMDStatusMonitor(Node):
             elif req.type == BLCMDReset.Request.RESOLVER:
                 self.get_logger().info(f'Reset resolver on BLCMD {req.id}')
             res.success = True
-        except :
-            self.get_logger().error('BLCMD Reset or Resolver Reset Failed');
+        except:
+            self.get_logger().error('BLCMD Reset or Resolver Reset Failed')
             res.success = False
         return res
+
+    def reset_drive_blcmd(self, blcmd_id: int):
+        msg_id = 0x00B | (blcmd_id << 4)
+
+        def deferred_reset():
+            self.bus.send(
+                jcan.Frame(id=msg_id, data=[])
+            )
+
+        self.deferred_functions.append(deferred_reset)
+
+    def reset_pivot_blcmd(self, blcmd_id: int):
+        raise NotImplementedError
+
+    # only run when an error from blcmd is detected
+    def auto_blcmd_reset(self, blcmd_id: int):
+        # check if auto blcmd reset is disabled
+        if not self.enable_auto_blcmd_reset:
+            return
+
+        # check if this is a blcmd id we can reset
+        if (blcmd_id not in self.auto_reset_drive_blmcd_ids
+          and blcmd_id not in self.auto_reset_pivot_blmcd_ids):
+            return
+
+        now = self.get_clock().now()
+
+        # check if it's too soon to send another reset (in timeout)
+        if (self.reset_timeout > 0
+          and blcmd_id in self.blcmd_reset_times
+          and (now - self.blcmd_reset_times[blcmd_id]) < Duration(seconds=self.reset_timeout)):
+            return
+
+        # check if we can't send more (reached max_resets)
+        if (self.max_resets > 0
+          and blcmd_id in self.blcmd_reset_count
+          and self.blcmd_reset_count[blcmd_id] >= self.max_resets):
+            return
+
+        # all checks passed, send reset now
+
+        # update counts and times
+        self.blcmd_reset_times[blcmd_id] = now
+        if blcmd_id not in self.blcmd_reset_count:
+            self.blcmd_reset_count[blcmd_id] = 1
+        else:
+            self.blcmd_reset_count[blcmd_id] += 1
+
+
+        if blcmd_id in self.auto_reset_pivot_blmcd_ids:
+            self.reset_pivot_blcmd(blcmd_id)
+        else:
+            self.reset_drive_blcmd(blcmd_id)
 
     def output_rate_limited(self, blcmd: int, output_message: str) -> bool:
         output_id = (blcmd, output_message)
@@ -212,6 +288,9 @@ class BLCMDStatusMonitor(Node):
                   and hasattr(blcmd_status, self.BLCMD_STATUS_ERROR_ATTRS[error_id])):
                     setattr(blcmd_status, self.BLCMD_STATUS_ERROR_ATTRS[error_id], True)
                     self.error_times[blcmd][error_id] = self.get_clock().now()
+
+                # attempt to reset blcmd automatically
+                self.auto_blcmd_reset(blcmd + 1)
 
             # warnings
             elif frame.data[0] == 1:

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -118,12 +118,17 @@ class BLCMDStatusMonitor(Node):
         self.enable_auto_blcmd_reset = self.declare_parameter("enable_auto_blcmd_reset", False).value
         self.max_resets = self.declare_parameter("max_resets", 5).value # set to 0 for no limit
         self.reset_timeout = self.declare_parameter("reset_timeout", 5).value # in seconds; set to 0 for no timeout
-        self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", [1, 2, 3, 4]).value
-        self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", []).value
+        self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", [1, 2, 3, 4]).value # which drive blcmds are allowed to be reset (by id)
+        self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", []).value # which pivot blcmds are allowed to be reset (by id)
+
+        self.blcmd_zero_response_timeout = self.declare_parameter("blcmd_zero_response_timeout", 3).value # in seconds (only used for pivots)
 
         # keep track of when blcmd was last reset and total number of resets sent
         self.blcmd_reset_times = {}
         self.blcmd_reset_count = {}
+
+        # keep track of when pivot blcmds were last reset
+        self.blcmd_pivot_reset_times = {}
 
         # list of functions to call after bus.spin()
         # workaround required due to inability to call bus.send in a can callback
@@ -134,11 +139,12 @@ class BLCMDStatusMonitor(Node):
 
         #initialise the can bus
         self.bus = jcan.Bus()
-        self.bus.set_id_filter_mask(0x400, 0xF0F)
+        self.bus.set_id_filter_mask(0x400, 0xF00)
 
         #add callbacks for each blcmd
         for i in range(self.num_blcmds):
             self.bus.add_callback(0x400 | (i + 1) << 4, self.get_callback(i))
+            self.bus.add_callback(0x409 | (i + 1) << 4, self.get_reset_pivot_blcmd_callback(i+1))
 
         #create timers
         self.run_callbacks_timer = self.create_timer(0.01, self.run_callbacks)
@@ -189,7 +195,64 @@ class BLCMDStatusMonitor(Node):
         self.deferred_functions.append(deferred_reset)
 
     def reset_pivot_blcmd(self, blcmd_id: int):
-        raise NotImplementedError
+
+        # WARNING: This process is based off firmware electrical has written for arm (they should adapt this feature for pivot firmware)
+
+        def deferred_reset():
+            self.get_logger().info(f'Resetting pivot BLCMD {blcmd_id} due to errors received (getting current zero position, response not guaranteed)')
+
+            # keep track of when the last request was made
+            self.blcmd_pivot_reset_times[blcmd_id] = self.get_clock().now()
+
+            # get configuration (blcmd zero position)
+            self.bus.send(
+                jcan.Frame(id=0x009 | blcmd_id << 4, data=[0xf])
+            )
+
+            # all following operations (including the actual reset of the blcmd occur in callbacks returned by get_reset_pivot_blcmd_callback
+            # run by receipt of reply from blcmd containing current zero position via bus.spin (no response = no reset)
+
+        self.deferred_functions.append(deferred_reset)
+
+    def get_reset_pivot_blcmd_callback(self, blcmd_id: int):
+        def callback(frame):
+            now = self.get_clock().now()
+
+            # don't do anything if there wasn't a recent enough request for pivot zero
+            if (blcmd_id not in self.blcmd_pivot_reset_times
+              or self.blcmd_pivot_reset_times[blcmd_id] is None
+              or now - self.blcmd_pivot_reset_times[blcmd_id] > Duration(seconds=self.blcmd_zero_response_timeout)):
+                return
+
+            # don't do anything if this isn't a response containing zero position
+            if frame.data[0] != 0xf:
+                return
+
+            self.get_logger().info(f'Response received for BLCMD zero position, resetting pivot BLCMD {blcmd_id}')
+
+            zero_position = frame.data[1:3]
+
+            def deferred_reset():
+
+                # reset pivot blcmd
+                self.bus.send(
+                    jcan.Frame(id=0x00B | (blcmd_id << 4), data=[])
+                )
+
+                # set pivot zero
+                self.bus.send(
+                    jcan.Frame(id=0x00A | (blcmd_id << 4), data=[
+                        0xf,
+                        *zero_position
+                    ])
+                )
+
+                self.blcmd_pivot_reset_times[blcmd_id] = None
+
+            self.deferred_functions.append(deferred_reset)
+
+        return callback
+
 
     # only run when an error from blcmd is detected
     def auto_blcmd_reset(self, blcmd_id: int):

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -181,6 +181,7 @@ class BLCMDStatusMonitor(Node):
         msg_id = 0x00B | (blcmd_id << 4)
 
         def deferred_reset():
+            self.get_logger().info(f'Resetting drive BLCMD {blcmd_id} due to errors received')
             self.bus.send(
                 jcan.Frame(id=msg_id, data=[])
             )


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

automatically reset blcmds (currently enabled only for the auto task in arch) when an error is received. parameters are highly flexible, so feel free to ask Jonathan Jia how any of this works.

change params for this feature in `nova.yaml` and `auto.yaml` in drive_bringup (in the `blcmd_status_monitor` section of the file)
