### PR TITLE
coordinate conversion script for cartographer

### DIFF
--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -314,6 +314,7 @@ in
           launch-gps-base = "~/Builds/active/bin/ros2 launch nova_bringup gps_base.launch.py";
           launch-magnetometer = "~/Builds/active/bin/ros2 run electronics magnetometer.py";
           mast = "ssh -C nova@10.0.0.150";
+          cc = "python3 src/other/convert_coordinates.py";
 
           # Master build binaries
           mros2 = "~/Builds/active/bin/ros2";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -314,7 +314,7 @@ in
           launch-gps-base = "~/Builds/active/bin/ros2 launch nova_bringup gps_base.launch.py";
           launch-magnetometer = "~/Builds/active/bin/ros2 run electronics magnetometer.py";
           mast = "ssh -C nova@10.0.0.150";
-          cc = "python3 src/other/convert_coordinates.py";
+          cc = "python3 ~/nova/src/other/convert_coordinates.py";
 
           # Master build binaries
           mros2 = "~/Builds/active/bin/ros2";

--- a/src/other/convert_coordinates.py
+++ b/src/other/convert_coordinates.py
@@ -1,0 +1,96 @@
+import argparse
+import re
+import sys
+
+def parse_coordinate(coord_str, in_format):
+    """Extracts numbers from the string and converts to a base Decimal Degree (DD) float."""
+    coord_str = coord_str.strip().upper()
+    
+    # Determine the sign based on cardinal direction or negative sign
+    sign = -1 if 'S' in coord_str or 'W' in coord_str or coord_str.startswith('-') else 1
+    
+    # Check if it's explicitly a Longitude based on the letter
+    is_lat = False if 'E' in coord_str or 'W' in coord_str else True
+
+    # Extract all floating-point or integer numbers from the string
+    nums = [float(n) for n in re.findall(r"\d+\.?\d*", coord_str)]
+
+    if not nums:
+        raise ValueError(f"Could not extract numbers from: '{coord_str}'")
+
+    if in_format == 'DMS' and len(nums) >= 3:
+        dd = nums[0] + (nums[1] / 60.0) + (nums[2] / 3600.0)
+    elif in_format == 'DDM' and len(nums) >= 2:
+        dd = nums[0] + (nums[1] / 60.0)
+    elif in_format == 'DD' and len(nums) >= 1:
+        dd = nums[0]
+    else:
+        raise ValueError(f"Input '{coord_str}' doesn't have enough numbers for {in_format} format.")
+
+    return dd * sign, is_lat
+
+def format_coordinate(dd, out_format, is_lat=True):
+    """Converts a Decimal Degree (DD) float back into the requested string format."""
+    # Determine cardinal direction
+    if is_lat:
+        direction = "N" if dd >= 0 else "S"
+    else:
+        direction = "E" if dd >= 0 else "W"
+        
+    dd = abs(dd)
+
+    if out_format == 'DD':
+        return f"{dd:.6f}° {direction}"
+        
+    elif out_format == 'DDM':
+        degrees = int(dd)
+        minutes = (dd - degrees) * 60
+        return f"{degrees}° {minutes:.4f}' {direction}"
+        
+    elif out_format == 'DMS':
+        degrees = int(dd)
+        minutes = int((dd - degrees) * 60)
+        seconds = (dd - degrees - (minutes / 60.0)) * 3600
+        return f"{degrees}° {minutes}' {seconds:.2f}\" {direction}"
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CLI tool to convert coordinates between DD, DDM, and DMS.",
+        epilog="Examples:\n"
+               "  python coord_converter.py \"40 26 46 N\"\n"
+               "  python coord_converter.py \"40° 26' 46 N\" \"79° 58' 56 W\"\n"
+               "  python coord_converter.py -i DD -o DMS \"40.446111\" \"-79.982222\"",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    
+    parser.add_argument("coordinates", nargs='+', help="The coordinate string(s) to convert. Enclose in quotes.")
+    parser.add_argument("-i", "--input", choices=['DD', 'DDM', 'DMS'], default='DMS', help="Format of the input (Default: DMS)")
+    parser.add_argument("-o", "--output", choices=['DD', 'DDM', 'DMS'], default='DD', help="Format of the output (Default: DD)")
+
+    args = parser.parse_args()
+
+    print(f"\nConverting {args.input} -> {args.output}\n" + "-"*30)
+
+    for i, coord in enumerate(args.coordinates):
+        try:
+            # Parse the input into a standard Decimal Degree format
+            base_dd, detected_is_lat = parse_coordinate(coord, args.input)
+            
+            # If the user didn't provide N/S/E/W, we assume the first coordinate is Lat and second is Lon
+            if 'N' not in coord.upper() and 'S' not in coord.upper() and 'E' not in coord.upper() and 'W' not in coord.upper():
+                is_lat = True if i == 0 else False
+            else:
+                is_lat = detected_is_lat
+                
+            # Format to the desired output
+            result = format_coordinate(base_dd, args.output, is_lat)
+            
+            print(f"Input:  {coord}")
+            print(f"Output: {result}\n")
+            
+        except ValueError as e:
+            print(f"Error processing '{coord}': {e}\n")
+            sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/src/other/convert_coordinates.py
+++ b/src/other/convert_coordinates.py
@@ -1,3 +1,5 @@
+#!/home/nova/Builds/master/bin/python3
+
 import argparse
 import re
 import sys

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/Cartographer.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/Cartographer.tsx
@@ -16,6 +16,7 @@ import { getDistance } from "./utils/geojson.ts";
 import { useLocalStorage } from "../../../hooks/useLocalStorage.ts";
 import { MapTile } from "./config.tsx";
 import AutoArrivedPopup from "./components/AutoArrivedPopup.tsx";
