### PR TITLE
feat: cameras3 blacklist + vis-spec pipeline

### DIFF
--- a/src/ros/cameras/cameras3/params/streamer.yaml
+++ b/src/ros/cameras/cameras3/params/streamer.yaml
@@ -1,5 +1,9 @@
 camera_streamer:
   ros__parameters:  
+    blacklist:
+      # These serials will not be used by the streamer node
+      - science_spectroscope
+      
     serial_pipelines:
       # Development cameras
       anthony-cam:

--- a/src/ros/cameras/cameras3/params/streamer.yaml
+++ b/src/ros/cameras/cameras3/params/streamer.yaml
@@ -2,7 +2,7 @@ camera_streamer:
   ros__parameters:  
     blacklist:
       # These serials will not be used by the streamer node
-      - science_spectroscope
+      - anthony-cam
       
     serial_pipelines:
       # Development cameras
@@ -45,8 +45,9 @@ camera_streamer:
         meta: Science - Shotglass
       science_rock_flipper:
         meta: Science - Rock flipper
-      #science_spectroscope:
-      #  autostart: false
+      science_spectroscope:
+        rossink: true
+        ros_topic: science/spectroscope
 
       # Arm
       arm_wrist:

--- a/src/ros/cameras/cameras3/src/camera_streamer_service.cpp
+++ b/src/ros/cameras/cameras3/src/camera_streamer_service.cpp
@@ -200,6 +200,13 @@ class CameraStreamer : public rclcpp::Node
   private: void topic_callback(const camera_msgs::msg::Cameras msg)
   {
     for (camera_msgs::msg::Camera camera : msg.cameras) {
+      // skip camera if blacklisted
+      std::vector<std::string> blacklist;
+      this->get_parameter("blacklist", blacklist);
+      if (std::find(blacklist.begin(), blacklist.end(), camera.serial) != blacklist.end()) {
+        RCLCPP_INFO(this->get_logger(), "%sCamera %s%s%s is blacklisted, skipping...%s", C_QUIET, C_FAIL, camera.serial.c_str(), C_QUIET, C_RESET);
+        continue;
+      }
       // Make the pipeline if it doesn't exist
       if (this->pipelines.find(camera.serial) == pipelines.end()) {
         std::unique_ptr<Pipeline> pipeline = std::make_unique<Pipeline>();

--- a/src/ros/cameras/cameras3/src/camera_streamer_service.cpp
+++ b/src/ros/cameras/cameras3/src/camera_streamer_service.cpp
@@ -124,6 +124,7 @@ class CameraStreamer : public rclcpp::Node
   rclcpp::Service<camera_msgs::srv::GetIPList>::SharedPtr ips_service_;
   rclcpp::Subscription<camera_msgs::msg::Cameras>::SharedPtr subscription_;
   std::unordered_map<std::string, std::unique_ptr<Pipeline>> pipelines;
+  std::set<std::string> camera_set;
   const std::unordered_set<std::string> profiles = {"default", "super", "still", "snail", "emergency"};
 
   // Initialize gstreamer opengl
@@ -199,6 +200,14 @@ class CameraStreamer : public rclcpp::Node
 
   private: void topic_callback(const camera_msgs::msg::Cameras msg)
   {
+    std::set<std::string> new_camera_set;
+    for (camera_msgs::msg::Camera camera : msg.cameras) {
+      // add camera serial to camera set
+      new_camera_set.insert(camera.serial);
+    }
+    if (new_camera_set == camera_set) return;
+    camera_set = new_camera_set;
+    
     for (camera_msgs::msg::Camera camera : msg.cameras) {
       // skip camera if blacklisted
       std::vector<std::string> blacklist;
@@ -207,6 +216,7 @@ class CameraStreamer : public rclcpp::Node
         RCLCPP_INFO(this->get_logger(), "%sCamera %s%s%s is blacklisted, skipping...%s", C_QUIET, C_FAIL, camera.serial.c_str(), C_QUIET, C_RESET);
         continue;
       }
+      
       // Make the pipeline if it doesn't exist
       if (this->pipelines.find(camera.serial) == pipelines.end()) {
         std::unique_ptr<Pipeline> pipeline = std::make_unique<Pipeline>();

--- a/src/ros/nova-gui/nova-gui/src/components/science/UVVisSpec/UVVisSpec.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/UVVisSpec/UVVisSpec.tsx
@@ -232,7 +232,7 @@ const UVVisSpec: React.FC<UVVisSpecProps> = (props) => {
         <div className="font-mono px-3 opacity-75">
           ({mousePoint[0].toFixed(3)}, {mousePoint[1].toFixed(3)}) -{'>'} {colToWavelength(mousePoint[0]).toFixed(2)} nm 
         </div>
-        <UVVisSpecStartStopButtons/>
+        {/*<UVVisSpecStartStopButtons/>*/}
         {settingsDropdown}
       </CardHeader>
       <CardBody className="flex flex-col gap-3">

--- a/src/ros/nova-gui/nova-gui/src/components/science/UVVisSpec/UVVisSpec.tsx
+++ b/src/ros/nova-gui/nova-gui/src/components/science/UVVisSpec/UVVisSpec.tsx
@@ -23,7 +23,7 @@ import {zip} from "lodash";
 import useDownload from "../../../hooks/useDownload.ts";
 import RamanLocalStorageSaveButton from "../RamanSpec/RamanLocalStorageSaveButton.tsx";
 import {useGenericStore} from "../../../hooks/useGenericStore.ts";
-import {UVVisSpecStartStopButtons} from "./UVVisSpecStartStopButtons.tsx";
+//import {UVVisSpecStartStopButtons} from "./UVVisSpecStartStopButtons.tsx";
 import {useCarouselPosition} from "../CarouselWidget/CarouselPositionContext.tsx";
 import {getCuvetteName} from "../CarouselWidget/cuvetteName.ts";
 import {shouldApplyBlank} from "./chemicalConfig.ts";

--- a/src/ros/rover/science/science/default.nix
+++ b/src/ros/rover/science/science/default.nix
@@ -7,6 +7,7 @@
 , rclpy
 , geometry-msgs
 , nav-msgs
+, sensor-msgs
 , trajectory-msgs
 , nova-science-interfaces
 , nova-input-interfaces
@@ -28,7 +29,7 @@ buildRosPackage {
 
   nativeBuildInputs = [ ament-cmake ];
 
-  buildInputs = [ rclcpp rclpy geometry-msgs nav-msgs trajectory-msgs ];
+  buildInputs = [ rclcpp rclpy geometry-msgs nav-msgs trajectory-msgs sensor-msgs];
 
   propagatedBuildInputs = with pythonPackages; [
     jcan
@@ -38,6 +39,7 @@ buildRosPackage {
     opencv4
     pyserial
     python3Packages.minimalmodbus
+    python3Packages.numpy
   ] ++
   [
     nova-python-control

--- a/src/ros/rover/science/science/science/urc/urc_uv_vis_spec.py
+++ b/src/ros/rover/science/science/science/urc/urc_uv_vis_spec.py
@@ -3,11 +3,16 @@
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Monash Nova Rover Team
-This file contains the ROS2 publisher code for the actuator limit switch.
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PACKAGE:     electronics
-AUTHOR(S):   Bailey Chessum
-CREATION:    2/05/2024
-EDITED:      2/05/2024
+
+This file contains the ROS2 node for the UV Vis Spectrometer, 
+which captures images from a camera, extracts luminance data, 
+and publishes it for use by other nodes. 
+The node also provides services to start and stop the camera feed.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+PACKAGE:     science
+AUTHOR(S):   Josh Leivenzon, Bailey Chessum, Felicity Matthews
+CREATION:    25/05/2024
+EDITED:      24/05/2026
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 """
 import typing

--- a/src/ros/rover/science/science/science/urc/urc_uv_vis_spec.py
+++ b/src/ros/rover/science/science/science/urc/urc_uv_vis_spec.py
@@ -10,7 +10,7 @@ and publishes it for use by other nodes.
 The node also provides services to start and stop the camera feed.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 PACKAGE:     science
-AUTHOR(S):   Josh Leivenzon, Bailey Chessum, Felicity Matthews
+AUTHOR(S):   Josh Leivenzon, Bailey Chessum, Felicity Matthews, Anthony Lew
 CREATION:    25/05/2024
 EDITED:      24/05/2026
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -19,15 +19,18 @@ import typing
 
 import camera_msgs.msg
 import rclpy
-from camera_msgs.msg import Camera, Cameras
+from sensor_msgs.msg import Image
 from rclpy import qos
 from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
 import cv2
 import math
+import numpy as np
 from typing import List
 from science_interfaces.msg import UVVisSpecData
 from std_srvs.srv import Trigger
 
+IMAGE_TOPIC = '/science/spectroscope'
 
 def rgb_to_luminance(rgb: [int, int, int]) -> float: # type: ignore
     """ Converts a 3 colour channel pixel value to a single luminance value. The max value for an RBG array element
@@ -59,142 +62,34 @@ class UVVisSpecPublisher(Node):
         # Specifies the size of the range of pixels to vertically average to get a reading
         self.__range = self.declare_parameter("range", 0.1)
         # The period at which the camera is sampled
-        self.declare_parameter("period", 0.05)
+        timer_period = self.declare_parameter("period", 0.05).get_parameter_value().double_value
 
         # Defines the range of columns to use
         self.__col_start = self.declare_parameter("col_start", 0.425)
         self.__col_end = self.declare_parameter("col_end", 0.7)
 
-        # Try get the camera
-        self.__timer = None
-        self.camera = None
-        self.__is_running = False
-        self.__camera_node = None  # Will be set when camera is discovered
+        self.image = None
+        self.__timer = self.create_timer(timer_period, self.__get_image)
+        self.image_sub = self.create_subscription(Image, IMAGE_TOPIC, self.__image_callback, qos_profile=qos_profile_sensor_data)
 
-        self.get_logger().info("Waiting for camera directory service...")
-        self.__camera_list_subscription = self.create_subscription(
-            camera_msgs.msg.Cameras,
-            "camera_directory/cameras",
-            self.__begin,
-            qos.QoSProfile(
-                history=qos.HistoryPolicy.KEEP_LAST,
-                depth=1,
-                reliability=qos.ReliabilityPolicy.RELIABLE,
-                durability=qos.DurabilityPolicy.TRANSIENT_LOCAL,
-            ),
-        )
+    def __image_callback(self, msg: Image):
+        self.image = msg
 
-        # Create stop/start services
-        self.stop_service = self.create_service(Trigger, "/science/uv_vis_spec/stop", self.__stop_callback)
-        self.start_service = self.create_service(Trigger, "/science/uv_vis_spec/start", self.__start_callback)
-
-    def __begin(self, cameras: Cameras):
-        """Callback when camera directory is received. Finds and initializes the spectroscope camera."""
-        # Don't restart if camera is already running or was intentionally stopped
-        if self.camera or (self.__camera_node and not self.__is_running):
-            return
-
-        camera_node = next((typing.cast(Camera, camera).node for camera in cameras.cameras if
-                            typing.cast(Camera, camera).serial == "science_spectroscope"), None)
-        if camera_node:
-            self.get_logger().info(f"uv_vis camera found at {camera_node}.")
-        else:
-            self.get_logger().warn("No uv_vis camera was found. UV Vis Spec. not running.")
-            return
-
-        # Store the camera_node for later use by start service
-        self.__camera_node = camera_node
-
-        # Open camera and start capture using helper method
-        if self.__start_camera_capture():
-            self.get_logger().info("Beginning UV Vis Spec.")
-            self.__is_running = True
-        else:
-            self.get_logger().error("Failed to start UV Vis Spec camera")
-
-    def __start_camera_capture(self) -> bool:
-        """
-        Opens the camera and starts the capture timer.
-        Assumes self.__camera_node has been set.
-        Returns True if successful, False otherwise.
-        """
-        if not self.__camera_node:
-            self.get_logger().error("No camera node available")
-            return False
-
+    def __msg_to_mat(self, logger, img, encoding) -> np.ndarray:
+        """Converts Image msg to cv2 frame"""
+        mat = None
         try:
-            # Open camera (same logic from __begin)
-            self.camera = cv2.VideoCapture(int(self.__camera_node.removeprefix("/dev/video")))
-            self.camera.set(cv2.CAP_PROP_BUFFERSIZE, 1)
-
-            # Start the timer for frame capture
-            self.__timer = self.create_timer(
-                float(self.get_parameter("period").value),
-                self.__get_image
-            )
-
-            return True
+            mat = np.frombuffer(img.data, dtype=np.uint8).reshape(img.height, img.width, -1)
         except Exception as e:
-            self.get_logger().error(f"Failed to start camera: {e}")
-            return False
-
-    def __stop_callback(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """Service callback to stop the camera feed and release the camera."""
-        if not self.__is_running:
-            self.get_logger().warn("Stop service called but camera is already stopped")
-            response.success = False
-            response.message = "UV Vis Spec camera is already stopped"
-            return response
-
-        # Stop the timer
-        if self.__timer:
-            self.__timer.cancel()
-            self.__timer = None
-
-        # Release the camera
-        if self.camera:
-            self.camera.release()
-            self.camera = None
-
-        self.__is_running = False
-        self.get_logger().info("UV Vis Spec camera stopped and released")
-
-        response.success = True
-        response.message = "Camera stopped successfully"
-        return response
-
-    def __start_callback(self, request: Trigger.Request, response: Trigger.Response) -> Trigger.Response:
-        """Service callback to restart the camera feed."""
-        if self.__is_running:
-            self.get_logger().warn("Start service called but camera is already running")
-            response.success = False
-            response.message = "UV Vis Spec camera is already running"
-            return response
-
-        # Reuse the camera opening logic
-        if self.__start_camera_capture():
-            self.__is_running = True
-            self.get_logger().info("UV Vis Spec camera restarted")
-            response.success = True
-            response.message = "Camera started successfully"
-        else:
-            self.get_logger().error("Start service failed to open camera")
-            response.success = False
-            response.message = "Failed to open camera"
-
-        return response
+            logger.error(str(e))
+        return mat
 
     def __get_image(self):
         """Capture a frame from the camera, extract luminance data, and publish it."""
-        # Safety check: only proceed if camera is running
-        if not self.__is_running or not self.camera:
-            return
-
-        self.camera.grab()
-        success, video_frame = self.camera.read()
+        video_frame = self.__msg_to_mat(self.get_logger(), self.image, 'bgr8')
 
         # Ensure the video was successfully retrieved
-        if not success or len(video_frame) == 0:
+        if video_frame is None or len(video_frame) == 0:
             self.get_logger().warn("UV Vis Spec failed to get frame from camera.")
             return
 
@@ -238,10 +133,6 @@ class UVVisSpecPublisher(Node):
 
         # Publish to the topic
         self.publisher.publish(msg)
-
-    def __del__(self):
-        """Destructor to release the camera when the node is destroyed."""
-        self.camera.release()
 
 
 # The main code that executes when starting


### PR DESCRIPTION
### Changes
Adds a blacklist option to the streamer node in Cameras3
Also configures a ros topic pipeline for the uv vis spec

uv vis spec now uses the ros topic instead of cv2.videoCapture function


### To do (In future):
Things to fix (less important and can be done after comp)
- Blacklisted cameras will still show up in the gui camera control panel
  - This is because the gui control panel uses the directory topic and not the streamer node's information so to fix this would be to create a service on the streamer node which the gui polls to see what cameras actually have an active webrtc endpoint
- I deleted the start and end camera stream buttons on the uv vis spec, we should add a button which opens a camera control panel for this camera
- the ros topic of a pipeline should be advertised on the gui camera control panel as well as printed in console. currently the only way to know is either read the config or ros2 topic list and guess
- The logging on urc_uv_vis_spec.py is not accurate to whats happening and there's nothing that checks for the camera etc so if it has the topic but nothing on it, it will spam the console

### To test:
- Run GUI 
  - `gui-dev-shell`; `gui-run`
  - `gui-rosbridge`
- Run the uv vis spec node 
  - `ros2 run science urc_uv_vis_spec.py`
- Open the GUI and watch as the cameras work simultaneously with the UV Vis Spec

### Meme:
![Uploading image.png…]()

<!-- TAGS START -->
Tags for Notion Integration:
tag:science;tag:cameras
<!-- TAGS END -->
