### PR TITLE
fix: nova cli main

### DIFF
--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -316,7 +316,7 @@ in
           launch-magnetometer = "~/Builds/active/bin/ros2 run electronics magnetometer.py";
           mast = "ssh -C nova@10.0.0.150";
 
-          # Master build binaries
+          # Active build binaries
           mros2 = "~/Builds/active/bin/ros2";
           mrviz2 = "~/Builds/active/bin/rviz2";
           mrviz = "~/Builds/active/bin/rviz2";

--- a/nixfiles/modules/home/macros/default.nix
+++ b/nixfiles/modules/home/macros/default.nix
@@ -99,7 +99,7 @@ in
         if [ -f "/run/user/$UID/nova/active_build" ]; then
           . "/run/user/$UID/nova/active_build"
         else
-          ln -sfn "$HOME/Builds/master" "$HOME/Builds/active"
+          ln -sfn "$HOME/Builds/main" "$HOME/Builds/active"
         fi
 
         # Calculate box width based on longest content line (in subshell to auto-cleanup)
@@ -156,7 +156,7 @@ in
           echo   "Config is written to ~/.config/nova/comp"
           echo   ""
           printf "''${yellow}Active Build:''${end} Set with set_active <build_path> function.\n"
-          echo   "~/Builds/active -> <build_path> symlink. Allows aliases to point to a build other than master. Currently only used by auto."
+          echo   "~/Builds/active -> <build_path> symlink. Allows aliases to point to a build other than main. Currently only used by auto."
           echo   "Config is written to /run/user/''${UID}/nova/active_build"
           echo   ""
           echo   "The files written to are sourced on shell startup."
@@ -336,8 +336,8 @@ in
 
           # Science
           predict-shell = "nom-shell ~/nova/src/other/ilmenite_ml"; # please come up with a more descriptive and less generic alias
-          run-spec = "~/Builds/master/bin/ros2 run science urc_uv_vis_spec.py";
-          run-theta = "sudo -E LANG=C ~/Builds/master/bin/ros2 run science urc_theta_360_cam.py";
+          run-spec = "~/Builds/main/bin/ros2 run science urc_uv_vis_spec.py";
+          run-theta = "sudo -E LANG=C ~/Builds/main/bin/ros2 run science urc_theta_360_cam.py";
 
           # ros2_control
           controllers-list = "~/Builds/active/bin/ros2 control list_controllers";

--- a/src/other/nova_cli/README.md
+++ b/src/other/nova_cli/README.md
@@ -37,7 +37,7 @@ nova_cli/
 | `build` | [build.py](nova_cli/commands/build.py) | Build workspace to `~/Builds/<name>` using ws-build |
 | `env` | [env.py](nova_cli/commands/env.py) | Manage environment variables (COMP, RMW, domain) and active build |
 | `launch` | [launch.py](nova_cli/commands/launch.py) | Launch ROS2 launch files with automatic `_bringup` and `.launch.py` handling |
-| `rebuild-master` | [rebuild_master.py](nova_cli/commands/rebuild_master.py) | Checkout master, pull latest changes, and build to `~/Builds/master` |
+| `rebuild-main` | [rebuild_main.py](nova_cli/commands/rebuild_main.py) | Checkout main, pull latest changes, and build to `~/Builds/main` |
 | `run` | [run.py](nova_cli/commands/run.py) | Run ROS2 node executables with automatic `.py` extension handling |
 | `sleuth` | [sleuth.py](nova_cli/commands/sleuth.py) | CAN bus tracer/emulator (passthrough to can_sleuth) |
 | `start` | [start.py](nova_cli/commands/start.py) | Execute terminal launch scripts from `~/Builds/<build>/launch/` |

--- a/src/other/nova_cli/nova_cli/build_utils.py
+++ b/src/other/nova_cli/nova_cli/build_utils.py
@@ -22,7 +22,7 @@ def validate_build_path(build_name):
     Validate that a build exists and return its path.
 
     Args:
-        build_name: Name of the build (e.g., 'active', 'master', 'auto')
+        build_name: Name of the build (e.g., 'active', 'main', 'auto')
 
     Returns:
         Path to build directory if valid, None otherwise