+import {useDisplayMapCoordinate} from "./utils/convertCoords.ts";
 
 interface CartographerProps {
   pointLabels?: { key: number; text: string }[];
@@ -72,6 +73,8 @@ export const Cartographer : React.FC<CartographerProps> = ({ bottomOverlayCompon
     // eslint-disable-next-line react-hooks/exhaustive-deps
   },[storedPoints])
 
+  const {lat: mouseLat, long: mouseLong} = useDisplayMapCoordinate({lat: mousePosition?.lat ?? 0, long: mousePosition?.long ?? 0})
+
   return (
     <div className="w-full h-full">
       <AutoArrivedPopup/>
@@ -95,8 +98,8 @@ export const Cartographer : React.FC<CartographerProps> = ({ bottomOverlayCompon
                     mousePosition && (
                       <PropRenderer
                         props={{
-                          latitude: mousePosition.lat,
-                          longitude: mousePosition.long,
+                          latitude: mouseLat,
+                          longitude: mouseLong,
                         }}
                         ignoreProps={[]}
                         row

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/AutoArrivedPopup.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/AutoArrivedPopup.tsx
@@ -6,6 +6,7 @@ import BanksiaAuto from "../../../../assets/banksia-auto.png"
 import {useBifrost} from "../../../../redux/actions/bifrost/useBifrostAction.ts";
 import {RosTopic} from "../../../../ros/topics/rosTopic.ts";
 import {IRosNovaInterfacesStatusConst} from "../../../../ros/rosTypes.ts";
+import {useDisplayMapCoordinate} from "../utils/convertCoords.ts";
 
 interface AutoArrivedPopupProps {
 }
@@ -34,6 +35,8 @@ export const AutoArrivedPopup : React.FC<AutoArrivedPopupProps> = () => {
 
   const onClose = () => setIsOpen(false)
 
+  const {lat, long} = useDisplayMapCoordinate({lat: arrivedLocation.latitude, long: arrivedLocation.longitude})
+
   return (
     <Modal isOpen={isOpen} size="5xl" onClose={onClose} className="dark text-foreground"  classNames={{
       base: "bg-success-100 text-[#a8b0d3]",
@@ -47,7 +50,7 @@ export const AutoArrivedPopup : React.FC<AutoArrivedPopupProps> = () => {
             at:
           </p>
           <p className="text-4xl">
-            {`(${arrivedLocation.latitude}, ${arrivedLocation.longitude})`}
+            {`(${lat}, ${long})`}
           </p>
           <Image src={BanksiaAuto} removeWrapper className="w-1/2 mt-10 items-center"/>
         </ModalBody>

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
@@ -28,6 +28,7 @@ import { useCartographerActions } from "../../../../redux/actions/useCartographe
 import { MapTile } from "../config.tsx";
 import { MapPoint, Vehicle } from "../../../../redux/models/CartographerState.ts";
 import React from "react";
+import {useDisplayMapCoordinate} from "../utils/convertCoords.ts";
 
 interface BottomOverlayProps {
   mapTile: MapTile;
@@ -117,6 +118,9 @@ export const BottomOverlay : React.FC<BottomOverlayProps> = ({mapTile, setMapTil
     }
   };
 
+  const {lat: baseLat, long: baseLong} = useDisplayMapCoordinate({lat: base.latitude, long: base.longitude})
+  const {lat: vehLat, long: vehLong} = useDisplayMapCoordinate({lat: currentVehicle.location.latitude, long: currentVehicle.location.longitude})
+
   return (
     <div className="relative w-full">
       <div className="flex justify-end p-2 z-50">
@@ -149,22 +153,22 @@ export const BottomOverlay : React.FC<BottomOverlayProps> = ({mapTile, setMapTil
                 <div className="flex flex-row gap-3">
                 <CopyableInput
                   readOnly
-                  value={String(base.latitude)}
+                  value={baseLat}
                   placeholder={`Base Latitude`}
                   label="Base Latitude"/>
                 <CopyableInput
                   readOnly
-                  value={String(base.longitude)}
+                  value={baseLong}
                   placeholder={`Base Longitude`}
                   label="Base Longitude"/>
                 <CopyableInput
                   readOnly
-                  value={String(currentVehicle.location.latitude)}
+                  value={vehLat}
                   placeholder={`${currentVehicle.label} Latitude`}
                   label={`${currentVehicle.label} Latitude`}/>
                 <CopyableInput
                   readOnly
-                  value={String(currentVehicle.location.longitude)}
+                  value={vehLong}
                   placeholder={`${currentVehicle.label} Longitude`}
                   label={`${currentVehicle.label} Longitude`}/>
                   <CopyableInput

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
@@ -28,7 +28,7 @@ import { useCartographerActions } from "../../../../redux/actions/useCartographe
 import { MapTile } from "../config.tsx";
 import { MapPoint, Vehicle } from "../../../../redux/models/CartographerState.ts";
 import React from "react";
-import {displayMapCoordinate, DisplayMapCoordinate, useDisplayMapCoordinate} from "../utils/convertCoords.ts";
+import {displayMapCoordinate, useDisplayMapCoordinate} from "../utils/convertCoords.ts";
 import { useGenericStore } from "../../../../hooks/useGenericStore.ts";
 
 interface BottomOverlayProps {

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/BottomOverlay.tsx
@@ -28,7 +28,8 @@ import { useCartographerActions } from "../../../../redux/actions/useCartographe
 import { MapTile } from "../config.tsx";
 import { MapPoint, Vehicle } from "../../../../redux/models/CartographerState.ts";
 import React from "react";
-import {useDisplayMapCoordinate} from "../utils/convertCoords.ts";
+import {displayMapCoordinate, DisplayMapCoordinate, useDisplayMapCoordinate} from "../utils/convertCoords.ts";
+import { useGenericStore } from "../../../../hooks/useGenericStore.ts";
 
 interface BottomOverlayProps {
   mapTile: MapTile;
@@ -39,6 +40,7 @@ interface BottomOverlayProps {
 }
 
 export const BottomOverlay : React.FC<BottomOverlayProps> = ({mapTile, setMapTile, deletePoint, bottomOverlayComponents = [], enableDroneTracking = false}) => {
+  const [cartographerCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
   const [overlayVisible, setOverlayVisible] = useState(true);
   const [overlayOpen, setOverlayOpen] = useState(false);
   const { points, centerOnRover, trackRover, showTrackRover, centerOnDrone, trackDrone, showTrackDrone, focusVehicle, showSearchZones } = useSelector(
@@ -281,11 +283,13 @@ export const BottomOverlay : React.FC<BottomOverlayProps> = ({mapTile, setMapTil
                           </TableColumn>
                         </TableHeader>
                         <TableBody emptyContent="Add Points on the Map to Display here">
-                          {points.map((point) => (
+                          {points.map((point) => {
+                            const {lat: pointLat, long: pointLong} = displayMapCoordinate({lat: point.lat, long: point.long}, cartographerCoordinateFormat)
+                            return (
                             <TableRow key={point.name}>
                               <TableCell>{point.name}</TableCell>
-                              <TableCell>{point.lat}</TableCell>
-                              <TableCell>{point.long}</TableCell>
+                              <TableCell>{pointLat}</TableCell>
+                              <TableCell>{pointLong}</TableCell>
                               <TableCell>{point.searchRadius != null ? `${point.searchRadius}m` : ''}</TableCell>
                               <TableCell>{point.labelName != null ? point.labelName : ''}</TableCell>
                               <TableCell className="flex flex-row justify-end">
@@ -299,7 +303,7 @@ export const BottomOverlay : React.FC<BottomOverlayProps> = ({mapTile, setMapTil
                                 </ToolTipButton>
                               </TableCell>
                             </TableRow>
-                          ))}
+                          )})}
                         </TableBody>
                       </Table>
                     </div>

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/NewMarkerModal.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/components/NewMarkerModal.tsx
@@ -14,6 +14,7 @@ import { MapPoint } from "../../../../redux/models/CartographerState.ts";
 import { useEffect, useState } from "react";
 import CopyableInput from "../../../shared/components/CopyableInput/CopyableInput.tsx";
 import toast from "react-hot-toast";
+import { calcLatFromDD, calcLatFromDDM, calcLatFromDMS, calcLongFromDD, calcLongFromDDM, calcLongFromDMS } from "../utils/convertCoords.ts";
 
 interface NewMarkerModalProps {
   isOpen: boolean;
@@ -36,21 +37,39 @@ export const NewMarkerModal = (props: NewMarkerModalProps) => {
     (state: RootState) => state.cartographerState.points
   );
 
+  const convertLatLong = (val: string, isLat: boolean = false) => {
+    const doFuncs = (functions: ((_: string) => number)[]) => {
+      for (const f in functions) {
+        const result = functions[f](val);
+        console.log(result, functions[f])
+        if (!isNaN(result)) return result;
+      }
+      return NaN
+    }
+    if (isLat) {
+      const functions = [calcLatFromDD, calcLatFromDMS, calcLatFromDDM]
+      return doFuncs(functions)
+    } else {
+      const functions = [calcLongFromDD, calcLongFromDMS, calcLongFromDDM]
+      return doFuncs(functions)
+    }
+  }
+
   const isValidPoint = () => {
     return (
       latitude !== "" &&
       longitude !== "" &&
-      !isNaN(Number(latitude)) &&
-      !isNaN(Number(longitude)) && 
-      points.reduce((acc, point) => acc && !(point.lat === Number(latitude) && point.long === Number(longitude)) && point.name !== name, true)
+      !isNaN(convertLatLong(latitude, true)) &&
+      !isNaN(convertLatLong(longitude)) && 
+      points.reduce((acc, point) => acc && !(point.lat === convertLatLong(latitude, true) && point.long === convertLatLong(longitude)) && point.name !== name, true)
     );
   }
 
   const handleDropPin = () => {
     if (isValidPoint()) {
       const newPoint = {
-        lat: Number(latitude),
-        long: Number(longitude),
+        lat: convertLatLong(latitude, true),
+        long: convertLatLong(longitude),
         labelNumber: labelNumber,
         labelName: labelName,
         name: !name || name === "" ? `Point ${points.length + 1}` : name,
@@ -61,6 +80,7 @@ export const NewMarkerModal = (props: NewMarkerModalProps) => {
       props.closeModal();
     }
     else{
+      console.log(convertLatLong(latitude, true), convertLatLong(longitude))
       toast.error("Point must have unique coordinates and name")
     }
 };
@@ -97,6 +117,9 @@ export const NewMarkerModal = (props: NewMarkerModalProps) => {
               }
             }}
           />
+          <div className="text-xs text-default-500">
+            Lat/Long entry allows DD, DMS and DDM where {`°, ' and "`} are optional<br/> Direction indicator(N, E for Lat or S, W) is not optional for DMS & DDM
+          </div>
           <CopyableInput
             value={latitude}
             onChange={(event) => setLatitude(event.target.value as string)}

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/utils/convertCoords.ts
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/utils/convertCoords.ts
@@ -6,20 +6,24 @@ export type DisplayMapCoordinate = {
     long: string
 }
 
-type DMS = {
+export type DD = {
+    degrees: number
+}
+
+export type DMS = {
     degrees: number
     minutes: number
     seconds: number
     direction: string
 }
 
-type DDM = {
+export type DDM = {
     degrees: number
     minutes: number
     direction: string
 }
 
-function DDtoDMS(dd: number, isLat: boolean | undefined = undefined): DMS {
+export function DDtoDMS(dd: number, isLat: boolean | undefined = undefined): DMS {
     const absDD = Math.abs(dd);
     const degrees = Math.floor(absDD);
     const minutes = Math.floor((absDD - degrees) * 60);
@@ -37,7 +41,7 @@ function DDtoDMS(dd: number, isLat: boolean | undefined = undefined): DMS {
     };
 }
 
-function DDtoDDM(dd: number, isLat: boolean | undefined = undefined): DDM {
+export function DDtoDDM(dd: number, isLat: boolean | undefined = undefined): DDM {
     const absDD = Math.abs(dd);
     const degrees = Math.floor(absDD);
     const minutes = (absDD - degrees) * 60;
@@ -53,69 +57,80 @@ function DDtoDDM(dd: number, isLat: boolean | undefined = undefined): DDM {
     };
 }
 
-function DMStoDD(dms: DMS): number {
+export function DMStoDD(dms: DMS): number {
     const dd = dms.degrees + (dms.minutes / 60) + (dms.seconds / 3600);
     const finalDD = dms.direction.toUpperCase() === 'S' || dms.direction.toUpperCase() === 'W' ? dd * -1 : dd;
     return finalDD
 }
 
-function DDMtoDD(ddm: DDM): number {
+export function DDMtoDD(ddm: DDM): number {
     const dd = ddm.degrees + (ddm.minutes / 60);
     const finalDD = ddm.direction.toUpperCase() === 'S' || ddm.direction.toUpperCase() === 'W' ? dd * -1 : dd;
     return finalDD
 }
 
-function calcMapCoordinateFromDD({lat, long}: DisplayMapCoordinate): MapCoordinate {
-    return {lat: +lat.slice(0,-1), long: +long.slice(0,-1)} as MapCoordinate
+export function calcLatFromDD(lat: string): number {
+    if (lat.slice(-1) === "°") return +lat.slice(0,-1);
+    return +lat
 }
 
-function calcMapCoordinateFromDMS({lat, long}: DisplayMapCoordinate): MapCoordinate {
-    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
-    const latDMS = {degrees: latArr[0], minutes: latArr[1], seconds: latArr[2], direction: latArr[3]} as DMS
-    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
-    const longDMS = {degrees: longArr[0], minutes: longArr[1], seconds: longArr[2], direction: longArr[3]} as DMS
-    const calcLat = DMStoDD(latDMS)
-    const calcLong = DMStoDD(longDMS);
-    return {
-        lat: calcLat,
-        long: calcLong
-    }
+export function calcLongFromDD(long: string): number {
+    if (long.slice(-1) === "°") return +long.slice(0,-1);
+    return +long
 }
 
-function calcMapCoordinateFromDDM({lat, long}: DisplayMapCoordinate): MapCoordinate {
-    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
-    const latDMS = {degrees: latArr[0], minutes: latArr[1], direction: latArr[2]} as DDM
-    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
-    const longDMS = {degrees: longArr[0], minutes: longArr[1], direction: longArr[2]} as DDM
-    const calcLat = DDMtoDD(latDMS)
-    const calcLong = DDMtoDD(longDMS);
-    return {
-        lat: calcLat,
-        long: calcLong
-    }
+
+export function calcLatFromDMS(lat: string): number {
+    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? (v.slice(-1) === ["°", "'", "\""][i] ? +v.slice(0,-1) : +v) : v);
+    if (latArr.length !== 4) return NaN
+    const latDMS = {degrees: latArr[0], minutes: latArr[1], seconds: latArr[2], direction: latArr[3]} as DMS;
+    return DMStoDD(latDMS);
 }
 
-function useCalcMapCoordinate(coord: DisplayMapCoordinate): MapCoordinate {
+export function calcLongFromDMS(long: string): number {
+    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? (v.slice(-1) === ["°", "'", "\""][i] ? +v.slice(0,-1) : +v) : v);
+     if (longArr.length !== 4) return NaN
+    const longDMS = {degrees: longArr[0], minutes: longArr[1], seconds: longArr[2], direction: longArr[3]} as DMS;
+    return DMStoDD(longDMS);
+}
+
+
+export function calcLatFromDDM(lat: string): number {
+    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? (v.slice(-1) === ["°", "'"][i] ? +v.slice(0,-1) : +v) : v);
+     if (latArr.length !== 3) return NaN
+    const latDMS = {degrees: latArr[0], minutes: latArr[1], direction: latArr[2]} as DDM;
+    return DDMtoDD(latDMS)
+}
+
+export function calcLongFromDDM(long: string): number {
+    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? (v.slice(-1) === ["°", "'"][i] ? +v.slice(0,-1) : +v) : v);
+     if (longArr.length !== 3) return NaN
+    const longDMS = {degrees: longArr[0], minutes: longArr[1], direction: longArr[2]} as DDM;
+    return DDMtoDD(longDMS)
+}
+
+
+export function useCalcMapCoordinate(coord: DisplayMapCoordinate): MapCoordinate {
     const [cartographerCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
     switch (cartographerCoordinateFormat) {
         /** numbers align with coordinateFormatOptions, there should be a better way to do this from "../../../navbar/settings/CartographerSettings.tsx"*/
         case 0:
-            return calcMapCoordinateFromDD(coord);
+            return {lat: calcLatFromDD(coord.lat), long: calcLongFromDD(coord.long)};
         case 1:
-            return calcMapCoordinateFromDMS(coord);
+            return {lat: calcLatFromDMS(coord.lat), long: calcLongFromDMS(coord.long)};
         case 2:
-            return calcMapCoordinateFromDDM(coord);
+            return {lat: calcLatFromDDM(coord.lat), long: calcLongFromDDM(coord.long)};
         default:
-            return calcMapCoordinateFromDD(coord);
+            return {lat: calcLatFromDD(coord.lat), long: calcLongFromDD(coord.long)};
     };
 }
 
 
-function displayMapCoordinateAsDD({lat, long}: MapCoordinate): DisplayMapCoordinate {
+export function displayMapCoordinateAsDD({lat, long}: MapCoordinate): DisplayMapCoordinate {
     return {lat: lat.toString()+"°", long: long.toString()+"°"} as DisplayMapCoordinate
 }
 
-function displayMapCoordinateAsDMS({lat, long}: MapCoordinate): DisplayMapCoordinate {
+export function displayMapCoordinateAsDMS({lat, long}: MapCoordinate): DisplayMapCoordinate {
     const dmsLat = DDtoDMS(lat, true);
     const dmsLong = DDtoDMS(long, false);
     return {
@@ -124,7 +139,7 @@ function displayMapCoordinateAsDMS({lat, long}: MapCoordinate): DisplayMapCoordi
     }
 }
 
-function displayMapCoordinateAsDDM({lat, long}: MapCoordinate): DisplayMapCoordinate {
+export function displayMapCoordinateAsDDM({lat, long}: MapCoordinate): DisplayMapCoordinate {
     const dmsLat = DDtoDDM(lat, true);
     const dmsLong = DDtoDDM(long, false);
     return {
@@ -133,7 +148,7 @@ function displayMapCoordinateAsDDM({lat, long}: MapCoordinate): DisplayMapCoordi
     }
 }
 
-function useDisplayMapCoordinate(coord: MapCoordinate): DisplayMapCoordinate {
+export function useDisplayMapCoordinate(coord: MapCoordinate): DisplayMapCoordinate {
     const [cartographerCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
     switch (cartographerCoordinateFormat) {
         /** numbers align with coordinateFormatOptions, there should be a better way to do this from "../../../navbar/settings/CartographerSettings.tsx"*/
@@ -148,4 +163,16 @@ function useDisplayMapCoordinate(coord: MapCoordinate): DisplayMapCoordinate {
     };
 }
 
-export {useDisplayMapCoordinate, useCalcMapCoordinate}
+export function displayMapCoordinate(coord: MapCoordinate, cartographerCoordinateFormat: number): DisplayMapCoordinate {
+    switch (cartographerCoordinateFormat) {
+        /** numbers align with coordinateFormatOptions, there should be a better way to do this from "../../../navbar/settings/CartographerSettings.tsx"*/
+        case 0:
+            return displayMapCoordinateAsDD(coord);
+        case 1:
+            return displayMapCoordinateAsDMS(coord);
+        case 2:
+            return displayMapCoordinateAsDDM(coord);
+        default:
+            return displayMapCoordinateAsDD(coord);
+    };
+}

--- a/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/utils/convertCoords.ts
+++ b/src/ros/nova-gui/nova-gui/src/components/maps/Cartographer/utils/convertCoords.ts
@@ -1,0 +1,151 @@
+import { useGenericStore } from "../../../../hooks/useGenericStore.ts";
+import { MapCoordinate} from "../../../../redux/models/CartographerState.ts";
+
+export type DisplayMapCoordinate = {
+    lat: string,
+    long: string
+}
+
+type DMS = {
+    degrees: number
+    minutes: number
+    seconds: number
+    direction: string
+}
+
+type DDM = {
+    degrees: number
+    minutes: number
+    direction: string
+}
+
+function DDtoDMS(dd: number, isLat: boolean | undefined = undefined): DMS {
+    const absDD = Math.abs(dd);
+    const degrees = Math.floor(absDD);
+    const minutes = Math.floor((absDD - degrees) * 60);
+    const seconds = ((absDD - degrees - minutes / 60) * 3600).toFixed(2);
+
+    return {
+        degrees: degrees,
+        minutes: minutes,
+        seconds: parseFloat(seconds),
+        direction: isLat === undefined 
+            ? (dd >= 0 ? "N/E" : "S/W") 
+            : (isLat 
+                ? (dd >= 0 ? "N" : "S") 
+                : (dd >= 0 ? "E" : "W"))
+    };
+}
+
+function DDtoDDM(dd: number, isLat: boolean | undefined = undefined): DDM {
+    const absDD = Math.abs(dd);
+    const degrees = Math.floor(absDD);
+    const minutes = (absDD - degrees) * 60;
+
+    return {
+        degrees: degrees,
+        minutes: minutes,
+        direction: isLat === undefined 
+            ? (dd >= 0 ? "N/E" : "S/W") 
+            : (isLat 
+                ? (dd >= 0 ? "N" : "S") 
+                : (dd >= 0 ? "E" : "W"))
+    };
+}
+
+function DMStoDD(dms: DMS): number {
+    const dd = dms.degrees + (dms.minutes / 60) + (dms.seconds / 3600);
+    const finalDD = dms.direction.toUpperCase() === 'S' || dms.direction.toUpperCase() === 'W' ? dd * -1 : dd;
+    return finalDD
+}
+
+function DDMtoDD(ddm: DDM): number {
+    const dd = ddm.degrees + (ddm.minutes / 60);
+    const finalDD = ddm.direction.toUpperCase() === 'S' || ddm.direction.toUpperCase() === 'W' ? dd * -1 : dd;
+    return finalDD
+}
+
+function calcMapCoordinateFromDD({lat, long}: DisplayMapCoordinate): MapCoordinate {
+    return {lat: +lat.slice(0,-1), long: +long.slice(0,-1)} as MapCoordinate
+}
+
+function calcMapCoordinateFromDMS({lat, long}: DisplayMapCoordinate): MapCoordinate {
+    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
+    const latDMS = {degrees: latArr[0], minutes: latArr[1], seconds: latArr[2], direction: latArr[3]} as DMS
+    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
+    const longDMS = {degrees: longArr[0], minutes: longArr[1], seconds: longArr[2], direction: longArr[3]} as DMS
+    const calcLat = DMStoDD(latDMS)
+    const calcLong = DMStoDD(longDMS);
+    return {
+        lat: calcLat,
+        long: calcLong
+    }
+}
+
+function calcMapCoordinateFromDDM({lat, long}: DisplayMapCoordinate): MapCoordinate {
+    const latArr = lat.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
+    const latDMS = {degrees: latArr[0], minutes: latArr[1], direction: latArr[2]} as DDM
+    const longArr = long.split(" ").map((v, i, a)=>a.length-1 !== i ? +v.slice(0,1) : v)
+    const longDMS = {degrees: longArr[0], minutes: longArr[1], direction: longArr[2]} as DDM
+    const calcLat = DDMtoDD(latDMS)
+    const calcLong = DDMtoDD(longDMS);
+    return {
+        lat: calcLat,
+        long: calcLong
+    }
+}
+
+function useCalcMapCoordinate(coord: DisplayMapCoordinate): MapCoordinate {
+    const [cartographerCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
+    switch (cartographerCoordinateFormat) {
+        /** numbers align with coordinateFormatOptions, there should be a better way to do this from "../../../navbar/settings/CartographerSettings.tsx"*/
+        case 0:
+            return calcMapCoordinateFromDD(coord);
+        case 1:
+            return calcMapCoordinateFromDMS(coord);
+        case 2:
+            return calcMapCoordinateFromDDM(coord);
+        default:
+            return calcMapCoordinateFromDD(coord);
+    };
+}
+
+
+function displayMapCoordinateAsDD({lat, long}: MapCoordinate): DisplayMapCoordinate {
+    return {lat: lat.toString()+"°", long: long.toString()+"°"} as DisplayMapCoordinate
+}
+
+function displayMapCoordinateAsDMS({lat, long}: MapCoordinate): DisplayMapCoordinate {
+    const dmsLat = DDtoDMS(lat, true);
+    const dmsLong = DDtoDMS(long, false);
+    return {
+        lat: `${dmsLat.degrees}° ${dmsLat.minutes}' ${dmsLat.seconds}" ${dmsLat.direction}`,
+        long: `${dmsLong.degrees}° ${dmsLong.minutes}' ${dmsLong.seconds}" ${dmsLong.direction}`
+    }
+}
+
+function displayMapCoordinateAsDDM({lat, long}: MapCoordinate): DisplayMapCoordinate {
+    const dmsLat = DDtoDDM(lat, true);
+    const dmsLong = DDtoDDM(long, false);
+    return {
+        lat: `${dmsLat.degrees}° ${dmsLat.minutes}' ${dmsLat.direction}`,
+        long: `${dmsLong.degrees}° ${dmsLong.minutes}' ${dmsLong.direction}`
+    }
+}
+
+function useDisplayMapCoordinate(coord: MapCoordinate): DisplayMapCoordinate {
+    const [cartographerCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
+    switch (cartographerCoordinateFormat) {
+        /** numbers align with coordinateFormatOptions, there should be a better way to do this from "../../../navbar/settings/CartographerSettings.tsx"*/
+        case 0:
+            return displayMapCoordinateAsDD(coord);
+        case 1:
+            return displayMapCoordinateAsDMS(coord);
+        case 2:
+            return displayMapCoordinateAsDDM(coord);
+        default:
+            return displayMapCoordinateAsDD(coord);
+    };
+}
+
+export {useDisplayMapCoordinate, useCalcMapCoordinate}

--- a/src/ros/nova-gui/nova-gui/src/components/navbar/settings/CartographerSettings.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/navbar/settings/CartographerSettings.tsx
@@ -1,0 +1,47 @@
+import { Select, SelectItem, SharedSelection } from "@nextui-org/react";
+import { useGenericStore } from "../../../hooks/useGenericStore";
+
+export type coordinateFormatOptionsType = {
+  id: number,  
+  label: string,
+  name: string,
+};
+
+export const coordinateFormatOptions = [
+  {id: 0, label: "DD", name: "Decimal Degrees"},
+  {id: 1, label: "DMS", name: "Degrees, Minutes and Seconds"},
+  {id: 2, label: "DDM", name: "Degrees, Decimal Minutes"},
+] as coordinateFormatOptionsType[];
+
+export default function CartographerSettings() {
+  const [coordinateFormat, setCoordinateFormat] = useGenericStore<number>("cartographerCoordinateFormat");
+
+  const onFormatSelectionChange = (keys: SharedSelection) => {
+    const selected = Array.from(keys)[0];
+    setCoordinateFormat(+selected);
+  };
+  return (
+    <div className="flex flex-col gap-3 mt-2 mb-4">
+      <Select
+        size="sm"
+        label="Latitude & Longitude Format"
+        selectedKeys={[coordinateFormat.toString()]}
+        onSelectionChange={onFormatSelectionChange}
+      >
+        {coordinateFormatOptions.map((option) => (
+          <SelectItem key={option.id}>
+            {`${option.label}: ${option.name}`}
+          </SelectItem>
+        ))}
+      </Select>
+
+      <div className="text-xs text-default-500">
+        Current coordinate format: {coordinateFormatOptions[coordinateFormat].label}
+      </div>
+
+      <div className="text-xs text-default-500">
+        Logs include batch, preprocessms, runms, postms, and totalms in the browser console.
+      </div>
+    </div>
+  );
+}

--- a/src/ros/nova-gui/nova-gui/src/components/navbar/settings/SettingsModal.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/navbar/settings/SettingsModal.tsx
@@ -10,6 +10,7 @@ import { useUIActions } from "../../../redux/actions/useUIActions.ts";
 import StoreSettings from "./StoreSettings.tsx";
 import {IPSettings} from "./IPSettings.tsx";
 import { YoloSettings } from "./YoloSettings.tsx";
+import CartographerSettings from "./CartographerSettings.tsx"
 
 /**
  * Settings Model containing GUI settings
@@ -46,6 +47,9 @@ export function SettingsModal() {
 
             <Tab title="YOLO">
               <YoloSettings />
+            </Tab>
+            <Tab title="Cartographer">
+              <CartographerSettings />
             </Tab>
           </Tabs>
 

--- a/src/ros/nova-gui/nova-gui/src/components/science/PresentationWidgets/SensorDataWidget.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/PresentationWidgets/SensorDataWidget.tsx
@@ -4,6 +4,7 @@ import {useGenericStore} from "../../../hooks/useGenericStore.ts";
 import {Site} from "../../../redux/models/genericStores/CurrentSiteStore.ts";
 import {SiteDataState} from "../../../redux/models/genericStores/SiteDataState.ts";
 import NIRResultsWidget from "./NIRResultsWidget.tsx";
+import {useDisplayMapCoordinate} from "../../maps/Cartographer/utils/convertCoords.ts";
 
 interface SensorDataWidgetProps {
   site: Site;
@@ -29,6 +30,8 @@ const SensorDataWidget: React.FC<SensorDataWidgetProps> = ({site}) => {
     return sensor.data.toFixed(2);
   };
 
+  const {lat: sensorLat, long: sensorLong} = useDisplayMapCoordinate({lat: +getSensorValue("Latitude"), long: +getSensorValue("Longitude")})
+
   return (
     <Card>
       <CardHeader className="text-h1 pb-0">
@@ -46,11 +49,11 @@ const SensorDataWidget: React.FC<SensorDataWidgetProps> = ({site}) => {
                 <div className="flex flex-row gap-4 flex-shrink-0">
                   <div className="flex flex-row gap-1 items-baseline whitespace-nowrap">
                     <span className="text-small text-default-500">Lat:</span>
-                    <span className="text-lg font-semibold">{getSensorValue("Latitude")}°</span>
+                    <span className="text-lg font-semibold">{sensorLat}</span>
                   </div>
                   <div className="flex flex-row gap-1 items-baseline whitespace-nowrap">
                     <span className="text-small text-default-500">Long:</span>
-                    <span className="text-lg font-semibold">{getSensorValue("Longitude")}°</span>
+                    <span className="text-lg font-semibold">{sensorLong}</span>
                   </div>
                 </div>
               </div>

--- a/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
+++ b/src/ros/nova-gui/nova-gui/src/redux/RootReducer.ts
@@ -437,6 +437,7 @@ export const reduxStores = {
   yoloActiveModel: createGenericStore("yoloActiveModel", DEFAULT_YOLO_MODEL_ID),
   yoloUseWebGPU: createGenericStore("yoloUseWebGPU", true),
   yoloTimingLogs: createGenericStore("yoloTimingLogs", true),
+  cartographerCoordinateFormat: createGenericStore("cartographerCoordinateFormat", 0),
   toolRotatorPresets: createGenericStore("toolRotatorPresets", {sweeper: 240.0, microscope: 0.0, nir_probe: 120.0} as PresetPositions),
   toolRotatorTwitchStep: createGenericStore("toolRotatorTwitchStep", 5.0),
   toolRotatorKeyboardControl: createGenericStore("toolRotatorKeyboardControl", false),


### PR DESCRIPTION
## Description

- script to convert between degrees/minutes/seconds and decimal degrees
- defaults to DMS --> DD as cartographer GUI only accepts DD, but has input and output flags for different formats
- can parse either positive/negative coordinates (e.g. "-XX YY ZZ") and also N/S/E/W coordinates (e.g. "XX YY ZZ S")
- can handle multiple coordinates at once (e.g. convert_coordinates.py "XX YY ZZ" "AA BB CC"), but will assume this to be a combined latitude + longitude string
- example usage below

## Changelogs
added src/other/convert_coordinates.py
added 'cc' alias for convert_coordinates.py in default.nix

## Screenshots
<img width="992" height="1173" alt="image" src="https://github.com/user-attachments/assets/2e847557-0432-493e-be6f-855f593cb30c" />
<img width="988" height="252" alt="image" src="https://github.com/user-attachments/assets/23afefa1-4c9c-4ffe-8b1d-f8c8183f7769" />

## Steps to Test
~/src/other/convert_coordinates.py "XX YY ZZ"
cc "XX YY ZZ"

## Memes
<img width="657" height="106" alt="image" src="https://github.com/user-attachments/assets/316b1ae1-742c-4c05-9cf1-50b4ca4cbdd1" />

<!-- TAGS START -->
Tags for Notion Integration:
tag:autonomous;tag:fieldtest;tag:gps;tag:ready_for_review
<!-- TAGS END -->
