### PR TITLE
fix: auto cartographer map goals modal

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/AutoStatus.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/AutoStatus.tsx
@@ -8,14 +8,12 @@ import {RosTopic} from "../../../../ros/topics/rosTopic.ts";
 interface AutoStatusProps {
 }
 
-type ChipColor = "primary" | "secondary" | "warning" | "success" | "danger";
-
-const variants: [string, ChipColor, string][] = [
-  ["Idle", "primary", "border-blue-500"],
-  ["Traversing", "secondary", "border-purple-500"],
-  ["Searching", "warning", "border-yellow-500"],
-  ["Arrived Successfully", "success", "border-green-500"],
-  ["Arrived Unsuccessfully", "danger", "border-red-500"],
+const variants: [string, string, string][] = [
+  ["Idle", "border-[#3eb1cf]", "bg-[#3eb1cf]"],
+  ["Traversing", "border-primary", "bg-primary"],
+  ["Searching", "border-warning", "bg-warning"],
+  ["Arrived Successfully", "border-success", "bg-success"],
+  ["Arrived Unsuccessfully", "border-danger", "bg-danger"],
 ];
 
 export const AutoStatus : React.FC<AutoStatusProps> = () => {
@@ -27,7 +25,16 @@ export const AutoStatus : React.FC<AutoStatusProps> = () => {
   }, [bifrost]);
 
   return (
-    <Chip radius='md' size="lg" variant="dot" color={variants[autoStatus][1]} className={`h-10 border-2 ${variants[autoStatus][2]}`}>
+    <Chip
+      key={autoStatus}
+      radius='md'
+      size="lg"
+      variant="dot"
+      classNames={{
+        base: `h-10 border-3 ${variants[autoStatus][1]}`,
+        dot: variants[autoStatus][2]
+      }}
+    >
       {variants[autoStatus][0]}
     </Chip>
   )

--- a/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
@@ -58,8 +58,8 @@ export const CartographerGoalModal: React.FC<{
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (active.id !== over!.id) {
-      const oldIndex = points.findIndex((point) => point.name === active.id);
-      const newIndex = points.findIndex((point) => point.name === over!.id);
+      const oldIndex = selection.findIndex((p) => points[p].name === active.id);
+      const newIndex = selection.findIndex((p) => points[p].name === over!.id);
       setSelection(arrayMove(selection, oldIndex, newIndex));
     }
   };

--- a/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   DndContext,
   closestCenter,
   PointerSensor,
   useSensor,
   useSensors,
+  DragEndEvent,
 } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -40,20 +41,44 @@ export const CartographerGoalModal: React.FC<{
   isOpen: boolean;
   onClose: () => void;
 }> = ({ isOpen, onClose }) => {
-  const { points } = useSelector(
-    (state: RootState) => state.cartographerState
-  );
-
-  const [items, setItems] = useState<MapPoint[]>(
-    points.map((point) => ({ ...point, selected: false }))
-  );
-
+  const sensors = useSensors(useSensor(PointerSensor));
+  
   const serviceBifrost = useBifrost({
     service: RosService.CARTOGRAPHER_COMMAND,
   });
 
+
+  const { points } = useSelector(
+    (state: RootState) => state.cartographerState
+  );
+  
+  
+  const [selection, setSelection] = useState<number[]>([]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (active.id !== over!.id) {
+      const oldIndex = points.findIndex((point) => point.name === active.id);
+      const newIndex = points.findIndex((point) => point.name === over!.id);
+      setSelection(arrayMove(selection, oldIndex, newIndex));
+    }
+  };
+
+  const toggleSelection = (name: string) => {
+    const i = points.findIndex((v)=>v.name === name);
+    if (selection.includes(i)) {
+      setSelection((prev)=>prev.filter((v)=>v!==i))
+    } else {
+      setSelection((prev)=>[...prev, points.findIndex((v)=>v.name === name)])
+    }
+  };
+
+
+  if (!isOpen && selection.length > 0) setSelection([]);
+
+
   const sendCartographerPoints = () => {
-    const selected = items.filter((item) => item.selected);
+    const selected = selection.map((v)=>points[v]);
     const goals = selected.map((item) => ({
       latitude: item.lat,
       longitude: item.long,
@@ -62,30 +87,6 @@ export const CartographerGoalModal: React.FC<{
     console.log("calling service with:", { goals: goals, types: types });
     serviceBifrost.callService({ goals: goals, types: types } as IRosNovaInterfacesCartographerCommandRequest);
   };
-
-  const sensors = useSensors(useSensor(PointerSensor));
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleDragEnd = (event: any) => {
-    const { active, over } = event;
-    if (active.id !== over.id) {
-      const oldIndex = items.findIndex((item) => item.name === active.id);
-      const newIndex = items.findIndex((item) => item.name === over.id);
-      setItems(arrayMove(items, oldIndex, newIndex));
-    }
-  };
-
-  const toggleSelection = (name: string) => {
-    setItems((prevItems) =>
-      prevItems.map((item) =>
-        item.name === name ? { ...item, selected: !item.selected } : item
-      )
-    );
-  };
-
-  useEffect(() => {
-    setItems(points.map((point) => ({ ...point, selected: false })));
-  }, [isOpen, points]);
 
   const renderPoints = (points: MapPoint[], isSortable: boolean) => {
     return points.map((point) => (
@@ -107,7 +108,7 @@ export const CartographerGoalModal: React.FC<{
   const renderPointContent = (point: MapPoint) => (
     <div className="flex justify-between items-center">
       <Checkbox
-        isSelected={point.selected}
+        isSelected={selection.includes(points.indexOf(point))}
         onChange={() => toggleSelection(point.name)}
       >
         <span className="flex-shrink-0 font-bold">{point.name}</span>
@@ -136,8 +137,8 @@ export const CartographerGoalModal: React.FC<{
     </div>
   );
 
-  const selectedItems = items.filter((item) => item.selected);
-  const unselectedItems = items.filter((item) => !item.selected);
+  const selectedItems = selection.map((v)=>points[v])
+  const unselectedItems = points.filter((_, i) => !selection.includes(i));
 
   return (
     <Modal

--- a/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/auto/Cartographer/components/CartographerGoalModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffectEvent, useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -83,10 +83,9 @@ export const CartographerGoalModal: React.FC<{
     );
   };
 
-  // idk how to fix this linting error cause i dont get what this is meant to do @Felicity
-  useEffectEvent(() => {
+  useEffect(() => {
     setItems(points.map((point) => ({ ...point, selected: false })));
-  });
+  }, [isOpen, points]);
 
   const renderPoints = (points: MapPoint[], isSortable: boolean) => {
     return points.map((point) => (

--- a/src/ros/nova-gui/nova-gui/src/utils/NavigationRoutes.tsx
+++ b/src/ros/nova-gui/nova-gui/src/utils/NavigationRoutes.tsx
@@ -149,9 +149,9 @@ export const urcNavigationData: NavigationInterface = {
   ],
   ["Autonomous"]: [
     {
-      title: "Dashboard",
+      title: "Auto Cartographer",
       route: "/urc/autonomous-navigation",
-      icon: <Home />,
+      icon: <Map />,
     },
     {
       title: "Cameras",
@@ -161,7 +161,7 @@ export const urcNavigationData: NavigationInterface = {
     {
       title: "Simulation",
       route: "/urc/gazebo",
-      icon: <Home />,
+      icon: <Tv />,
     },
   ]
 };

--- a/src/ros/nova-gui/nova-gui/src/utils/NavigationRoutes.tsx
+++ b/src/ros/nova-gui/nova-gui/src/utils/NavigationRoutes.tsx
@@ -149,7 +149,7 @@ export const urcNavigationData: NavigationInterface = {
   ],
   ["Autonomous"]: [
     {
-      title: "Auto Cartographer",
+      title: "Cartographer",
       route: "/urc/autonomous-navigation",
       icon: <Map />,
     },


### PR DESCRIPTION
Linting Error Fix accidentally broke this feature so this PR is two fold.
The first commit changes auto homepage icon in side bar
Second commit undos the linting change which broke it
Third commit rewrites the modal so that redux state store and react state are separated which removes the linting error and keeps the functionality.

To test:
`gui-shell then `gui-link` then `gui-run` and navigate to localhost:5173/urc/autonomous-navigation
`tileserver`
`gui-rosbridge`

When goals are published you can observe the correct order in the console as it also logs to web console (F12 menu)
Selected points also reset when reopening modal
Points should update the modal as since points are part of redux state it will force a rerender through the library.

<!-- TAGS START -->
Tags for Notion Integration:
tag:nova-gui
<!-- TAGS END -->
