### PR TITLE
No more bunny hops :rabbit: (+ other drive fixes inc. no more teleop lag!) 

### DIFF
--- a/nixfiles/scripts/zero-pivots.sh
+++ b/nixfiles/scripts/zero-pivots.sh
@@ -5,10 +5,10 @@
 # BLCMD IDs
 declare -A pivots
 pivots=(
-  [FLP]=5
-  [BLP]=6
-  [BRP]=7
-  [FRP]=8
+  [5]=FLP
+  [6]=BLP
+  [7]=BRP
+  [8]=FRP
 )
 
 echo "Ensure that drive is not running before starting the alignment process."
@@ -42,38 +42,19 @@ echo
 zero_pivot() {
   local id=$1
    # Zero pivot
-  cansend can0 0${id}8#
-  sleep 0.5
-  cansend can0 0${id}8#
-  
-  sleep 1
-  
-  # Move to angle
-  cansend can0 0${id}4#c764
-  sleep 0.5
-  cansend can0 0${id}4#c764
-  
-  sleep 1
-  
-  # Zero pivot
-  cansend can0 0${id}8#
-  sleep 0.5
-  cansend can0 0${id}8#
+  cansend can0 0${id}B#
 }
 
 if [[ "$blcmd_id" == "0" ]]; then
-  for pivot in "${!pivots[@]}"; do
-    id=${pivots[$pivot]}
+  for id in $(echo "${!pivots[@]}" | tr ' ' '\n' | sort); do
+    pivot=${pivots[$id]}
     zero_pivot "$id"
     echo "BLCMD ${id} (${pivot}) successfully aligned."
-    sleep 0.5
   done
 else
   zero_pivot "$blcmd_id"
-  echo "BLCMD ${blcmd_id} successfully aligned."
+  echo "BLCMD ${blcmd_id} (${pivots[$blcmd_id]}) successfully aligned."
 fi
 
 echo
 echo "Done."
-echo
-echo "Remember to run the 'launch-drive' command so that the pivots to return to their zero position."

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -75,10 +75,10 @@ pivot_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 5.0
-      min_velocity: -1.5
-      max_acceleration: 4.0
-      min_acceleration: -10.0
+      max_velocity: 2.5
+      min_velocity: -0.75
+      max_acceleration: 2.0
+      min_acceleration: -5.0
     angular: # radians
       has_velocity_limits: true
       max_velocity: 1.57079632 # PI/2 rad/s = 90 deg/s
@@ -100,8 +100,8 @@ strafe_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 3.0
-      max_acceleration: 6.0
+      max_velocity: 1.5
+      max_acceleration: 3.0
 
 diff_drive_controller:
   ros__parameters:
@@ -115,10 +115,10 @@ diff_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 3.0
-      min_velocity: -1.5
-      max_acceleration: 4.0
-      min_acceleration: -10.0
+      max_velocity: 1.5
+      min_velocity: -0.75
+      max_acceleration: 2.0
+      min_acceleration: -5.0
     angular: # radians
       has_velocity_limits: true
       max_velocity: 0.78539816 # PI/4 rad/s = 45 deg/s

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -75,10 +75,10 @@ pivot_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 5.0
-      min_velocity: -1.5
-      max_acceleration: 4.0
-      min_acceleration: -10.0
+      max_velocity: 2.5
+      min_velocity: -0.75
+      max_acceleration: 2.0
+      min_acceleration: -5.0
     angular: # radians
       has_velocity_limits: true
       max_velocity: 1.57079632 # PI/2 rad/s = 90 deg/s
@@ -100,8 +100,8 @@ strafe_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 3.0
-      max_acceleration: 6.0
+      max_velocity: 1.5
+      max_acceleration: 3.0
 
 diff_drive_controller:
   ros__parameters:
@@ -116,10 +116,10 @@ diff_drive_controller:
     drive: # metres
       has_velocity_limits: true
       has_acceleration_limits: true
-      max_velocity: 3.0
-      min_velocity: -1.5
-      max_acceleration: 4.0
-      min_acceleration: -10.0
+      max_velocity: 1.5
+      min_velocity: -0.75
+      max_acceleration: 2.0
+      min_acceleration: -5.0
     angular: # radians
       has_velocity_limits: true
       max_velocity: 0.78539816 # PI/4 rad/s = 45 deg/s

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/include/nova_drive_controller_base/nova_drive_controller_base.hpp
@@ -203,7 +203,7 @@ private:
   const std::string DEFAULT_COMMAND_OUT_TOPIC_;
 
   bool is_active_ = false;
-  bool is_halted_ = false;
+  bool disconnected_ = false;
 
   std::unique_ptr<nova_controller_common::HardwareInterfaceWrapper> hwif_wrapper_;
   std::unique_ptr<Odometry> odometry_;
