### PR TITLE
Fix nixos-rebuild 

### DIFF
--- a/nixfiles/modules/home/nova/default.nix
+++ b/nixfiles/modules/home/nova/default.nix
@@ -111,7 +111,7 @@ in
         # Shell utilities
         pciutils
         pcl
-        cloudcompare
+        # cloudcompare
         usbutils
         gpsd
         can-utils

--- a/nixfiles/modules/nixos/common/desktop/default.nix
+++ b/nixfiles/modules/nixos/common/desktop/default.nix
@@ -21,7 +21,6 @@ in
     services = {
       displayManager.gdm = {
         enable = true;
-        wayland = cfg.wayland.enable;
       };
       desktopManager.gnome.enable = true;
       xserver.excludePackages = with pkgs; [

--- a/nixfiles/modules/nixos/devices/jetson/default.nix
+++ b/nixfiles/modules/nixos/devices/jetson/default.nix
@@ -1,11 +1,12 @@
-{ config, lib, pkgs, jetpack-nixos ? builtins.fetchTarball {
-    url = "https://github.com/anduril/jetpack-nixos/archive/79a0ba1d5df6bfef19b425169fcb8478ecf2686f.tar.gz";
-    sha256 = "1wywzmx452f594gsvbj4207m3fm993mkg0jscidjdj36alalf82a";
-  }, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   cfg = config.devices.jetson;
   hasJetpackChannel = true;
+  jetpack-nixos = builtins.fetchTarball {
+    url = "https://github.com/anduril/jetpack-nixos/archive/79a0ba1d5df6bfef19b425169fcb8478ecf2686f.tar.gz";
+    sha256 = "1wywzmx452f594gsvbj4207m3fm993mkg0jscidjdj36alalf82a";
+  };
   jetpack-nixos-module = (import (builtins.toPath "${jetpack-nixos}/modules/default.nix") (import ( builtins.toPath "${jetpack-nixos}/overlay.nix")));
 in
 {


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description

<!--- Elaborate on your Wonderful Work! --->

`nixos-rebuild` currently fails due to some accumulated tech debt from untested changes or upstream changes that have propagated back down to us.

<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs

<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

- Fixed infinite recursion error in jetson imports. 
- Fixed removed wayland option in gdm service (wayland is the only supported option now).
- Commented out cloudcompare (needs to be fixed in a future PR; nixpkgs builds the latest release of CloudCompare which is from 2 years ago, despite the main branch constantly being updated. Either a PR needs to be made to nixos-unstable to patch CloudCompare main's fix to nixos-unstable's cloudcompare, or cloudcompare's src needs to be overwritten to point to CloudCompare's main branch)

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->

<img width="482" height="639" alt="image" src="https://github.com/user-attachments/assets/e41bd938-8273-4e6e-8f15-daa7106f5745" />
