### PR TITLE
Gui Dev Shell

### DIFF
--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -168,6 +168,7 @@ in
           # GUI
           gui-serve = "~/Builds/master/bin/gui-serve 5173 && echo http://localhost:5173";
 
+          gui-dev-shell = "nova-shell -A pkgs.ros.nova-gui-dev-shell";
           gui-shell = "nova-shell -A pkgs.ros.nova-gui";
           gui-link = "ln -sf \"$ROS_TS_DEFINITIONS\" ~/nova/src/ros/nova-gui/nova-gui/src/ros/rosTypes.ts";
           gui-rosbridge = "~/Builds/master/bin/ros2 launch rosbridge_server rosbridge_websocket_launch.xml";

--- a/src/ros/nova-gui/default.nix
+++ b/src/ros/nova-gui/default.nix
@@ -1,5 +1,6 @@
 {
   rosPackages = pkgs: with pkgs; {
     nova-gui = callPackage ./nix/packages/gui { };
+    nova-gui-dev-shell = callPackage ./nix/packages/gui/dev-shell.nix { };
   };
 }

--- a/src/ros/nova-gui/nix/packages/gui/dev-shell.nix
+++ b/src/ros/nova-gui/nix/packages/gui/dev-shell.nix
@@ -1,0 +1,58 @@
+{ mkShell
+, config
+, nova-gui
+, pkgs
+}:
+
+# This shell is designed for use in development and it is assumed the developer will run the gui using yarn
+# If looking for a shell with the gui fully built, use the default.nix instead (e.g for gui-serve)
+
+let 
+
+gui = nova-gui.overrideAttrs(oldAttrs :{
+  # disable building of gui-serve to make it faster
+  postUnpack = "";
+  buildPhase = ''
+    runHook preBuild
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+    runHook postInstall
+  '';
+
+  # add path to node_modules to output to be used in dev shell
+  configurePhase = oldAttrs.configurePhase + ''
+    mkdir -p $out
+    echo $node_modules > $out/node_modules
+    echo $ROS_TS_DEFINITIONS > $out/ROS_TS_DEFINITIONS
+  '';
+
+  passthru.ROS_TS_DEFINITIONS = oldAttrs.ROS_TS_DEFINITIONS;
+});
+
+diff_ignore=''-x ".vite" -x ".vite-temp" -x "nova-gui"'';
+
+in
+
+mkShell {
+  preBuild = ''
+    echo "Entering GUI shell..."
+  '';
+  buildInputs = [ gui ];
+
+  shellHook = ''
+    if ! diff -rq $(cat ${gui}/node_modules) \${builtins.toString ../../../nova-gui/node_modules} ${diff_ignore} >/dev/null; then
+      echo "Copying nix-store gui modules $(cat ${gui}/node_modules) to ${builtins.toString ../../../nova-gui/node_modules}"
+      cp -rf $(cat ${gui}/node_modules) ${builtins.toString ../../../nova-gui}
+      chmod -R 777 ${builtins.toString ../../../nova-gui/node_modules}
+    else
+      echo "Node modules has not changed, skipping copy..."
+    fi
+
+    echo "Linking Typescript Definitions... "
+    ln -sf $(cat ${gui}/ROS_TS_DEFINITIONS) ${builtins.toString ../../../nova-gui/src/ros/rosTypes.ts}
+
+    echo -e "Done! Run \e[40m\e[1;93mgui-run\e[0m to run the GUI, or to change to nova-gui's directory run \e[40m\e[1;93mgui\e[0m"
+  '';
+}


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description
This creates a nix-shell for development in the GUI
It does the following steps, builds all dependencies of GUI
copies node_modules into your local repo (no more running yarn install after gui-shell)
automatically links ros-types to your local repo (no more running gui-link)

creates new alias to run it `gui-dev-shell`

This does not modify original gui default.nix so gui should work as expected as it is untouched
This script also does not build gui-serve so it should be faster than running traditional gui shell
<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Screenshots
<img width="1260" height="125" alt="image" src="https://github.com/user-attachments/assets/4fec1d1d-13f3-4724-8fa3-805da4098fbe" />

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## Steps to Test
`nova-shell -A pkgs.ros.nova-gui-dev-shell`
then try `gui-run`
gui should work as intended.
<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes
<img width="640" height="460" alt="image" src="https://github.com/user-attachments/assets/1f415a58-0648-43c1-ac0b-caf3665d8513" />
This is why this PR exists, its so heavy yet we pull it twice ;-;
<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:nova-gui;tag:nixfiles
<!-- TAGS END -->