@@ -71,7 +71,7 @@ def add_build_argument(parser):
     parser.add_argument(
         '-b', '--build',
         default='active',
-        help='Build to use (default: active). Available: master, auto, arm, drive, etc.'
+        help='Build to use (default: active). Available: main, auto, arm, drive, etc.'
     )
 
 

--- a/src/other/nova_cli/nova_cli/commands/__init__.py
+++ b/src/other/nova_cli/nova_cli/commands/__init__.py
@@ -13,7 +13,7 @@ EDITED:         09/07/2026
 from nova_cli.commands.build import BuildCommand
 from nova_cli.commands.env import EnvCommand
 from nova_cli.commands.launch import LaunchCommand
-from nova_cli.commands.rebuild_main import RebuildMasterCommand
+from nova_cli.commands.rebuild_main import RebuildMainCommand
 from nova_cli.commands.run import RunCommand
 from nova_cli.commands.sleuth import SleuthCommand
 from nova_cli.commands.start import StartCommand

--- a/src/other/nova_cli/nova_cli/commands/__init__.py
+++ b/src/other/nova_cli/nova_cli/commands/__init__.py
@@ -13,7 +13,7 @@ EDITED:         09/07/2026
 from nova_cli.commands.build import BuildCommand
 from nova_cli.commands.env import EnvCommand
 from nova_cli.commands.launch import LaunchCommand
-from nova_cli.commands.rebuild_master import RebuildMasterCommand
+from nova_cli.commands.rebuild_main import RebuildMasterCommand
 from nova_cli.commands.run import RunCommand
 from nova_cli.commands.sleuth import SleuthCommand
 from nova_cli.commands.start import StartCommand