@@ -211,6 +211,7 @@ private:
   // Timeout to consider cmd_vel commands old
   rclcpp::Duration cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(0.5);
   rclcpp::Duration cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(0.5);
+  rclcpp::Duration connection_timeout_ = rclcpp::Duration::from_seconds(2.0);
   rclcpp::Time last_received_time_;
 
   // Subscriber and realtime buffer for received TwistStamped messages

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -180,7 +180,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
     if (age_of_last_command < connection_timeout_)
     {
       RCLCPP_WARN_THROTTLE(
-        logger, *get_node()->get_clock(), cmd_vel_command_timeout_.seconds() * 1000,
+        logger, *get_node()->get_clock(), 500,
         "The last received command is %.2f seconds old, which exceeds the allowed timeout of "
         "%.2f seconds. Publishing zero commands.",
         age_of_last_command.seconds(), cmd_vel_command_timeout_.seconds());
@@ -407,7 +407,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
 
   // Initialise twist subscriber
   twist_subscriber_ = get_node()->create_subscription<TwistStamped>(
-    DEFAULT_COMMAND_TOPIC_, rclcpp::QoS(10).best_effort(),
+    DEFAULT_COMMAND_TOPIC_, rclcpp::QoS(1).best_effort(),
     [this](const std::shared_ptr<TwistStamped> msg) -> void
     {
       if (!is_active_)

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -407,7 +407,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
 
   // Initialise twist subscriber
   twist_subscriber_ = get_node()->create_subscription<TwistStamped>(
-    DEFAULT_COMMAND_TOPIC_, rclcpp::SystemDefaultsQoS(),
+    DEFAULT_COMMAND_TOPIC_, rclcpp::QoS(10).best_effort(),
     [this](const std::shared_ptr<TwistStamped> msg) -> void
     {
       if (!is_active_)

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -176,9 +176,34 @@ controller_interface::return_type NovaDriveControllerBase::update(
   if (age_of_last_command > cmd_vel_command_timeout_)
   {
     cmds = twist_to_commands(Twist(), base_params_->autonomous_mode, period);
+
+    if (age_of_last_command < connection_timeout_)
+    {
+      RCLCPP_WARN_THROTTLE(
+        logger, *get_node()->get_clock(), cmd_vel_command_timeout_.seconds() * 1000,
+        "The last received command is %.10f seconds old, which exceeds the allowed timeout of "
+        "%.4f seconds. Publishing zero commands.",
+        age_of_last_command.seconds(), cmd_vel_command_timeout_.seconds());
+    }
+    else if (!disconnected_)
+    {
+      disconnected_ = true;
+      RCLCPP_ERROR(
+        logger, "The last received command is %.10f seconds old, which exceeds the connection timeout of "
+                "%.4f seconds. Connection to the command publisher is assumed to be lost, no further warnings "
+                "will be issued.",
+        age_of_last_command.seconds(), connection_timeout_.seconds());
+    }
   }
   else
   {
+    if (disconnected_)
+    {
+      disconnected_ = false;
+      RCLCPP_INFO(logger, "Connection has been restored! (Received a new command after not receiving any "
+                          "for > %.4f seconds)", connection_timeout_.seconds());
+    }
+
     cmds = twist_to_commands(command_msg_ptr->twist, base_params_->autonomous_mode, period);
   }
 
@@ -345,6 +370,7 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
 
   cmd_vel_receive_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_receive_timeout);
   cmd_vel_command_timeout_ = rclcpp::Duration::from_seconds(base_params_->cmd_vel_command_timeout);
+  connection_timeout_ = rclcpp::Duration::from_seconds(base_params_->connection_timeout);
 
   limiter_drive_ = SpeedLimiter(
     base_params_->drive.has_velocity_limits, base_params_->drive.has_acceleration_limits,
@@ -456,7 +482,6 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_activate(
     return controller_interface::CallbackReturn::ERROR;
   }
 
-  is_halted_ = false;
   is_active_ = true;
 
   RCLCPP_INFO(get_node()->get_logger(), "Subscriber and publisher are now active.");

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -188,16 +188,15 @@ controller_interface::return_type NovaDriveControllerBase::update(
     {
       RCLCPP_WARN_THROTTLE(
         logger, *get_node()->get_clock(), 500,
-        C_WARN "Cmd age %.2fs exceeds timeout %.2fs; publishing zero commands." C_END,
+        C_WARN "Halting; command age %.2fs exceeds timeout %.2fs." C_END,
         age_of_last_command.seconds(), cmd_vel_command_timeout_.seconds());
     }
     else if (!disconnected_)
     {
       disconnected_ = true;
       RCLCPP_ERROR_SKIPFIRST(
-        logger, C_ERROR "The last received command is %.2f seconds old, which exceeds the connection timeout of "
-                "%.2f seconds. Connection to the command publisher is assumed to be lost, no further warnings "
-                "will be issued." C_END,
+        logger, C_ERROR "Command age %.2fs exceeds connection timeout of %.2fs. No further warnings "
+                "will be issued; connection to the command publisher is assumed to be lost." C_END,
         age_of_last_command.seconds(), connection_timeout_.seconds());
     }
   }

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -21,6 +21,13 @@
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 
+// Define colors for logging
+#define C_INFO "\033[1;34m"    // blue
+#define C_ERROR "\033[1;31m"   // red
+#define C_WARN "\033[;33m"     // yellow
+#define C_SUCCESS "\033[1;32m" // green
+#define C_END "\033[0m"
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
@@ -150,14 +157,14 @@ controller_interface::return_type NovaDriveControllerBase::update(
   if (base_param_listener_->is_old(*base_params_))
   {
     *base_params_ = base_param_listener_->get_params();
-    RCLCPP_INFO(logger, "Parameters were updated");
+    RCLCPP_INFO(logger, C_INFO "Parameters were updated" C_END);
   }
   update_params();
 
   std::shared_ptr<TwistStamped> command_msg_ptr = *(received_twist_msg_ptr_.readFromRT());
   if (command_msg_ptr == nullptr)
   {
-    RCLCPP_WARN(logger, "Received TwistStamped message was a nullptr.");
+    RCLCPP_WARN(logger, C_WARN "Received TwistStamped message was a nullptr." C_END);
     return controller_interface::return_type::ERROR;
   }
   else if ((std::isnan(command_msg_ptr->twist.linear.x) ||
@@ -165,7 +172,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
   {
     RCLCPP_WARN_SKIPFIRST_THROTTLE(
       logger, *get_node()->get_clock(), cmd_vel_receive_timeout_.seconds() * 1000,
-      "Command message contains NaNs. Not updating reference interfaces.");
+      C_WARN "Command message contains NaNs. Not updating reference interfaces." C_END);
     return controller_interface::return_type::OK;
   }
 
@@ -181,17 +188,16 @@ controller_interface::return_type NovaDriveControllerBase::update(
     {
       RCLCPP_WARN_THROTTLE(
         logger, *get_node()->get_clock(), 500,
-        "The last received command is %.2f seconds old, which exceeds the allowed timeout of "
-        "%.2f seconds. Publishing zero commands.",
+        C_WARN "Cmd age %.2fs exceeds timeout %.2fs; publishing zero commands." C_END,
         age_of_last_command.seconds(), cmd_vel_command_timeout_.seconds());
     }
     else if (!disconnected_)
     {
       disconnected_ = true;
-      RCLCPP_ERROR(
-        logger, "The last received command is %.2f seconds old, which exceeds the connection timeout of "
+      RCLCPP_ERROR_SKIPFIRST(
+        logger, C_ERROR "The last received command is %.2f seconds old, which exceeds the connection timeout of "
                 "%.2f seconds. Connection to the command publisher is assumed to be lost, no further warnings "
-                "will be issued.",
+                "will be issued." C_END,
         age_of_last_command.seconds(), connection_timeout_.seconds());
     }
   }
@@ -200,8 +206,10 @@ controller_interface::return_type NovaDriveControllerBase::update(
     if (disconnected_)
     {
       disconnected_ = false;
-      RCLCPP_INFO(logger, "Connection has been restored! (Received a new command after not receiving any "
-                          "for > %.2f seconds)", connection_timeout_.seconds());
+      RCLCPP_INFO_SKIPFIRST(
+        logger,
+        C_SUCCESS "Connection has been restored! (Received a new command after not receiving any "
+                  "for > %.2f seconds)" C_END, connection_timeout_.seconds());
     }
 
     cmds = twist_to_commands(command_msg_ptr->twist, base_params_->autonomous_mode, period);
@@ -228,8 +236,8 @@ controller_interface::return_type NovaDriveControllerBase::update(
       {
         RCLCPP_DEBUG(
           logger,
-          "Failed to get feedback from hardware interfaces for left/right drive joints %zu, "
-          "odometry cannot be updated. Ending current update loop early.",
+          C_INFO "Failed to get feedback from hardware interfaces for left/right drive joints %zu, "
+          "odometry cannot be updated. Ending current update loop early." C_END,
           pos);
         return controller_interface::return_type::OK;
       }
@@ -240,8 +248,8 @@ controller_interface::return_type NovaDriveControllerBase::update(
       {
         RCLCPP_ERROR(
           logger,
-          "Received NaN feedback for left/right drive joints %zu, odometry cannot be updated. "
-          "Ending current update loop early.",
+           C_ERROR "Received NaN feedback for left/right drive joints %zu, odometry cannot be updated. "
+          "Ending current update loop early." C_END,
           pos);
         return controller_interface::return_type::ERROR;
       }
@@ -260,8 +268,8 @@ controller_interface::return_type NovaDriveControllerBase::update(
       {
         RCLCPP_DEBUG(
           logger,
-          "Failed to get feedback from hardware interfaces for left/right pivot joints %zu, "
-          "odometry cannot be updated. Ending current update loop early.",
+          C_INFO "Failed to get feedback from hardware interfaces for left/right pivot joints %zu, "
+          "odometry cannot be updated. Ending current update loop early." C_END,
           pos);
         return controller_interface::return_type::OK;
       }
@@ -272,8 +280,8 @@ controller_interface::return_type NovaDriveControllerBase::update(
       {
         RCLCPP_ERROR(
           logger,
-          "Received NaN feedback for left/right pivot joints %zu, odometry cannot be updated. "
-          "Ending current update loop early.",
+           C_ERROR "Received NaN feedback for left/right pivot joints %zu, odometry cannot be updated. "
+          "Ending current update loop early." C_END,
           pos);
         return controller_interface::return_type::ERROR;
       }
@@ -298,7 +306,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
         cmds.right_drive_speeds[pos] / base_params_->wheel_radius,
         encoded_pos(pos, JointSide::RIGHT, JointType::DRIVE)))
     {
-      RCLCPP_ERROR(logger, "Failed to set drive command values for position %zu.", pos);
+      RCLCPP_ERROR(logger, C_ERROR "Failed to set drive command values for position %zu." C_END, pos);
       return controller_interface::return_type::ERROR;
     }
   }
@@ -311,7 +319,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
       !hwif_wrapper_->set_value(
         cmds.right_pivot_positions[pos], encoded_pos(pos, JointSide::RIGHT, JointType::PIVOT)))
     {
-      RCLCPP_ERROR(logger, "Failed to set pivot command values for position %zu.", pos);
+      RCLCPP_ERROR(logger, C_ERROR "Failed to set pivot command values for position %zu." C_END, pos);
       return controller_interface::return_type::ERROR;
     }
   }
@@ -342,28 +350,28 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
   if (base_param_listener_->is_old(*base_params_))
   {
     *base_params_ = base_param_listener_->get_params();
-    RCLCPP_INFO(logger, "Base parameters were updated");
+    RCLCPP_INFO(logger,  C_INFO "Base parameters were updated" C_END);
   }
   update_params();
 
   if (base_params_->left_drive_names.size() != base_params_->right_drive_names.size())
   {
     RCLCPP_ERROR(
-      logger, "The number of left wheels [%zu] and the number of right wheels [%zu] are different",
+      logger, C_ERROR "The number of left wheels [%zu] and the number of right wheels [%zu] are different" C_END,
       base_params_->left_drive_names.size(), base_params_->right_drive_names.size());
     return controller_interface::CallbackReturn::ERROR;
   }
 
   if (base_params_->left_drive_names.empty())
   {
-    RCLCPP_ERROR(logger, "Wheel names parameters are empty!");
+    RCLCPP_ERROR(logger, C_ERROR "Wheel names parameters are empty!" C_END);
     return controller_interface::CallbackReturn::ERROR;
   }
 
   if (base_params_->left_pivot_names.size() != 2 || base_params_->right_pivot_names.size() != 2)
   {
     RCLCPP_ERROR(
-      logger, "Expected exactly two pivots per side, instead got %zu left and %zu right pivots",
+      logger, C_ERROR "Expected exactly two pivots per side, instead got %zu left and %zu right pivots" C_END,
       base_params_->left_pivot_names.size(), base_params_->right_pivot_names.size());
     return controller_interface::CallbackReturn::ERROR;
   }
@@ -408,20 +416,19 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
   // Initialise twist subscriber
   twist_subscriber_ = get_node()->create_subscription<TwistStamped>(
     DEFAULT_COMMAND_TOPIC_, rclcpp::QoS(1).best_effort(),
-    [this](const std::shared_ptr<TwistStamped> msg) -> void
+    [this, logger](const std::shared_ptr<TwistStamped> msg) -> void
     {
       if (!is_active_)
       {
-        RCLCPP_WARN_ONCE(
-          get_node()->get_logger(), "Can't accept new commands, subscriber is inactive");
+        RCLCPP_WARN_ONCE(logger, C_WARN "Can't accept new commands, subscriber is inactive" C_END);
         return;
       }
       if ((msg->header.stamp.sec == 0) && (msg->header.stamp.nanosec == 0))
       {
         RCLCPP_WARN_ONCE(
-          get_node()->get_logger(),
-          "Received TwistStamped with zero timestamp, setting it to current "
-          "time, this message will only be shown once");
+          logger,
+          C_WARN "Received TwistStamped with zero timestamp, setting it to current "
+          "time, this message will only be shown once" C_END);
         msg->header.stamp = get_node()->get_clock()->now();
       }
 
@@ -437,9 +444,9 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
       else
       {
         RCLCPP_WARN(
-          get_node()->get_logger(),
-          "Ignoring the received message (timestamp %.10f) because it is older than "
-          "the current time by %.10f seconds, which exceeds the allowed timeout (%.4f)",
+          logger,
+          C_WARN "Ignoring the received message (timestamp %.10f) because it is older than "
+          "the current time by %.10f seconds, which exceeds the allowed timeout (%.4f)" C_END,
           rclcpp::Time(msg->header.stamp).seconds(), current_time_diff.seconds(),
           cmd_vel_receive_timeout_.seconds());
       }
@@ -451,6 +458,8 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_configure(
 controller_interface::CallbackReturn NovaDriveControllerBase::on_activate(
   const rclcpp_lifecycle::State&)
 {
+  auto logger = get_node()->get_logger();
+
   // Configure joints
   std::vector<Joint> joints;
   for (size_t pos = 0; pos < wheels_per_side_; ++pos)
@@ -478,13 +487,13 @@ controller_interface::CallbackReturn NovaDriveControllerBase::on_activate(
 
   if (!hwif_wrapper_->configure_joint_handles(joints, base_params_->open_loop))
   {
-    RCLCPP_ERROR(get_node()->get_logger(), "Error configuring drives and pivots");
+    RCLCPP_ERROR(logger,  C_ERROR "Error configuring drives and pivots" C_END);
     return controller_interface::CallbackReturn::ERROR;
   }
 
   is_active_ = true;
 
-  RCLCPP_INFO(get_node()->get_logger(), "Subscriber and publisher are now active.");
+  RCLCPP_INFO(logger, C_SUCCESS "Subscriber and publisher are now active." C_END);
   return controller_interface::CallbackReturn::SUCCESS;
 }
 

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -181,16 +181,16 @@ controller_interface::return_type NovaDriveControllerBase::update(
     {
       RCLCPP_WARN_THROTTLE(
         logger, *get_node()->get_clock(), cmd_vel_command_timeout_.seconds() * 1000,
-        "The last received command is %.10f seconds old, which exceeds the allowed timeout of "
-        "%.4f seconds. Publishing zero commands.",
+        "The last received command is %.2f seconds old, which exceeds the allowed timeout of "
+        "%.2f seconds. Publishing zero commands.",
         age_of_last_command.seconds(), cmd_vel_command_timeout_.seconds());
     }
     else if (!disconnected_)
     {
       disconnected_ = true;
       RCLCPP_ERROR(
-        logger, "The last received command is %.10f seconds old, which exceeds the connection timeout of "
-                "%.4f seconds. Connection to the command publisher is assumed to be lost, no further warnings "
+        logger, "The last received command is %.2f seconds old, which exceeds the connection timeout of "
+                "%.2f seconds. Connection to the command publisher is assumed to be lost, no further warnings "
                 "will be issued.",
         age_of_last_command.seconds(), connection_timeout_.seconds());
     }
@@ -201,7 +201,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
     {
       disconnected_ = false;
       RCLCPP_INFO(logger, "Connection has been restored! (Received a new command after not receiving any "
-                          "for > %.4f seconds)", connection_timeout_.seconds());
+                          "for > %.2f seconds)", connection_timeout_.seconds());
     }
 
     cmds = twist_to_commands(command_msg_ptr->twist, base_params_->autonomous_mode, period);

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.cpp
@@ -41,6 +41,7 @@ namespace nova_drive_controller_base
 using namespace nova_controller_common;
 using controller_interface::interface_configuration_type;
 using controller_interface::InterfaceConfiguration;
+using geometry_msgs::msg::Twist;
 using geometry_msgs::msg::TwistStamped;
 using hardware_interface::HW_IF_POSITION;
 using hardware_interface::HW_IF_VELOCITY;
@@ -174,13 +175,7 @@ controller_interface::return_type NovaDriveControllerBase::update(
   const auto age_of_last_command = time - last_received_time_;
   if (age_of_last_command > cmd_vel_command_timeout_)
   {
-    cmds.linear_velocity_x = 0.0;
-    cmds.linear_velocity_y = 0.0;
-    cmds.angular_velocity = 0.0;
-    cmds.left_drive_speeds.assign(wheels_per_side_, 0.0);
-    cmds.right_drive_speeds.assign(wheels_per_side_, 0.0);
-    cmds.left_pivot_positions.assign(PIVOTS_PER_SIDE_, 0.0);
-    cmds.right_pivot_positions.assign(PIVOTS_PER_SIDE_, 0.0);
+    cmds = twist_to_commands(Twist(), base_params_->autonomous_mode, period);
   }
   else
   {

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -109,9 +109,11 @@ nova_drive_controller_base:
     default_value: 999.0 # Seconds
     description: "Timeout to receive cmd_vel commands from base."
 
+  # Set to a higher value to be more lenient towards transient connection dropouts,
+  # however this also means the rover will take longer to stop when connection is truly lost.
   cmd_vel_command_timeout:
     type: double
-    default_value: 0.5 # Seconds
+    default_value: 1.0 # Seconds; teleop publishes at 50Hz i.e. every 0.02 seconds
     description: "Timeout since last commanded velocity from cmd_vel."
 
   publish_commanded_velocities:

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -113,7 +113,7 @@ nova_drive_controller_base:
   # but the rover will take longer to stop when connection is truly lost.
   cmd_vel_command_timeout:
     type: double
-    default_value: 0.1 # Seconds; teleop publishes at 50Hz i.e. every 0.02 seconds
+    default_value: 0.1 # Seconds; teleop publishes at 20 Hz i.e. every 0.02 seconds
     description: "Timeout since last commanded velocity from cmd_vel."
 
   connection_timeout:

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -116,6 +116,13 @@ nova_drive_controller_base:
     default_value: 0.1 # Seconds; teleop publishes at 50Hz i.e. every 0.02 seconds
     description: "Timeout since last commanded velocity from cmd_vel."
 
+  connection_timeout:
+    type: double
+    default_value: 2.0 # Seconds
+    description: >
+      After no commands have been received for this duration, assume connection to the
+      command publisher has been lost.
+
   publish_commanded_velocities:
     type: bool
     default_value: false

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -109,11 +109,11 @@ nova_drive_controller_base:
     default_value: 999.0 # Seconds
     description: "Timeout to receive cmd_vel commands from base."
 
-  # Set to a higher value to be more lenient towards transient connection dropouts,
-  # however this also means the rover will take longer to stop when connection is truly lost.
+  # Higher values are more lenient towards transient connection dropouts,
+  # but the rover will take longer to stop when connection is truly lost.
   cmd_vel_command_timeout:
     type: double
-    default_value: 1.0 # Seconds; teleop publishes at 50Hz i.e. every 0.02 seconds
+    default_value: 0.1 # Seconds; teleop publishes at 50Hz i.e. every 0.02 seconds
     description: "Timeout since last commanded velocity from cmd_vel."
 
   publish_commanded_velocities:

--- a/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
+++ b/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
@@ -15,7 +15,7 @@
  *  - client:     /diff_drive_controller/set_parameters    [rcl_interfaces/srv/SetParameters]
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * PACKAGE:   teleop_drive_joy
- * AUTHORS:	  Kabi, Terry Tian
+ * AUTHORS:	  Kabi, Terry Tian, Jonathan Jia
  * CREATION:  2024
  * EDITED:    2025
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -270,7 +270,6 @@ private:
 
   Params params_;
   sensor_msgs::msg::Joy::SharedPtr joy_msg_;
-  bool sent_lock_msg_;
   bool locked_;
   uint8_t locked_reason_;
   DriveMode drive_mode_;

--- a/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
+++ b/src/ros/rover/drive/teleop_drive_joy/include/teleop_drive_joy/teleop_drive_joy.hpp
@@ -172,6 +172,11 @@ private:
   void map_button_callbacks();
 
   /**
+   * @brief Callback function for main publish loop timer.
+   */
+  void timer_callback();
+  
+  /**
    * @brief Callback function for joystick messages.
    * @param joy_msg Shared pointer to the joystick message.
    */
@@ -246,6 +251,7 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::JoyFeedback>::SharedPtr joy_feedback_pub_;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_state_sub_;
   rclcpp::Subscription<blcmd_interfaces::msg::BLCMDLog>::SharedPtr blcmd_log_sub_;
+  rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr
     switch_controller_client_;
@@ -263,6 +269,7 @@ private:
   bool autolock_override_trigger;
 
   Params params_;
+  sensor_msgs::msg::Joy::SharedPtr joy_msg_;
   bool sent_lock_msg_;
   bool locked_;
   uint8_t locked_reason_;

--- a/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
+++ b/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
@@ -12,6 +12,7 @@ def launch_setup(context, *args, **kwargs):
     device_name = LaunchConfiguration('device_name')
     joy_vel = LaunchConfiguration('joy_vel')
     teleop_params = LaunchConfiguration('teleop_params')
+    log_level = LaunchConfiguration('log_level')
 
     return [
         # Add Nodes
@@ -25,6 +26,7 @@ def launch_setup(context, *args, **kwargs):
                  'deadzone': 0.1,
                  'autorepeat_rate': 20.0} | {'device_name': device_name} if device_name else {}
             ],
+            arguments = ['--ros-args', '--log-level', log_level],
         ),
         Node(
             package='teleop_drive_joy',
@@ -34,6 +36,7 @@ def launch_setup(context, *args, **kwargs):
             remappings=[
                 ('/cmd_vel', joy_vel),
             ],
+            arguments = ['--ros-args', '--log-level', log_level],
         ),
     ]
 
@@ -66,6 +69,11 @@ def generate_launch_description():
         DeclareLaunchArgument(
             name='joy_vel', 
             default_value='cmd_vel'
+        ),
+        DeclareLaunchArgument(
+            name='log_level',
+            default_value='info',
+            description='Logging level for all nodes launched by this file',
         ),
     ]
 

--- a/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
+++ b/src/ros/rover/drive/teleop_drive_joy/launch/teleop.launch.py
@@ -1,6 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import OpaqueFunction, DeclareLaunchArgument
-from launch.substitutions import LaunchConfiguration, PythonExpression, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, IfElseSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 from os.path import expanduser
@@ -41,11 +41,11 @@ def launch_setup(context, *args, **kwargs):
     ]
 
 def generate_launch_description():
-    teleop_drive_dir = PythonExpression([
-        '"', PathJoinSubstitution([expanduser("~") + '/nova/src/ros/rover/drive/teleop_drive_joy']),
-        '" if "', LaunchConfiguration('local'), '".lower() == "true" else "',
-        FindPackageShare('teleop_drive_joy'), '"'
-    ])
+    local = LaunchConfiguration('local')
+    teleop_drive_dir = IfElseSubstitution(local,
+        PathJoinSubstitution([expanduser("~") + '/nova/src/ros/rover/drive/teleop_drive_joy']),
+        FindPackageShare('teleop_drive_joy')
+    )
 
     declared_arguments = [
         DeclareLaunchArgument(

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -3,7 +3,7 @@
  * Monash Nova Rover Team
  *
  * PACKAGE: teleop_drive_joy
- * AUTHORS:	Kabi, Terry Tian
+ * AUTHORS:	Kabi, Terry Tian, Jonathan Jia
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  */
 
@@ -32,7 +32,6 @@ namespace teleop_drive_joy
 
 TeleopDriveJoy::TeleopDriveJoy(const rclcpp::NodeOptions& options)
   : Node("teleop_drive_joy_node", options)
-  , sent_lock_msg_(false)
   , locked_(true)
   , locked_reason_(drive_interfaces::msg::DriveInfo::START_LOCKED)
   , drive_mode_(DriveMode::PIVOT)
@@ -422,19 +421,13 @@ void TeleopDriveJoy::send_drive_command(const sensor_msgs::msg::Joy::SharedPtr j
   cmd_vel_msg->header.stamp = this->now();
 
   cmd_vel_pub_->publish(std::move(cmd_vel_msg));
-
-  sent_lock_msg_ = false;
 }
 
 void TeleopDriveJoy::send_halt_command()
 {
-  if (sent_lock_msg_) return;
-
   auto cmd_vel_msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
   cmd_vel_msg->header.stamp = this->now();
   cmd_vel_pub_->publish(std::move(cmd_vel_msg));
-
-  sent_lock_msg_ = true;
 }
 
 void TeleopDriveJoy::switch_controller(const DriveMode requested_control_mode)

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -141,7 +141,8 @@ void TeleopDriveJoy::initialize_interfaces()
 {
   joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
     params_.input_topic, rclcpp::QoS(10), std::bind(&TeleopDriveJoy::joy_callback, this, _1));
-  cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(params_.output_topic, 50);
+  cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(params_.output_topic,
+    rclcpp::QoS(10).best_effort());
 
   switch_controller_client_ = this->create_client<controller_manager_msgs::srv::SwitchController>(
     "/controller_manager/switch_controller");

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -142,7 +142,9 @@ void TeleopDriveJoy::initialize_interfaces()
   joy_sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
     params_.input_topic, rclcpp::QoS(10), std::bind(&TeleopDriveJoy::joy_callback, this, _1));
   cmd_vel_pub_ = this->create_publisher<geometry_msgs::msg::TwistStamped>(params_.output_topic,
-    rclcpp::QoS(10).best_effort());
+    rclcpp::QoS(1));
+  timer_ = this->create_wall_timer(std::chrono::milliseconds(1000 / params_.teleop_frequency),
+    std::bind(&TeleopDriveJoy::timer_callback, this));
 
   switch_controller_client_ = this->create_client<controller_manager_msgs::srv::SwitchController>(
     "/controller_manager/switch_controller");
@@ -283,11 +285,16 @@ void TeleopDriveJoy::map_button_callbacks()
   };
 }
 
-void TeleopDriveJoy::joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
+void TeleopDriveJoy::timer_callback()
 {
+  if (!connected_)
+  {
+    return;
+  }
+
   update_params();
-  handle_button_callbacks(joy_msg);
-  handle_axis_callbacks(joy_msg);
+  handle_button_callbacks(joy_msg_);
+  handle_axis_callbacks(joy_msg_);
 
   if (params_.autolock_enable)
   {
@@ -296,13 +303,18 @@ void TeleopDriveJoy::joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg
 
   if (!locked_)
   {
-    send_drive_command(joy_msg);
+    send_drive_command(joy_msg_);
   }
   else
   {
     send_halt_command();
   }
+}
 
+void TeleopDriveJoy::joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
+{
+  joy_msg_ = joy_msg;
+  
   // update connection status
   connection_timer_->reset();
   set_connected(true);

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.yaml
@@ -2,6 +2,11 @@
 # This YAML will be converted to teleop_drive_joy_parameters.hpp upon build
 # Look here for docs about this YAML : https://github.com/PickNikRobotics/generate_parameter_library
 teleop_drive_joy:
+  teleop_frequency:
+    type: int
+    default_value: 20
+    description: "Frequency (in Hz) at which teleop publishes commands"
+
   input_topic:
     type: string
     default_value: "/drive/joy"

--- a/src/ros/rover/rover_description/banksia/urdf/ros2_control.xacro
+++ b/src/ros/rover/rover_description/banksia/urdf/ros2_control.xacro
@@ -12,7 +12,7 @@
                     <param name="resolver_reduction">1.33333333333</param>
                     <param name="clock_rate">100000000</param>
                     <param name="revolution_pulses">8192</param>
-                    <param name="min_interval">122</param>
+                    <param name="min_interval">233</param>
                     <param name="gear_ratio">15.0</param>
                     <param name="mock">true</param>
                     <param name="reversed">true</param>
@@ -58,7 +58,7 @@
                     <param name="resolver_reduction">1.33333333333</param>
                     <param name="clock_rate">100000000</param>
                     <param name="revolution_pulses">8192</param>
-                    <param name="min_interval">122</param>
+                    <param name="min_interval">233</param>
                     <param name="gear_ratio">15.0</param>
                     <param name="mock">true</param>
                     <param name="reversed">true</param>
@@ -105,7 +105,7 @@
                     <param name="resolver_reduction">1.33333333333</param>
                     <param name="clock_rate">100000000</param>
                     <param name="revolution_pulses">8192</param>
-                    <param name="min_interval">122</param>
+                    <param name="min_interval">233</param>
                     <param name="gear_ratio">15.0</param>
 	                <param name="mock">true</param>
                     <param name="reversed">false</param>
@@ -151,7 +151,7 @@
                     <param name="resolver_reduction">1.33333333333</param>
                     <param name="clock_rate">100000000</param>
                     <param name="revolution_pulses">8192</param>
-                    <param name="min_interval">122</param>
+                    <param name="min_interval">233</param>
                     <param name="gear_ratio">15.0</param>
 	                <param name="mock">true</param>
                     <param name="reversed">false</param>


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Fix stopping instantly when connection is lost and be more lenient towards transient connection dropouts.

To be merged when tested IRL!

Edit:
Okay I ended up applying some other improvements/fixes on this branch so there's a couple more changes than originally anticipated :sweat_smile: 

Additional changes are listed in the changelogs section :arrow_down: 

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Don't bypass derived controller limiters when sending zero commands after losing connection
- Stricter command timeout at 0.1 (can be adjusted after further testing at long range with unstable connections)
- Toned down speed limits in `nova.yaml` and `auto.yaml` after the 2.4 multiplier removal in the firmware
- Changed min_interval in `ros2_control.xacro` to 233
- Improved logging in drive controllers; it's now coloured and tells you when connection is lost (both temporarily and for extended periods of time)
- Changed QoS profile for drive controllers and teleop
  - Best effort with depth 1 for drive controllers makes sense and also seems to be fairly standard (it's what ackermann_steering_controller uses, which is not written by us)
  - Reliable with depth 1 for teleop, as it seems teleop generally uses reliable?
- **IMPORTANT** Decouple teleop_drive_joy's publishing from the publish rate of ros2 joy, this resolves the intermittent lag issue. Currently set the publish rate to 20 Hz
- Keep publishing zero commands when controller is locked, teleop should always be publishing unless the controller is physically disconnected

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

<img width="452" height="651" alt="image" src="https://github.com/user-attachments/assets/f39471a6-8243-4ce3-b2d4-23f0d1eb05e4" />

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->

```
# start vcan
can start vcan0

# launch drive
ros2 launch drive_bringup drive.launch.py

# launch teleop
ros2 launch teleop_drive_joy teleop.launch.py
```

<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->
