### PR TITLE
gui: nix: rebuild node modules less

### DIFF
--- a/src/ros/nova-gui/nix/packages/gui/default.nix
+++ b/src/ros/nova-gui/nix/packages/gui/default.nix
@@ -33,6 +33,11 @@ in
 mkYarnPackage {
   name = "gui";
 
+  # Make sure that the node modules derevation doesn't have the whole source
+  # folder as an input (i.e. changes to tsx files won't trigger rebuilding node_modules)
+  packageJSON = ../../../nova-gui/package.json;
+  yarnLock = ../../../nova-gui/yarn.lock;
+
   src = builtins.path rec {
     name = "gui";
     path = ../../../nova-gui;


### PR DESCRIPTION
by default, mkYarnPackage sets its packageJSON and yarnLock to src + filename. this means that when those arguments are passed down to the builder for the node modules, its in the form of /nix/store/{entire gui source code}/package.json. that means any change to gui code changes the nix store path for the node modules builder so it has to rebuild it even though the particular files (package.json + yarn.lock) haven't changed.

work around this by copying those files to the nix store seperately. this means that their nix-store hash is only based on the individual files' contents not the whole gui source code, and you rebuild node-modules only when you actually changed the modules.

https://github.com/NixOS/nixpkgs/blob/5f7ca9ab52cf303ec12876e19150cb079046fa0b/pkgs/development/tools/yarn2nix-moretea/default.nix#L312-L313

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