@@ -23,7 +23,7 @@ COMMANDS = {
     'build': BuildCommand,
     'env': EnvCommand,
     'launch': LaunchCommand,
-    'rebuild-master': RebuildMasterCommand,
+    'rebuild-main': RebuildMasterCommand,
     'run': RunCommand,
     'sleuth': SleuthCommand,
     'start': StartCommand,

--- a/src/other/nova_cli/nova_cli/commands/__init__.py
+++ b/src/other/nova_cli/nova_cli/commands/__init__.py
@@ -23,7 +23,7 @@ COMMANDS = {
     'build': BuildCommand,
     'env': EnvCommand,
     'launch': LaunchCommand,
-    'rebuild-main': RebuildMasterCommand,
+    'rebuild-main': RebuildMainCommand,
     'run': RunCommand,
     'sleuth': SleuthCommand,
     'start': StartCommand,

--- a/src/other/nova_cli/nova_cli/commands/build.py
+++ b/src/other/nova_cli/nova_cli/commands/build.py
@@ -4,7 +4,7 @@ Builds the Nova workspace to a named output directory. Wraps nom-build
 with automatic output path handling.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 EXAMPLES:
-  nova build master             # Build to ~/Builds/master
+  nova build main             # Build to ~/Builds/main
   nova build auto               # Build to ~/Builds/auto
   nova build test --packages-select science  # Pass extra args
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -36,7 +36,7 @@ class BuildCommand(Command):
 
         buildname_arg = parser.add_argument(
             'buildname',
-            help='Build output name (e.g., master, auto, arm)'
+            help='Build output name (e.g., main, auto, arm)'
         )
         buildname_arg.completer = BuildCommand.complete_buildname
 

--- a/src/other/nova_cli/nova_cli/commands/env.py
+++ b/src/other/nova_cli/nova_cli/commands/env.py
@@ -8,7 +8,7 @@ EXAMPLES:
   nova env status               # Show all env var values
   nova env set comp URC         # Set competition mode
   nova env set rmw cyclone      # Set RMW (with shortcut)
-  nova env set build master     # Switch active build
+  nova env set build main     # Switch active build
   nova env get domain           # Get ROS domain ID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        nova_cli

--- a/src/other/nova_cli/nova_cli/commands/rebuild_main.py
+++ b/src/other/nova_cli/nova_cli/commands/rebuild_main.py
@@ -1,11 +1,11 @@
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Checkout master branch, pull latest changes, and rebuild.
+Checkout main branch, pull latest changes, and rebuild.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 EXAMPLES:
-  nova rebuild-master              # Update and rebuild master
-  nova rebuild-master --stash      # Auto-stash uncommitted changes
-  nova rebuild-master --verbose    # Pass --verbose to nom-build
+  nova rebuild-main              # Update and rebuild main
+  nova rebuild-main --stash      # Auto-stash uncommitted changes
+  nova rebuild-main --verbose    # Pass --verbose to nom-build
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        nova_cli
 AUTHOR(S):      Nova Team
@@ -21,16 +21,16 @@ from nova_cli.commands.base import Command
 
 
 class RebuildMasterCommand(Command):
-    """Implements 'nova rebuild-master' command"""
+    """Implements 'nova rebuild-main' command"""
 
     @staticmethod
     def add_parser(subparsers):
-        """Add rebuild-master subcommand parser"""
+        """Add rebuild-main subcommand parser"""
         parser = subparsers.add_parser(
-            'rebuild-master',
-            help='Checkout master, pull latest changes, and rebuild',
-            description='Checkout master branch in ~/nova, pull latest changes, '
-                       'and build to ~/Builds/master'
+            'rebuild-main',
+            help='Checkout main, pull latest changes, and rebuild',
+            description='Checkout main branch in ~/nova, pull latest changes, '
+                       'and build to ~/Builds/main'
         )
 
         parser.add_argument(
@@ -43,11 +43,11 @@ class RebuildMasterCommand(Command):
 
     @staticmethod
     def execute(args):
-        """Execute rebuild-master command"""
+        """Execute rebuild-main command"""
         # Define paths
         nova_dir = Path.home() / "nova"
         builds_dir = Path.home() / "Builds"
-        output_path = builds_dir / "master"
+        output_path = builds_dir / "main"
 
         # Step 1: Validate nova directory exists
         if not nova_dir.exists():
@@ -79,16 +79,16 @@ class RebuildMasterCommand(Command):
                 print("  git stash", file=sys.stderr)
                 print("  git commit -am 'message'", file=sys.stderr)
                 print("\nOr run with --stash flag to automatically stash changes:", file=sys.stderr)
-                print("  nova rebuild-master --stash", file=sys.stderr)
+                print("  nova rebuild-main --stash", file=sys.stderr)
                 return 1
 
-        # Step 3: Checkout master
-        print("Checking out master branch...", file=sys.stderr)
-        cmd = ['git', '-C', str(nova_dir), 'checkout', 'master']
+        # Step 3: Checkout main
+        print("Checking out main branch...", file=sys.stderr)
+        cmd = ['git', '-C', str(nova_dir), 'checkout', 'main']
         result = subprocess.run(cmd)
 
         if result.returncode != 0:
-            print("Error: Failed to checkout master branch", file=sys.stderr)
+            print("Error: Failed to checkout main branch", file=sys.stderr)
             return 1
 
         # Step 4: Pull latest changes
@@ -100,8 +100,8 @@ class RebuildMasterCommand(Command):
             print("Error: Failed to pull latest changes", file=sys.stderr)
             return 1
 
-        # Step 5: Build master
-        print("Building master...", file=sys.stderr)
+        # Step 5: Build main
+        print("Building main...", file=sys.stderr)
         cmd = [
             'bash', '-ic', # use bash to get the alias
             f'ws-build -o {output_path} {" ".join(args.extra_args)}'
@@ -118,5 +118,5 @@ class RebuildMasterCommand(Command):
             print("Error: nom-build not found in PATH", file=sys.stderr)
             return 1
 
-        print("\nSuccessfully updated and built master!", file=sys.stderr)
+        print("\nSuccessfully updated and built main!", file=sys.stderr)
         return 0

--- a/src/other/nova_cli/nova_cli/commands/rebuild_main.py
+++ b/src/other/nova_cli/nova_cli/commands/rebuild_main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from nova_cli.commands.base import Command
 
 
-class RebuildMasterCommand(Command):
+class RebuildMainCommand(Command):
     """Implements 'nova rebuild-main' command"""
 
     @staticmethod

--- a/src/other/nova_cli/nova_cli/main.py
+++ b/src/other/nova_cli/nova_cli/main.py
@@ -47,8 +47,8 @@ Examples:
   nova launch science urc           Launch science_bringup/urc.launch.py
   nova run science kiln             Run science/kiln.py node
   nova start gui                    Run ~/Builds/active/launch/run-gui script
-  nova build master                 Build workspace to ~/Builds/master
-  nova env set build master         Switch active build to master
+  nova build main                 Build workspace to ~/Builds/main
+  nova env set build main         Switch active build to main
         '''
     )
 

--- a/src/other/nova_cli/tests/conftest.py
+++ b/src/other/nova_cli/tests/conftest.py
@@ -43,7 +43,7 @@ def nova_cli():
         cmd = nova_cli(["launch", "science", "urc"])
         cmd = nova_cli(["run", "science", "kiln"])
         cmd = nova_cli(["start", "run-gui"])
-        cmd = nova_cli(["build", "master"])
+        cmd = nova_cli(["build", "main"])
 
     Override available packages/executables/scripts:
         cmd = nova_cli(["launch", "cameras"], packages=["cameras"])

--- a/src/other/nova_cli/tests/test_build.py
+++ b/src/other/nova_cli/tests/test_build.py
@@ -20,10 +20,10 @@ class TestBuildCLI:
     """Full CLI tests for nova build command."""
 
     def test_basic_build(self, nova_cli):
-        cmd = nova_cli(["build", "master"])
+        cmd = nova_cli(["build", "main"])
         assert cmd == [
             "bash", "-ic",
-            "ws-build -o /home/test/Builds/master"
+            "ws-build -o /home/test/Builds/main"
         ]
 
     def test_build_auto(self, nova_cli):
@@ -45,7 +45,7 @@ class TestBuildCommand:
     """Unit tests for BuildCommand error handling."""
 
     def test_nom_build_not_found(self, capsys):
-        args = SimpleNamespace(buildname='master', extra_args=[])
+        args = SimpleNamespace(buildname='main', extra_args=[])
 
         with patch.object(Path, 'home', return_value=Path('/home/test')):
             with patch('subprocess.run', side_effect=FileNotFoundError):

--- a/src/other/nova_cli/tests/test_build_utils.py
+++ b/src/other/nova_cli/tests/test_build_utils.py
@@ -51,7 +51,7 @@ class TestListAvailableBuilds:
     def test_lists_valid_builds(self, tmp_path):
         """Lists only directories with ros2 binary"""
         # Create valid build
-        valid_build = tmp_path / "master"
+        valid_build = tmp_path / "main"
         (valid_build / "bin").mkdir(parents=True)
         (valid_build / "bin" / "ros2").touch()
 
@@ -61,7 +61,7 @@ class TestListAvailableBuilds:
 
         with patch('nova_cli.build_utils.BUILDS_DIR', tmp_path):
             result = list_available_builds()
-            assert result == ["master"]
+            assert result == ["main"]
 
     def test_empty_builds_dir(self, tmp_path):
         """Returns empty list when no builds exist"""
@@ -78,14 +78,14 @@ class TestListAvailableBuilds:
 
     def test_sorted_output(self, tmp_path):
         """Builds are returned in sorted order"""
-        for name in ["drive", "auto", "master", "arm"]:
+        for name in ["drive", "auto", "main", "arm"]:
             build = tmp_path / name
             (build / "bin").mkdir(parents=True)
             (build / "bin" / "ros2").touch()
 
         with patch('nova_cli.build_utils.BUILDS_DIR', tmp_path):
             result = list_available_builds()
-            assert result == ["arm", "auto", "drive", "master"]
+            assert result == ["arm", "auto", "drive", "main"]
 
     def test_includes_symlinks(self, tmp_path):
         """Symlinks with ros2 binary are included"""

--- a/src/other/nova_cli/tests/test_env.py
+++ b/src/other/nova_cli/tests/test_env.py
@@ -25,10 +25,10 @@ class TestEnvStatus:
                 assert var_name in output
 
     def test_status_shows_build_with_arrow(self, capsys):
-        with patch.object(EnvCommand, '_get_value', side_effect=lambda v: "master" if v.name == "build" else "(not set)"):
+        with patch.object(EnvCommand, '_get_value', side_effect=lambda v: "main" if v.name == "build" else "(not set)"):
             EnvCommand._status()
             output = capsys.readouterr().out
-            assert "build:   active -> master" in output
+            assert "build:   active -> main" in output
 
 
 class TestEnvSet:
@@ -60,15 +60,15 @@ class TestEnvSet:
 
     def test_set_build_calls_setter(self, tmp_path):
         builds_dir = tmp_path / "Builds"
-        master_build = builds_dir / "master" / "bin"
-        master_build.mkdir(parents=True)
-        (master_build / "ros2").touch()
+        main_build = builds_dir / "main" / "bin"
+        main_build.mkdir(parents=True)
+        (main_build / "ros2").touch()
 
         with patch('nova_cli.commands.env.BUILDS_DIR', builds_dir):
-            result = set_active_build("master")
+            result = set_active_build("main")
             assert result == 0
             assert (builds_dir / "active").is_symlink()
-            assert (builds_dir / "active").resolve() == builds_dir / "master"
+            assert (builds_dir / "active").resolve() == builds_dir / "main"
 
     def test_set_build_nonexistent(self, tmp_path, capsys):
         builds_dir = tmp_path / "Builds"
@@ -116,16 +116,16 @@ class TestEnvGet:
 
     def test_get_build_uses_getter(self, tmp_path):
         builds_dir = tmp_path / "Builds"
-        master_build = builds_dir / "master" / "bin"
-        master_build.mkdir(parents=True)
-        (master_build / "ros2").touch()
+        main_build = builds_dir / "main" / "bin"
+        main_build.mkdir(parents=True)
+        (main_build / "ros2").touch()
 
         active = builds_dir / "active"
-        active.symlink_to(builds_dir / "master")
+        active.symlink_to(builds_dir / "main")
 
         with patch('nova_cli.commands.env.BUILDS_DIR', builds_dir):
             value = get_active_build()
-            assert value == "master"
+            assert value == "main"
 
     def test_get_build_not_set(self, tmp_path):
         builds_dir = tmp_path / "Builds"

--- a/src/other/nova_cli/tests/test_launch.py
+++ b/src/other/nova_cli/tests/test_launch.py
@@ -37,8 +37,8 @@ class TestLaunchCLI:
         assert cmd == ["/builds/active/bin/ros2", "launch", "auto_bringup", "sim.launch.py", "sim:=True", "debug:=False"]
 
     def test_build_flag_short(self, nova_cli):
-        cmd = nova_cli(["launch", "science", "urc", "-b", "master"])
-        assert cmd == ["/builds/master/bin/ros2", "launch", "science_bringup", "urc.launch.py"]
+        cmd = nova_cli(["launch", "science", "urc", "-b", "main"])
+        assert cmd == ["/builds/main/bin/ros2", "launch", "science_bringup", "urc.launch.py"]
 
     def test_build_flag_long(self, nova_cli):
         cmd = nova_cli(["launch", "science", "urc", "--build", "auto"])
@@ -49,16 +49,16 @@ class TestLaunchCLI:
         assert cmd == ["/builds/arm/bin/ros2", "launch", "science_bringup", "urc.launch.py"]
 
     def test_build_flag_with_extra_args(self, nova_cli):
-        cmd = nova_cli(["launch", "auto", "sim", "sim:=True", "-b", "master"])
-        assert cmd == ["/builds/master/bin/ros2", "launch", "auto_bringup", "sim.launch.py", "sim:=True"]
+        cmd = nova_cli(["launch", "auto", "sim", "sim:=True", "-b", "main"])
+        assert cmd == ["/builds/main/bin/ros2", "launch", "auto_bringup", "sim.launch.py", "sim:=True"]
 
     def test_cameras_fallback_no_bringup(self, nova_cli):
         cmd = nova_cli(["launch", "cameras"], packages=["cameras"])
         assert cmd == ["/builds/active/bin/ros2", "launch", "cameras", "cameras.launch.py"]
 
     def test_drive_with_build_flag(self, nova_cli):
-        cmd = nova_cli(["launch", "drive", "-b", "master"])
-        assert cmd == ["/builds/master/bin/ros2", "launch", "drive_bringup", "drive.launch.py"]
+        cmd = nova_cli(["launch", "drive", "-b", "main"])
+        assert cmd == ["/builds/main/bin/ros2", "launch", "drive_bringup", "drive.launch.py"]
 
     def test_drive_with_extra_arg(self, nova_cli):
         cmd = nova_cli(["launch", "drive", "auto:=true"])

--- a/src/other/nova_cli/tests/test_main.py
+++ b/src/other/nova_cli/tests/test_main.py
@@ -24,8 +24,8 @@ class TestCreateParser:
     def test_build_flag_on_launch(self):
         """Build flag is available on launch command"""
         parser = create_parser()
-        args, _ = parser.parse_known_args(['launch', 'science', '-b', 'master'])
-        assert args.build == 'master'
+        args, _ = parser.parse_known_args(['launch', 'science', '-b', 'main'])
+        assert args.build == 'main'
 
     def test_build_flag_on_run(self):
         """Build flag is available on run command"""
@@ -42,7 +42,7 @@ class TestCreateParser:
     def test_no_global_build_flag(self):
         """Build flag before command causes an error"""
         parser = create_parser()
-        # -b before command is now invalid - argparse will treat 'master' as the command
-        # and fail because 'master' is not a valid subcommand
+        # -b before command is now invalid - argparse will treat 'main' as the command
+        # and fail because 'main' is not a valid subcommand
         with pytest.raises(SystemExit):
-            parser.parse_known_args(['-b', 'master', 'launch', 'science'])
+            parser.parse_known_args(['-b', 'main', 'launch', 'science'])

--- a/src/other/nova_cli/tests/test_rebuild_main.py
+++ b/src/other/nova_cli/tests/test_rebuild_main.py
@@ -1,6 +1,6 @@
 """
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Tests for rebuild-master command.
+Tests for rebuild-main command.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 PACKAGE:        nova_cli
 AUTHOR(S):      Nova Team
@@ -13,7 +13,7 @@ from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
 from pathlib import Path
 
-from nova_cli.commands.rebuild_master import RebuildMasterCommand
+from nova_cli.commands.rebuild_main import RebuildMasterCommand
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def mock_args():
 
 
 class TestRebuildMasterCommand:
-    """Test nova rebuild-master command."""
+    """Test nova rebuild-main command."""
 
     def test_successful_rebuild(self, mock_home, mock_args):
         """Test successful rebuild with no uncommitted changes."""
@@ -126,7 +126,7 @@ class TestRebuildMasterCommand:
 
             assert result == 1
             captured = capsys.readouterr()
-            assert 'Failed to checkout master branch' in captured.err
+            assert 'Failed to checkout main branch' in captured.err
 
     def test_git_pull_fails(self, mock_home, mock_args, capsys):
         """Test error when git pull fails."""

--- a/src/other/nova_cli/tests/test_rebuild_main.py
+++ b/src/other/nova_cli/tests/test_rebuild_main.py
@@ -13,7 +13,7 @@ from unittest.mock import patch, MagicMock
 from types import SimpleNamespace
 from pathlib import Path
 
-from nova_cli.commands.rebuild_main import RebuildMasterCommand
+from nova_cli.commands.rebuild_main import RebuildMainCommand
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def mock_args():
     return _make
 
 
-class TestRebuildMasterCommand:
+class TestRebuildMainCommand:
     """Test nova rebuild-main command."""
 
     def test_successful_rebuild(self, mock_home, mock_args):
@@ -52,7 +52,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 0
             assert mock_run.call_count == 4  # status, checkout, pull, build
@@ -67,7 +67,7 @@ class TestRebuildMasterCommand:
                 stdout='M src/some/file.py\n'
             )
 
-            result = RebuildMasterCommand.execute(mock_args(stash=False))
+            result = RebuildMainCommand.execute(mock_args(stash=False))
 
             assert result == 1
             captured = capsys.readouterr()
@@ -88,7 +88,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args(stash=True))
+            result = RebuildMainCommand.execute(mock_args(stash=True))
 
             assert result == 0
             # Verify stash was called with -u flag
@@ -103,7 +103,7 @@ class TestRebuildMasterCommand:
              patch('pathlib.Path.exists', return_value=True):
             mock_run.return_value = MagicMock(returncode=1)
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 1
             captured = capsys.readouterr()
@@ -122,7 +122,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 1
             captured = capsys.readouterr()
@@ -141,7 +141,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 1
             captured = capsys.readouterr()
@@ -160,7 +160,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 1
             captured = capsys.readouterr()
@@ -179,7 +179,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 5  # Propagate nom-build's exit code
             captured = capsys.readouterr()
@@ -196,7 +196,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(
+            result = RebuildMainCommand.execute(
                 mock_args(extra=['--packages-select', 'science'])
             )
 
@@ -211,7 +211,7 @@ class TestRebuildMasterCommand:
     def test_nova_directory_missing(self, mock_home, mock_args, capsys):
         """Test error when ~/nova directory doesn't exist."""
         with patch.object(Path, 'exists', return_value=False):
-            result = RebuildMasterCommand.execute(mock_args())
+            result = RebuildMainCommand.execute(mock_args())
 
             assert result == 1
             captured = capsys.readouterr()
@@ -230,7 +230,7 @@ class TestRebuildMasterCommand:
 
             mock_run.side_effect = run_side_effect
 
-            result = RebuildMasterCommand.execute(mock_args(stash=True))
+            result = RebuildMainCommand.execute(mock_args(stash=True))
 
             assert result == 1
             captured = capsys.readouterr()

--- a/src/other/nova_cli/tests/test_run.py
+++ b/src/other/nova_cli/tests/test_run.py
@@ -29,8 +29,8 @@ class TestRunCLI:
         assert cmd == ["/builds/active/bin/ros2", "run", "science", "controller", "--ros-args", "-p", "param:=value"]
 
     def test_build_flag_short(self, nova_cli):
-        cmd = nova_cli(["run", "science", "controller", "-b", "master"])
-        assert cmd == ["/builds/master/bin/ros2", "run", "science", "controller"]
+        cmd = nova_cli(["run", "science", "controller", "-b", "main"])
+        assert cmd == ["/builds/main/bin/ros2", "run", "science", "controller"]
 
     def test_build_flag_long(self, nova_cli):
         cmd = nova_cli(["run", "science", "controller", "--build", "auto"])
@@ -41,8 +41,8 @@ class TestRunCLI:
         assert cmd == ["/builds/arm/bin/ros2", "run", "science", "controller"]
 
     def test_build_flag_with_extra_args(self, nova_cli):
-        cmd = nova_cli(["run", "science", "controller", "--ros-args", "-b", "master"])
-        assert cmd == ["/builds/master/bin/ros2", "run", "science", "controller", "--ros-args"]
+        cmd = nova_cli(["run", "science", "controller", "--ros-args", "-b", "main"])
+        assert cmd == ["/builds/main/bin/ros2", "run", "science", "controller", "--ros-args"]
 
 
 class TestExecutableNotFound:

--- a/src/other/nova_cli/tests/test_start.py
+++ b/src/other/nova_cli/tests/test_start.py
@@ -34,8 +34,8 @@ class TestStartCLI:
         assert cmd == ["/builds/active/launch/run-auto", "nova@10.0.0.2"]
 
     def test_start_with_build_flag(self, nova_cli):
-        cmd = nova_cli(["start", "run-gui", "-b", "master"])
-        assert cmd == ["/builds/master/launch/run-gui"]
+        cmd = nova_cli(["start", "run-gui", "-b", "main"])
+        assert cmd == ["/builds/main/launch/run-gui"]
 
     def test_start_build_flag_position(self, nova_cli):
         cmd = nova_cli(["start", "-b", "arm", "run-drive"])


### PR DESCRIPTION
Since we renamed master to main we need to update nova cli so that it can use main instead of master for the rebuild-master command. Also renamed any instance of master to main so all the tests and examples use main now.

Tested locally on mine and works fine.
To test either checkout and nixos rebuild or just run the nova command from your build folder
`nova build main`
`nova rebuild-main`
`nova` - check help message changed

<!-- TAGS START -->
Tags for Notion Integration:
tag:software
<!-- TAGS END -->
