### PR TITLE
arm_bringup: launch: don't log can when using mock hardware

### DIFF
--- a/src/ros/rover/arm/arm_bringup/launch/control.launch.py
+++ b/src/ros/rover/arm/arm_bringup/launch/control.launch.py
@@ -109,19 +109,24 @@ def launch_setup(context, *args, **kwargs):
                     arguments=[end_effector_velocity_controller_name, '--inactive', "-c", "/arm/controller_manager"],
                     additional_env=show_colours_additional_env,
                 ),
-                IncludeLaunchDescription(
-                    launch_description_source=PythonLaunchDescriptionSource(
-                        PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
-                    ),
-                    launch_arguments={
-                        "bus" : "can1",
-                        "bitrate" : IfElseSubstitution(
-                            condition=arm,
-                            if_value="250000",
-                            else_value="200000",
+                GroupAction(
+                    condition=UnlessCondition(use_mock_hardware),
+                    actions=[
+                        IncludeLaunchDescription(
+                            launch_description_source=PythonLaunchDescriptionSource(
+                                PathJoinSubstitution([nova_bringup_dir, "launch", "can.launch.py"])
+                            ),
+                            launch_arguments={
+                                "bus" : "can1",
+                                "bitrate" : IfElseSubstitution(
+                                    condition=arm,
+                                    if_value="250000",
+                                    else_value="200000",
+                                ),
+                                "log_name" : "arm",
+                            }.items()
                         ),
-                        "log_name" : "arm",
-                    }.items()
+                    ],
                 ),
             ]
         ),


### PR DESCRIPTION
when we are using mock hardware, we shouldn't try to source the can launch file as we don't need a can bus and don't use it

<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Screenshots

<!--- Add some Shiny Screenshots or Videos Demonstrating the Feature (if applicable) --->

## ROS
<!-- Add Information about Nodes/Topics that is Purely ROS Related -->

## Steps to Test

<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
