### PR TITLE
feat: drive improvements

### DIFF
--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -339,6 +339,16 @@ in
           # use this as `can_viewer can0` for example to get "-c can0"
           can-viewer = "can_viewer";
           can_viewer = "~/Builds/active/bin/can_viewer -i socketcan -c";
+
+          # Drive
+          reset-flw = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 1}"'';
+          reset-blw = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 2}"'';
+          reset-brw = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 3}"'';
+          reset-frw = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 4}"'';
+          reset-flp = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 5}"'';
+          reset-blp = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 6}"'';
+          reset-brp = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 7}"'';
+          reset-frp = ''~/Builds/active/bin/ros2 service call /blcmds/blcmd_reset blcmd_interfaces/srv/BLCMDReset "{type: 1, id: 8}"'';
         }
       ];
 

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveControlWidget/DriveControlWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveControlWidget/DriveControlWidget.tsx
@@ -16,6 +16,13 @@ export interface IDriveControlWidgetProps extends CardProps {}
  * originating from teleop drive. Also has functionality to toggle drive Autolock as well.
  */
 
+const lockedReasons: Record<number, string> = {
+  1: "Initial State",
+  2: "Lock Button Pressed",
+  3: "Excessive BLCMD Errors",
+  4: "Gamepad Disconnected",
+};
+
 const DriveControlWidget: React.FC<IDriveControlWidgetProps> = (
   props: IDriveControlWidgetProps) => {
 
@@ -31,23 +38,19 @@ const DriveControlWidget: React.FC<IDriveControlWidgetProps> = (
     connected: useSelector((state: RootState) => state.driveStore.connected),
   }
 
-  const lockedReasons: Record<number, string> = {
-    1: "Initial State",
-    2: "Lock Button Pressed",
-    3: "Excessive BLCMD Errors",
-    4: "Gamepad Disconnected",
-  };
-  const suppressLockedReasonToast = [1, 2];
-
   const [autolockOverride, setAutolockOverride] = useState(false);
   const currentLockedReason = lockedReasons[driveInfo.locked_reason] ?? "Reason Unknown";
 
-  // show toast when locked unexpectedly
+  // show toast when locked unexpectedly (this should be done in redux/bifrost instead)
   useEffect(() => {
+    const suppressLockedReasonToast = [1, 2];
+
     if (!suppressLockedReasonToast.includes(driveInfo.locked_reason) && driveInfo.locked) {
-      toast.error(`Drive Locked due to: ${currentLockedReason}`);
+      const toastId = toast.error(`Drive Locked due to: ${currentLockedReason}`);
+
+      return () => { toast.dismiss(toastId); };
     }
-  }, [driveInfo.locked_reason, driveInfo.locked])
+  }, [driveInfo.locked_reason, driveInfo.locked, currentLockedReason])
 
   // callback to toggle autolock override in teleop drive
   const onAutolockButtonPress = () => {

--- a/src/ros/nova-gui/nova-gui/src/components/drive/DriveControlWidget/DriveControlWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/drive/DriveControlWidget/DriveControlWidget.tsx
@@ -43,9 +43,11 @@ const DriveControlWidget: React.FC<IDriveControlWidgetProps> = (
   const currentLockedReason = lockedReasons[driveInfo.locked_reason] ?? "Reason Unknown";
 
   // show toast when locked unexpectedly
-  if (!suppressLockedReasonToast.includes(driveInfo.locked_reason) && driveInfo.locked) {
-    toast.error(`Drive Locked due to: ${currentLockedReason}`);
-  }
+  useEffect(() => {
+    if (!suppressLockedReasonToast.includes(driveInfo.locked_reason) && driveInfo.locked) {
+      toast.error(`Drive Locked due to: ${currentLockedReason}`);
+    }
+  }, [driveInfo.locked_reason, driveInfo.locked])
 
   // callback to toggle autolock override in teleop drive
   const onAutolockButtonPress = () => {

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
@@ -120,6 +120,7 @@ const urcScienceCams = [
 const driveCams = [
   CameraSerials.WHEEL_TELEMETRY,
   CameraSerials.DRIVE_TELEMETRY,
+  CameraSerials.DRIVE_CONTROL,
 ]
 
 const autoCams = [
@@ -228,7 +229,8 @@ export const urc_autonomous_views: CameraViewConfig[] = [
 
 export const urc_science_views: CameraViewConfig[] = [
   {
-    cameraSerials: [...mastCams, ...urcScienceCams, ...driveCams, CameraSerials.URC_ACTIVATED_NODES, CameraSerials.URC_SCIENCE_AUGER_DEPTH_SENSORS
+    cameraSerials: [...mastCams, ...urcScienceCams, ...driveCams.filter((driveCam) => driveCam != CameraSerials.DRIVE_CONTROL),
+      CameraSerials.URC_ACTIVATED_NODES, CameraSerials.URC_SCIENCE_AUGER_DEPTH_SENSORS, CameraSerials.DRIVE_CONTROL,
     ],
     viewTitle: "All Cams",
   },

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -152,4 +152,4 @@ blcmd_status_monitor:
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
-    check_pivot_zero_period: 60
+    check_pivot_zero_period: 30

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -141,7 +141,7 @@ ackermann_steering_controller:
 blcmd_status_monitor:
   ros__parameters:
     # auto blcmd reset parameters
-    enable_auto_blcmd_reset: false
+    enable_auto_blcmd_reset: true
     max_resets: 5
     reset_timeout: 5
     auto_reset_drive_blmcd_ids: [1, 2, 3, 4]

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -34,8 +34,9 @@ pivot_position_controller:
       - brp
       - frp
 
-joint_state_broadcaster:
+/drive/joint_state_broadcaster:
   ros__parameters:
+    update_rate: 20
     interfaces:
       ["position", "velocity",
        "effort"]
@@ -44,22 +45,24 @@ joint_state_broadcaster:
       ["blp", "brp", "flp", "frp",
       "blw", "brw", "flw", "frw"]
 
-    extra_joints:
-      ["chassis_to_left_leg",
-       "chassis_to_right_leg",
-        "chassis_to_diffbar",
-        "tl_ball_roll",
-        "tl_ball_pitch",
-        "tl_ball_yaw",
-        "tr_ball_roll",
-        "tr_ball_pitch",
-        "tr_ball_yaw",
-        "bl_ball_roll",
-        "bl_ball_pitch",
-        "bl_ball_yaw",
-        "br_ball_roll",
-        "br_ball_pitch",
-        "br_ball_yaw"]
+    #    I think this could be helpful if you need tf2 transforms
+    #    or visualization in RViz?
+    #    extra_joints:
+    #      ["chassis_to_left_leg",
+    #       "chassis_to_right_leg",
+    #        "chassis_to_diffbar",
+    #        "tl_ball_roll",
+    #        "tl_ball_pitch",
+    #        "tl_ball_yaw",
+    #        "tr_ball_roll",
+    #        "tr_ball_pitch",
+    #        "tr_ball_yaw",
+    #        "bl_ball_roll",
+    #        "bl_ball_pitch",
+    #        "bl_ball_yaw",
+    #        "br_ball_roll",
+    #        "br_ball_pitch",
+    #        "br_ball_yaw"]
     use_local_topics: false
     
 pivot_drive_controller:

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -147,8 +147,8 @@ blcmd_status_monitor:
     blcmd_zero_response_timeout: 3
     canbus: can0
     error_active_duration: 2
-    log_gate_driver_condition: false
     num_blcmds: 8
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
+    check_pivot_zero_period: 60

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -145,6 +145,7 @@ blcmd_status_monitor:
     auto_reset_pivot_blmcd_ids: [5, 6, 7, 8]
 
     blcmd_zero_response_timeout: 3
+    pivot_set_zero_delay: 3
     canbus: can0
     error_active_duration: 2
     num_blcmds: 8

--- a/src/ros/rover/drive/drive_bringup/params/auto.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/auto.yaml
@@ -152,4 +152,3 @@ blcmd_status_monitor:
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
-    check_pivot_zero_period: 30

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -147,6 +147,7 @@ blcmd_status_monitor:
     auto_reset_pivot_blmcd_ids: []
 
     blcmd_zero_response_timeout: 3
+    pivot_set_zero_delay: 3
     canbus: can0
     error_active_duration: 2
     num_blcmds: 8

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -34,8 +34,9 @@ pivot_position_controller:
       - brp
       - frp
 
-joint_state_broadcaster:
+/drive/joint_state_broadcaster:
   ros__parameters:
+    update_rate: 20
     interfaces:
        ["position", "velocity",
         "effort"]
@@ -44,22 +45,24 @@ joint_state_broadcaster:
       ["blp", "brp", "flp", "frp",
       "blw", "brw", "flw", "frw"]
 
-    extra_joints:
-      ["chassis_to_left_leg",
-       "chassis_to_right_leg",
-        "chassis_to_diffbar",
-        "tl_ball_roll",
-        "tl_ball_pitch",
-        "tl_ball_yaw",
-        "tr_ball_roll",
-        "tr_ball_pitch",
-        "tr_ball_yaw",
-        "bl_ball_roll",
-        "bl_ball_pitch",
-        "bl_ball_yaw",
-        "br_ball_roll",
-        "br_ball_pitch",
-        "br_ball_yaw"]
+#    I think this could be helpful if you need tf2 transforms
+#    or visualization in RViz?
+#    extra_joints:
+#      ["chassis_to_left_leg",
+#       "chassis_to_right_leg",
+#        "chassis_to_diffbar",
+#        "tl_ball_roll",
+#        "tl_ball_pitch",
+#        "tl_ball_yaw",
+#        "tr_ball_roll",
+#        "tr_ball_pitch",
+#        "tr_ball_yaw",
+#        "bl_ball_roll",
+#        "bl_ball_pitch",
+#        "bl_ball_yaw",
+#        "br_ball_roll",
+#        "br_ball_pitch",
+#        "br_ball_yaw"]
     use_local_topics: false
     
 pivot_drive_controller:

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -154,4 +154,3 @@ blcmd_status_monitor:
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
-    check_pivot_zero_period: 30

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -149,8 +149,8 @@ blcmd_status_monitor:
     blcmd_zero_response_timeout: 3
     canbus: can0
     error_active_duration: 2
-    log_gate_driver_condition: false
     num_blcmds: 8
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
+    check_pivot_zero_period: 60

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -154,4 +154,4 @@ blcmd_status_monitor:
     output_max_frequency: 1
     publish_log_max_frequency: 10
     publish_status_frequency: 2
-    check_pivot_zero_period: 60
+    check_pivot_zero_period: 30

--- a/src/ros/rover/drive/drive_bringup/params/nova.yaml
+++ b/src/ros/rover/drive/drive_bringup/params/nova.yaml
@@ -147,7 +147,7 @@ blcmd_status_monitor:
     max_resets: 5
     reset_timeout: 5
     auto_reset_drive_blmcd_ids: [1, 2, 3, 4]
-    auto_reset_pivot_blmcd_ids: []
+    auto_reset_pivot_blmcd_ids: [5, 6, 7, 8]
 
     blcmd_zero_response_timeout: 3
     pivot_set_zero_delay: 3

--- a/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
+++ b/src/ros/rover/drive/drive_controllers/nova_drive_controller_base/src/nova_drive_controller_base.yaml
@@ -113,7 +113,7 @@ nova_drive_controller_base:
   # but the rover will take longer to stop when connection is truly lost.
   cmd_vel_command_timeout:
     type: double
-    default_value: 0.3 # Seconds; teleop publishes at 20 Hz i.e. every 0.02 seconds
+    default_value: 1.0 # Seconds; teleop publishes at 20 Hz i.e. every 0.02 seconds
     description: "Timeout since last commanded velocity from cmd_vel."
 
   connection_timeout:

--- a/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
+++ b/src/ros/rover/drive/teleop_drive_joy/src/teleop_drive_joy.cpp
@@ -614,8 +614,9 @@ void TeleopDriveJoy::blcmd_log_callback(const blcmd_interfaces::msg::BLCMDLog::S
 
   RCLCPP_DEBUG(this->get_logger(), "Processing blcmd log message from %hhu of type %hhu", blcmd_log_msg->id, blcmd_log_msg->type);
 
-  // update if log message was an error
-  if (blcmd_log_msg->type == blcmd_interfaces::msg::BLCMDLog::ERROR)
+  // update if log message was an error or gate drive fault
+  if (blcmd_log_msg->type == blcmd_interfaces::msg::BLCMDLog::ERROR
+    or blcmd_log_msg->type == blcmd_interfaces::msg::BLCMDLog::GATE_DRIVER_CONDITION)
   {
     int blcmd_id { blcmd_log_msg->id };
 

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -26,6 +26,7 @@ from rclpy.duration import Duration
 import jcan
 from collections.abc import Callable
 from itertools import chain
+from time import sleep
 
 # import custom messages
 from blcmd_interfaces.msg import BLCMDStatus, BLCMDStatusArray, BLCMDLog
@@ -98,7 +99,7 @@ class BLCMDStatusMonitor(Node):
         self.output_period = 1 / int(self.declare_parameter("output_max_frequency", 1).value) # in logs per second
         self.publish_log_period = 1 / int(self.declare_parameter("publish_log_max_frequency", 10).value) # in logs per second
         self.publish_status_period = 1 / int(self.declare_parameter("publish_status_frequency", 2).value) # in blcmd statuses per second
-        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 1).value # in seconds between checks
+        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 60).value # in seconds between checks
 
         # ignoring the numbers provided by the gate driver condition errors as they seem unreliable/unused atm
         self.ignore_gate_driver_condition_error_number = self.declare_parameter("ignore_gate_driver_condition_error_number", True).value
@@ -143,6 +144,9 @@ class BLCMDStatusMonitor(Node):
         # workaround required due to inability to call bus.send in a can callback
         self.deferred_functions: list[Callable[[], None]] = []
 
+        # delay after resetting pivot blcmd before setting zero position to previous value
+        self.pivot_set_zero_delay = self.declare_parameter("pivot_set_zero_delay", 3).value # in seconds
+
         #create reset_time variable to prevent multiple resets in a short time
         self.reset_time = self.get_clock().now()
 
@@ -166,6 +170,25 @@ class BLCMDStatusMonitor(Node):
         #create timers
         self.run_callbacks_timer = self.create_timer(0.01, self.run_callbacks)
         self.publish_status_timer = self.create_timer(self.publish_status_period, self.publish_blcmd_status)
+        self.pivot_set_zero_delay_timers = {}
+        for pivot_id in self.pivot_blcmd_ids:
+            def set_pivot_zero(id=pivot_id):
+                if self.pivot_zeros[id] is None:
+                    self.get_logger().error(f'Did not set zero position for pivot BLCMD {id} as a zero position was never received from it')
+                    return
+
+                self.bus.send(
+                    jcan.Frame(id=0x00A | (id << 4), data=[
+                        0xf,
+                        *self.pivot_zeros[id]
+                    ])
+                )
+
+                self.pivot_set_zero_delay_timers[id].cancel()
+
+            self.pivot_set_zero_delay_timers[pivot_id] = self.create_timer(self.pivot_set_zero_delay,
+                                                                           set_pivot_zero,
+                                                                           autostart=False)
 
         # regularly query pivots for zero positions (which are verified against stored initial zero)
         # to ensure that there is no funny business going on
@@ -303,12 +326,7 @@ class BLCMDStatusMonitor(Node):
                 )
 
                 # set pivot zero
-                self.bus.send(
-                    jcan.Frame(id=0x00A | (blcmd_id << 4), data=[
-                        0xf,
-                        *self.pivot_zeros[blcmd_id]
-                    ])
-                )
+                self.pivot_set_zero_delay_timers[blcmd_id].reset()
 
                 self.blcmd_pivot_reset_times[blcmd_id] = None
 

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -98,8 +98,8 @@ class BLCMDStatusMonitor(Node):
         self.publish_log_period = 1 / int(self.declare_parameter("publish_log_max_frequency", 10).value) # in logs per second
         self.publish_status_period = 1 / int(self.declare_parameter("publish_status_frequency", 2).value) # in blcmd statuses per second
 
-        # disabled by default as there seems to be issues with these messages rn
-        self.log_gate_driver_condition = self.declare_parameter("log_gate_driver_condition", False).value
+        # ignoring the numbers provided by the gate driver condition errors as they seem unreliable/unused atm
+        self.ignore_gate_driver_condition_error_number = self.declare_parameter("ignore_gate_driver_condition_error_number", True).value
 
         # params used to determine BLCMDStatus (i.e. keep track of blcmd error states so they can be published)
         self.blcmd_statuses = [BLCMDStatus(id=i+1) for i in range(self.get_parameter("num_blcmds").value)]
@@ -401,16 +401,13 @@ class BLCMDStatusMonitor(Node):
 
             # gate driver condition
             elif frame.data[0] == 3:
-
-                # don't log if not enabled
-                if not self.log_gate_driver_condition:
-                    return
-
                 data = frame.data[1]
 
                 # message sequence ended; output/publish log
-                if data == 0xFF:
-                    if len(self.gate_driver_registers) > 0:
+                if data == 0xFF or self.ignore_gate_driver_condition_error_number:
+                    if self.ignore_gate_driver_condition_error_number:
+                        gate_driver_condition_messsage = "Gate driver fault"
+                    elif len(self.gate_driver_registers) > 0:
                         gate_driver_condition_messsage = f"Gate driver fault on registers {self.gate_driver_registers}"
                     else:
                         gate_driver_condition_messsage = f"Gate driver fault (but no registers were received)"

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -98,7 +98,7 @@ class BLCMDStatusMonitor(Node):
         self.output_period = 1 / int(self.declare_parameter("output_max_frequency", 1).value) # in logs per second
         self.publish_log_period = 1 / int(self.declare_parameter("publish_log_max_frequency", 10).value) # in logs per second
         self.publish_status_period = 1 / int(self.declare_parameter("publish_status_frequency", 2).value) # in blcmd statuses per second
-        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 1).value # in minutes between checks
+        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 1).value # in seconds between checks
 
         # ignoring the numbers provided by the gate driver condition errors as they seem unreliable/unused atm
         self.ignore_gate_driver_condition_error_number = self.declare_parameter("ignore_gate_driver_condition_error_number", True).value
@@ -170,7 +170,7 @@ class BLCMDStatusMonitor(Node):
         # regularly query pivots for zero positions (which are verified against stored initial zero)
         # to ensure that there is no funny business going on
         if self.check_pivot_zero_period > 0:
-            self.check_pivot_zero_timer = self.create_timer(self.check_pivot_zero_period * 60, self.check_all_pivot_blcmd_zeros)
+            self.check_pivot_zero_timer = self.create_timer(self.check_pivot_zero_period, self.check_all_pivot_blcmd_zeros)
 
         #open the can bus
         self.bus.open(self.get_parameter("canbus").value)

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -25,6 +25,7 @@ from rclpy.time import Time
 from rclpy.duration import Duration
 import jcan
 from collections.abc import Callable
+from itertools import chain
 
 # import custom messages
 from blcmd_interfaces.msg import BLCMDStatus, BLCMDStatusArray, BLCMDLog
@@ -97,6 +98,7 @@ class BLCMDStatusMonitor(Node):
         self.output_period = 1 / int(self.declare_parameter("output_max_frequency", 1).value) # in logs per second
         self.publish_log_period = 1 / int(self.declare_parameter("publish_log_max_frequency", 10).value) # in logs per second
         self.publish_status_period = 1 / int(self.declare_parameter("publish_status_frequency", 2).value) # in blcmd statuses per second
+        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 1).value # in minutes between checks
 
         # ignoring the numbers provided by the gate driver condition errors as they seem unreliable/unused atm
         self.ignore_gate_driver_condition_error_number = self.declare_parameter("ignore_gate_driver_condition_error_number", True).value
@@ -151,25 +153,31 @@ class BLCMDStatusMonitor(Node):
         #initialise zero positions
         self.pivot_zeros = dict.fromkeys(self.auto_reset_pivot_blmcd_ids, None)
 
-        #add callbacks for each blcmd
-        for i in range(self.num_blcmds):
-            self.bus.add_callback(0x400 | (i + 1) << 4, self.get_callback(i))
-            self.bus.add_callback(0x409 | (i + 1) << 4, self.get_reset_pivot_blcmd_callback(i+1))
+        #add callbacks
+
+        for i in chain(self.drive_blcmd_ids, self.pivot_blcmd_ids):
+
+            # i-1 is for compatibility with legacy code
+            self.bus.add_callback(0x400 | i << 4, self.get_callback(i-1))
+
+        for i in self.pivot_blcmd_ids:
+            self.bus.add_callback(0x409 | i << 4, self.get_reset_pivot_blcmd_callback(i))
 
         #create timers
         self.run_callbacks_timer = self.create_timer(0.01, self.run_callbacks)
         self.publish_status_timer = self.create_timer(self.publish_status_period, self.publish_blcmd_status)
+
+        # regularly query pivots for zero positions (which are verified against stored initial zero)
+        # to ensure that there is no funny business going on
+        if self.check_pivot_zero_period > 0:
+            self.check_pivot_zero_timer = self.create_timer(self.check_pivot_zero_period * 60, self.check_all_pivot_blcmd_zeros)
 
         #open the can bus
         self.bus.open(self.get_parameter("canbus").value)
 
         # store all "initial" zero positions for pivot reset later
         # (for some reason we can't do this just before resetting a pivot)
-        if self.enable_auto_blcmd_reset:
-            for pivot_id in self.auto_reset_pivot_blmcd_ids:
-                self.bus.send(
-                    jcan.Frame(id=0x009 | pivot_id << 4, data=[0xf])
-                )
+        self.check_all_pivot_blcmd_zeros()
 
     def run_callbacks(self):
         self.bus.spin()
@@ -244,7 +252,26 @@ class BLCMDStatusMonitor(Node):
 
         self.deferred_functions.append(deferred_reset)
 
+    def check_all_pivot_blcmd_zeros(self):
+        for blcmd_id in self.pivot_blcmd_ids:
+            self.check_pivot_blmcd_zero(blcmd_id)
+
+    def check_pivot_blmcd_zero(self, blcmd_id: int):
+
+        # does not trigger reset, as blcmd_pivot_reset_times is not updated
+        def deferred_check():
+
+            # get configuration (blcmd zero position)
+            self.bus.send(
+                jcan.Frame(id=0x009 | blcmd_id << 4, data=[0xf])
+            )
+
+        self.deferred_functions.append(deferred_check)
+
     def get_reset_pivot_blcmd_callback(self, blcmd_id: int):
+        def position_str(position: list[int]):
+            return f'0x{position[0]:02X}{position[1]:02X}'
+
         def callback(frame):
             now = self.get_clock().now()
 
@@ -255,6 +282,10 @@ class BLCMDStatusMonitor(Node):
             # save all pivot zeros on startup
             if self.pivot_zeros[blcmd_id] is None:
                 self.pivot_zeros[blcmd_id] = frame.data[1:3]
+                self.get_logger().info(f'Received pivot BLCMD {blcmd_id} zero position: {position_str(self.pivot_zeros[blcmd_id])} (used for all future resets)')
+
+            elif self.pivot_zeros[blcmd_id] != frame.data[1:3]:
+                self.get_logger().warn(f'Received pivot BLCMD {blcmd_id} zero position {position_str(frame.data[1:3])} does not match the initial/set zero position of {position_str(self.pivot_zeros[blcmd_id])}')
 
             # don't do anything if there wasn't a recent enough request for pivot zero
             if (blcmd_id not in self.blcmd_pivot_reset_times

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -195,6 +195,8 @@ class BLCMDStatusMonitor(Node):
         # repeatedly attempt to get "initial" zero positions for pivot to use in reset later
         if self.declare_parameter("get_pivot_blcmd_initial_zero", True).value:
             self.get_pivot_blmcd_zero_period = self.declare_parameter("get_pivot_blmcd_zero_period", 15).value
+            for pivot_id in self.pivot_blcmd_ids:
+                self.get_pivot_blmcd_zero(pivot_id)
             self.get_pivot_blmcd_zero_timers = {pivot_id: self.create_timer(self.get_pivot_blmcd_zero_period, self.get_pivot_blmcd_zero_timer_callback(pivot_id))
                                                 for pivot_id in self.pivot_blcmd_ids}
 

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -99,7 +99,6 @@ class BLCMDStatusMonitor(Node):
         self.output_period = 1 / int(self.declare_parameter("output_max_frequency", 1).value) # in logs per second
         self.publish_log_period = 1 / int(self.declare_parameter("publish_log_max_frequency", 10).value) # in logs per second
         self.publish_status_period = 1 / int(self.declare_parameter("publish_status_frequency", 2).value) # in blcmd statuses per second
-        self.check_pivot_zero_period = self.declare_parameter("check_pivot_zero_period", 60).value # in seconds between checks
 
         # ignoring the numbers provided by the gate driver condition errors as they seem unreliable/unused atm
         self.ignore_gate_driver_condition_error_number = self.declare_parameter("ignore_gate_driver_condition_error_number", True).value
@@ -189,11 +188,6 @@ class BLCMDStatusMonitor(Node):
             self.pivot_set_zero_delay_timers[pivot_id] = self.create_timer(self.pivot_set_zero_delay,
                                                                            set_pivot_zero,
                                                                            autostart=False)
-
-        # regularly query pivots for zero positions (which are verified against stored initial zero)
-        # to ensure that there is no funny business going on
-        if self.check_pivot_zero_period > 0:
-            self.check_pivot_zero_timer = self.create_timer(self.check_pivot_zero_period, self.check_all_pivot_blcmd_zeros)
 
         #open the can bus
         self.bus.open(self.get_parameter("canbus").value)

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -487,6 +487,9 @@ class BLCMDStatusMonitor(Node):
                     # reset for next sequence
                     self.gate_driver_registers = []
 
+                    # attempt to reset blcmd automatically
+                    self.auto_blcmd_reset(blcmd + 1)
+
                 # received message containing id of faulted register
                 else:
                     self.gate_driver_registers.append(data)

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -192,9 +192,11 @@ class BLCMDStatusMonitor(Node):
         #open the can bus
         self.bus.open(self.get_parameter("canbus").value)
 
-        # store all "initial" zero positions for pivot reset later
-        # (for some reason we can't do this just before resetting a pivot)
-        self.check_all_pivot_blcmd_zeros()
+        # repeatedly attempt to get "initial" zero positions for pivot to use in reset later
+        if self.declare_parameter("get_pivot_blcmd_initial_zero", True).value:
+            self.get_pivot_blmcd_zero_period = self.declare_parameter("get_pivot_blmcd_zero_period", 15).value
+            self.get_pivot_blmcd_zero_timers = {pivot_id: self.create_timer(self.get_pivot_blmcd_zero_period, self.get_pivot_blmcd_zero_timer_callback(pivot_id))
+                                                for pivot_id in self.pivot_blcmd_ids}
 
     def run_callbacks(self):
         self.bus.spin()
@@ -269,11 +271,17 @@ class BLCMDStatusMonitor(Node):
 
         self.deferred_functions.append(deferred_reset)
 
-    def check_all_pivot_blcmd_zeros(self):
-        for blcmd_id in self.pivot_blcmd_ids:
-            self.check_pivot_blmcd_zero(blcmd_id)
+    def get_pivot_blmcd_zero_timer_callback(self, blcmd_id: int):
 
-    def check_pivot_blmcd_zero(self, blcmd_id: int):
+        def callback():
+            if self.pivot_zeros[blcmd_id] is not None:
+                self.get_pivot_blmcd_zero_timers[blcmd_id].cancel()
+            else:
+                self.get_pivot_blmcd_zero(blcmd_id)
+
+        return callback
+
+    def get_pivot_blmcd_zero(self, blcmd_id: int):
 
         # does not trigger reset, as blcmd_pivot_reset_times is not updated
         def deferred_check():

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -88,7 +88,7 @@ class BLCMDStatusMonitor(Node):
         #publisher to publish log messages from each blcmd
         self.log_publisher = self.create_publisher(BLCMDLog, "/drive/blcmd_log", 1)
         #service to reset the blcmd
-        self.reset_service = self.create_service(BLCMDReset, "/blcmds/blcmd_reset", self.reset)
+        self.reset_service = self.create_service(BLCMDReset, "/blcmds/blcmd_reset", self.reset_blcmd)
 
         #declare parameters
         self.num_blcmds = self.declare_parameter("num_blcmds", 8).value
@@ -118,10 +118,13 @@ class BLCMDStatusMonitor(Node):
         self.enable_auto_blcmd_reset = self.declare_parameter("enable_auto_blcmd_reset", False).value
         self.max_resets = self.declare_parameter("max_resets", 5).value # set to 0 for no limit
         self.reset_timeout = self.declare_parameter("reset_timeout", 5).value # in seconds; set to 0 for no timeout
-        self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", [1, 2, 3, 4]).value # which drive blcmds are allowed to be reset (by id)
+        self.drive_blcmd_ids = [1, 2, 3, 4]
+        self.auto_reset_drive_blmcd_ids = self.declare_parameter("auto_reset_drive_blmcd_ids", self.drive_blcmd_ids).value # which drive blcmds are allowed to be reset (by id)
         if self.auto_reset_drive_blmcd_ids is None:
             self.auto_reset_drive_blmcd_ids = []
-        self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", [5, 6, 7, 8]).value # which pivot blcmds are allowed to be reset (by id)
+
+        self.pivot_blcmd_ids = [5, 6, 7, 8]
+        self.auto_reset_pivot_blmcd_ids = self.declare_parameter("auto_reset_pivot_blmcd_ids", self.pivot_blcmd_ids).value # which pivot blcmds are allowed to be reset (by id)
         if self.auto_reset_pivot_blmcd_ids is None:
             self.auto_reset_pivot_blmcd_ids = []
 
@@ -175,46 +178,58 @@ class BLCMDStatusMonitor(Node):
             function()
         self.deferred_functions = []
 
-    def reset(self,req,res):
+    def reset_blcmd(self, req, res):
         """
         Updates the classes internal msg state
         :param msg: nova_interfaces.msg.BLCMDReset message from the subscriber callback
         :return: None
         """
         try:
-            if req.type == BLCMDReset.Request.BLCMD:
-                frame = jcan.Frame(0x00B | req.id << 4, [0])
-            elif req.type == BLCMDReset.Request.RESOLVER:
-                frame = jcan.Frame(0x00C | req.id << 4, [0])
-
-            self.bus.send(frame)
-            if req.type == BLCMDReset.Request.BLCMD:
-                self.get_logger().info(f'Reset BLCMD {req.id}')
-            elif req.type == BLCMDReset.Request.RESOLVER:
-                self.get_logger().info(f'Reset resolver on BLCMD {req.id}')
+            # assume success unless otherwise provided
             res.success = True
-        except:
-            self.get_logger().error('BLCMD Reset or Resolver Reset Failed')
+
+            # reset resolver (extracted from existing code)
+            if req.type == BLCMDReset.Request.RESOLVER:
+                frame = jcan.Frame(0x00C | req.id << 4, [0])
+                self.bus.send(frame)
+                self.get_logger().info(f'Reset resolver on BLCMD {req.id}')
+                return res
+
+            if req.type != BLCMDReset.Request.BLCMD:
+                self.get_logger().warn(f'Failed to reset BLCMD {req.id} as an unsupported reset type was provided')
+                res.success = False
+                return res
+
+            if req.id in self.drive_blcmd_ids:
+                self.reset_drive_blcmd(req.id, "as requested")
+            elif req.id in self.pivot_blcmd_ids:
+                self.reset_pivot_blcmd(req.id, "as requested")
+            else:
+                self.get_logger().warn(f'Failed to reset BLCMD {req.id} as it is not a valid drive or pivot BLCMD id')
+                res.success = False
+
+        except Exception as e:
+            self.get_logger().error(f'BLCMD Reset Failed due to exception: {e}')
             res.success = False
         return res
 
-    def reset_drive_blcmd(self, blcmd_id: int):
+    def reset_drive_blcmd(self, blcmd_id: int, reason: str):
         msg_id = 0x00B | (blcmd_id << 4)
 
         def deferred_reset():
-            self.get_logger().info(f'Resetting drive BLCMD {blcmd_id} due to errors received')
+            self.get_logger().info(f'Resetting drive BLCMD {blcmd_id} {reason}')
             self.bus.send(
                 jcan.Frame(id=msg_id, data=[])
             )
 
         self.deferred_functions.append(deferred_reset)
 
-    def reset_pivot_blcmd(self, blcmd_id: int):
+    def reset_pivot_blcmd(self, blcmd_id: int, reason: str):
 
         # WARNING: This process is based off firmware electrical has written for arm (they should adapt this feature for pivot firmware)
 
         def deferred_reset():
-            self.get_logger().info(f'Resetting pivot BLCMD {blcmd_id} due to errors received (patched by Will and Terry)')
+            self.get_logger().info(f'Resetting pivot BLCMD {blcmd_id} {reason} (patched by Will and Terry)')
 
             # keep track of when the last request was made
             self.blcmd_pivot_reset_times[blcmd_id] = self.get_clock().now()
@@ -307,9 +322,9 @@ class BLCMDStatusMonitor(Node):
 
 
         if blcmd_id in self.auto_reset_pivot_blmcd_ids:
-            self.reset_pivot_blcmd(blcmd_id)
+            self.reset_pivot_blcmd(blcmd_id, "due to errors received")
         else:
-            self.reset_drive_blcmd(blcmd_id)
+            self.reset_drive_blcmd(blcmd_id, "due to errors received")
 
     def output_rate_limited(self, blcmd: int, output_message: str) -> bool:
         output_id = (blcmd, output_message)

--- a/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
+++ b/src/ros/rover/hardware_interfaces/old/blcmds/blcmd_utils/blcmd_utils/blcmd_status_monitor.py
@@ -155,7 +155,7 @@ class BLCMDStatusMonitor(Node):
         self.bus.set_id_filter_mask(0x400, 0xF00)
 
         #initialise zero positions
-        self.pivot_zeros = dict.fromkeys(self.auto_reset_pivot_blmcd_ids, None)
+        self.pivot_zeros = dict.fromkeys(self.pivot_blcmd_ids, None)
 
         #add callbacks
 


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Many improvements to drive given provided feedback; this should cover most, if not all, issues with drive.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs
- add autolock widget to all cameras pages (special cased for science urc to change its default location)
- increase cmd vel command timeout to 1 second (too short previously)
- deslopify drive autolock notifications
- make blcmd status monitor show gate driver faults (without discriminating between different error numbers; all are just considered "gate driver fault") and have drive autolock recognise these can messages as errors (enabling it to automatically trigger locking when there are too many)
- fast pivot blcmd reset (via aliases that make service calls to blcmd status monitor)
- improve pivot blcmd reset by delaying when zero position is set (~3 seconds after reset; hopefully should work consistently and reliably now)
- slow down update rate of drive joint state broadcaster so gui running via gui-shell has enough time to process each message

## Memes

With reference to the firmware required to support automatic pivot blcmd resetting:
<img width="537" height="272" alt="Screenshot From 2026-05-18 01-32-17" src="https://github.com/user-attachments/assets/1000cea1-5ddf-41e7-9fa9-b8efdc985a58" />
there are now 1 million and 1 blcmd firmware changes to be made on the plane.



<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<!-- TAGS START -->
Tags for Notion Integration:
tag:ready_for_review
<!-- TAGS END -->
