### PR TITLE
nixfiles: fastlivo2: don't make derevation depend on $HOME

### DIFF
--- a/nixfiles/packages/ros/fast-livo2/default.nix
+++ b/nixfiles/packages/ros/fast-livo2/default.nix
@@ -73,7 +73,8 @@ buildRosPackage {
   postPatch = ''
     # Change ROOT_DIR from FAST-LIVO2 to /home/user/.ros
     # Needed for saving .pcd files from FAST-LIVO2.
-    export USER_HOME_DIR=${builtins.getEnv "HOME"}
+    # TODO: patch it to get the $HOME env var at runtime
+    export USER_HOME_DIR=/home/nova
     sed -i CMakeLists.txt \
       -e 's@''${CMAKE_CURRENT_SOURCE_DIR}@$ENV{USER_HOME_DIR}/.ros@g'
 


### PR DESCRIPTION
not ideal to hard code this to /home/nova, but rn hydra builds a different derivation because its not nova building it so everyone has to build fastlivo themselves till someone manually copy closures each version to hydra.

<!--- Remove any prompt if irrelevant to your changes --->
gonna see if hydra builds this right
## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
