### PR TITLE
feat: Camera gui start/stop presets

### DIFF
--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/CameraComponent.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraComponent/CameraComponent.tsx
@@ -168,9 +168,9 @@ export const CameraComponent = (props: CameraComponentProps) => {
       link.download = filename;
       link.click();
     } catch (err) {
-      toast("Unable to Take a Screenshot");
+      toast(`Unable to Take a Screenshot: ${err}`);
     }
-  }, [videoRef, cameraSerial, currentSite, cameraName, getScreenshotName]);
+  }, [cameraSerial, currentSite, cameraName, getScreenshotName]);
 
   useEffect(() => {
     const handleMouseEnter = () => {

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
@@ -9,8 +9,9 @@ import { useSelector } from "react-redux";
 import { useBifrost } from "../../../redux/actions/bifrost/useBifrostAction.ts";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
 import { RootState } from "../../../redux/RootState.ts";
-import {ProfileOption} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
+import {ProfileOption, SerialPreset} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
 import {CameraProfileSelector} from "./CameraProfileSelector.tsx";
+import {SerialPresetControls} from "./SerialPresetControls.tsx";
 
 interface CameraSidebarProps {
   refreshAvailabilities: () => void;
@@ -19,16 +20,19 @@ interface CameraSidebarProps {
   gridSize: number
   setGridSize: (_: number) => void
   presets: ProfileOption[]
+  serialPresets?: SerialPreset[]
 }
 
 export const CameraSidebar = (
-  {refreshAvailabilities, showSidebar, setShowSidebar, gridSize, setGridSize, presets}
+  {refreshAvailabilities, showSidebar, setShowSidebar, gridSize, setGridSize, presets, serialPresets}
   : CameraSidebarProps) => {
   const expandedSidebarWidth = "27vw";
   const sidebarWidth = showSidebar ? expandedSidebarWidth : "0px";
 
   const nodes = useRosNodes();
   const camerasRunning = useMemo(() => nodes.includes("/camera_streamer"), [nodes]);
+
+  console.log(serialPresets)
 
   const booleanChip = useMemo(() => <BooleanChip
     boolean={camerasRunning}
@@ -101,7 +105,18 @@ export const CameraSidebar = (
 
           </CardBody>
 
-          <CardFooter className="flex flex-row gap-3 items-center">
+          {serialPresets && serialPresets.length > 0 && (
+            <div className="px-3 py-3 border-t border-divider">
+              <SerialPresetControls
+                presets={serialPresets}
+                startStreaming={startStreaming}
+                pauseStreaming={pauseStreaming}
+                stopStreaming={stopStreaming}
+              />
+            </div>
+          )}
+
+          <CardFooter className="flex flex-row gap-3 items-center border-t border-divider">
             <span className="shrink-0">Grid Size:</span>
             <Input
               className="flex-1 min-w-0"

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
@@ -9,9 +9,10 @@ import { useSelector } from "react-redux";
 import { useBifrost } from "../../../redux/actions/bifrost/useBifrostAction.ts";
 import { RosTopic } from "../../../ros/topics/rosTopic.ts";
 import { RootState } from "../../../redux/RootState.ts";
-import {ProfileOption, SerialPreset} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
+import {ProfileOption} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
 import {CameraProfileSelector} from "./CameraProfileSelector.tsx";
 import {SerialPresetControls} from "./SerialPresetControls.tsx";
+import { SerialPreset } from "../../../views/shared/CamerasPage/CameraViewConstants.tsx";
 
 interface CameraSidebarProps {
   refreshAvailabilities: () => void;

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/CameraSidebar.tsx
@@ -33,8 +33,6 @@ export const CameraSidebar = (
   const nodes = useRosNodes();
   const camerasRunning = useMemo(() => nodes.includes("/camera_streamer"), [nodes]);
 
-  console.log(serialPresets)
-
   const booleanChip = useMemo(() => <BooleanChip
     boolean={camerasRunning}
     variant="dot"

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
@@ -1,4 +1,4 @@
-import {Button} from "@nextui-org/react";
+import {Button, Tooltip} from "@nextui-org/react";
 import {Pause, Play, Square} from "react-feather";
 import {SerialPreset} from "../../../views/shared/CamerasPage/CameraViewConstants.tsx";
 
@@ -20,11 +20,17 @@ export const SerialPresetControls = ({
       <span>Camera Set Controls</span>
       {presets.map((preset) => (
         <div key={preset.displayName} className="flex flex-row items-center justify-between">
-          <span className="text-sm text-default-500">{preset.displayName}</span>
+          <Tooltip
+            className="dark text-foreground"
+            content={preset.serials.join(", ")}
+            closeDelay={100}
+          >
+            <span className="text-sm text-default-500">{preset.displayName}</span>
+          </Tooltip>
           <div className="flex flex-row gap-2">
             <Button
               color="primary"
-              size="md"
+              size="sm"
               startContent={<Play size={16}/>}
               onPress={() => startStreaming(preset.serials, false)}
             >
@@ -32,7 +38,7 @@ export const SerialPresetControls = ({
             </Button>
             <Button
               color="warning"
-              size="md"
+              size="sm"
               startContent={<Pause size={16}/>}
               onPress={() => pauseStreaming(preset.serials, false)}
             >
@@ -40,7 +46,7 @@ export const SerialPresetControls = ({
             </Button>
             <Button
               color="danger"
-              size="md"
+              size="sm"
               startContent={<Square size={16}/>}
               onPress={() => stopStreaming(preset.serials, false)}
             >

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
@@ -1,6 +1,6 @@
 import {Button} from "@nextui-org/react";
 import {Pause, Play, Square} from "react-feather";
-import {SerialPreset} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
+import {SerialPreset} from "../../../views/shared/CamerasPage/CameraViewConstants.tsx";
 
 interface SerialPresetControlsProps {
   presets: SerialPreset[];

--- a/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/cameras/CameraPage/SerialPresetControls.tsx
@@ -1,0 +1,54 @@
+import {Button} from "@nextui-org/react";
+import {Pause, Play, Square} from "react-feather";
+import {SerialPreset} from "../../../views/shared/CamerasPage/CameraProfileConstants.ts";
+
+interface SerialPresetControlsProps {
+  presets: SerialPreset[];
+  startStreaming: (serials: string[], useAllMessage: boolean) => void;
+  pauseStreaming: (serials: string[], useAllMessage: boolean) => void;
+  stopStreaming: (serials: string[], useAllMessage: boolean) => void;
+}
+
+export const SerialPresetControls = ({
+  presets,
+  startStreaming,
+  pauseStreaming,
+  stopStreaming,
+}: SerialPresetControlsProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <span>Camera Set Controls</span>
+      {presets.map((preset) => (
+        <div key={preset.displayName} className="flex flex-row items-center justify-between">
+          <span className="text-sm text-default-500">{preset.displayName}</span>
+          <div className="flex flex-row gap-2">
+            <Button
+              color="primary"
+              size="md"
+              startContent={<Play size={16}/>}
+              onPress={() => startStreaming(preset.serials, false)}
+            >
+              Start
+            </Button>
+            <Button
+              color="warning"
+              size="md"
+              startContent={<Pause size={16}/>}
+              onPress={() => pauseStreaming(preset.serials, false)}
+            >
+              Pause
+            </Button>
+            <Button
+              color="danger"
+              size="md"
+              startContent={<Square size={16}/>}
+              onPress={() => stopStreaming(preset.serials, false)}
+            >
+              Stop
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
@@ -1,9 +1,16 @@
 import {ProfileOption} from "./CameraProfileConstants.ts";
 
+export interface SerialPreset {
+  displayName: string;    // User-facing name (e.g., "Site Analysis Cams")
+  serials: string[];      // Array of camera serials
+}
+
+
 export interface CameraViewConfig {
   viewTitle: string;
   cameraSerials: string[];
   cameraPrests?: ProfileOption[];
+  serialPresets?: SerialPreset[];
 }
 
 export enum ARCCompModes {
@@ -128,6 +135,32 @@ const urcScienceCams = [
   ],
 ]
 
+const urcScienceSerialPresets: SerialPreset[] = [
+  {
+    displayName: "Mast Cams",
+    serials: [
+      CameraSerials.MAST_FORWARD,
+      CameraSerials.MAST_BACKWARD,
+      CameraSerials.MAST_ARM_STOW,
+    ],
+  },
+  {
+    displayName: "Payload Cams",
+    serials: [
+      CameraSerials.URC_SCIENCE_BOOM,
+      CameraSerials.URC_SCIENCE_CACHE_LEFT,
+      CameraSerials.URC_SCIENCE_CACHE_RIGHT,
+    ],
+  },
+  {
+    displayName: "Internal Cams",
+    serials: [
+      CameraSerials.URC_SCIENCE_CUVETTE,
+      CameraSerials.URC_SCIENCE_LITMUS,
+    ],
+  },
+]
+
 const driveCams = [
   CameraSerials.WHEEL_TELEMETRY,
   CameraSerials.DRIVE_TELEMETRY,
@@ -242,14 +275,17 @@ export const urc_science_views: CameraViewConfig[] = [
   {
     cameraSerials: [...mastCams.slice(1, 4), ...urcScienceCams[0], ...urcScienceCams[1],  ...driveCams.slice(0, 2), CameraSerials.URC_ACTIVATED_NODES, CameraSerials.URC_SCIENCE_AUGER_DEPTH_SENSORS, CameraSerials.DRIVE_CONTROL],
     viewTitle: "All Cams",
+    serialPresets: urcScienceSerialPresets,
   },
   {
     cameraSerials: [CameraSerials.MAST_FORWARD, CameraSerials.MAST_ARM_STOW, ...urcScienceCams[0], CameraSerials.URC_SCIENCE_LITMUS, ...driveCams.slice(0, 2), CameraSerials.URC_ACTIVATED_NODES, CameraSerials.URC_SCIENCE_AUGER_DEPTH_SENSORS, CameraSerials.DRIVE_CONTROL],
-    viewTitle: "Site Analysis"
+    viewTitle: "Site Analysis",
+    serialPresets: urcScienceSerialPresets,
   },
   {
     cameraSerials: [...mastCams.slice(3, 4), CameraSerials.URC_SCIENCE_CACHE_LEFT, CameraSerials.URC_SCIENCE_CACHE_RIGHT, ...urcScienceCams[1],  ...driveCams.slice(0, 2), CameraSerials.URC_ACTIVATED_NODES, CameraSerials.DRIVE_CONTROL],
     viewTitle: "Vis Spec",
+    serialPresets: urcScienceSerialPresets,
   }
 ]
 

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CameraViewConstants.tsx
@@ -153,6 +153,13 @@ const urcScienceSerialPresets: SerialPreset[] = [
     ],
   },
   {
+    displayName: "Analysis Cams",
+    serials: [
+      CameraSerials.SCIENCE_MICROSCOPE,
+      CameraSerials.SCIENCE_GIMBAL,
+    ],
+  },
+  {
     displayName: "Internal Cams",
     serials: [
       CameraSerials.URC_SCIENCE_CUVETTE,

--- a/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasView.tsx
+++ b/src/ros/nova-gui/nova-gui/src/views/shared/CamerasPage/CamerasView.tsx
@@ -27,6 +27,7 @@ export const CameraView = (props: CameraViewProps) => {
           gridSize={gridSize}
           setGridSize={setGridSize}
           presets={props.views[0].cameraPrests ? props.views[0].cameraPrests : defaultCameraProfilePresets}
+          serialPresets={props.views[0].serialPresets}
         />
         <div className="grow">
           <CamerasPage


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

Adding camera start/stop preset options to the camera page, mainly for urc science since we are starting and stopping cameras a lot.

no other camera pages are affected.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- adding optional config for a set of cameras to start/pause/stop

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

<img width="2149" height="1305" alt="image" src="https://github.com/user-attachments/assets/dde73ba9-ac14-4053-97b0-fe36f6cfe047" />



