### PR TITLE
nixfiles: allow nova to use rt fifo scheduler

### DIFF
--- a/nixfiles/modules/nixos/common/users/default.nix
+++ b/nixfiles/modules/nixos/common/users/default.nix
@@ -40,12 +40,36 @@
             wheel.name
             video.name
             dialout.name
+            realtime.name
           ];
         };
       }
     ];
 
     nix.settings.trusted-users = lib.optional config.nova.users.nova.enable config.users.users.nova.name;
+
+    # Allow RT FIFO Scheduler, locking memory not in swap for ros2control
+    users.groups.realtime = {};
+    security.pam.loginLimits = [
+      {
+        domain = "@realtime";
+        item = "rtprio";
+        type = "-";
+        value = "99";
+      }
+      {
+        domain = "@realtime";
+        item = "priority";
+        type = "-";
+        value = "99";
+      }
+      {
+        domain = "@realtime";
+        item = "memlock";
+        type = "-";
+        value = "unlimited";
+      }
+    ];
 
     home-manager = {
       useUserPackages = true;


### PR DESCRIPTION
ros2control complains about not being able to do this. this should help with the responsiveness of ros2control.

to confirm it works:

chrt -a -p $(pgrep ros2_control_no) | grep -A1 FIFO

closes #1043

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
