### PR TITLE
fix: update gnome photos to loupe

### DIFF
--- a/nixfiles/modules/nixos/common/desktop/default.nix
+++ b/nixfiles/modules/nixos/common/desktop/default.nix
@@ -66,7 +66,7 @@ in
       gnome-contacts
       gnome-maps
       gnome-music
-      gnome-photos
+      loupe
       gnome-connections
       gnome-weather
       simple-scan


### PR DESCRIPTION
<!--- Remove any prompt if irrelevant to your changes --->

## Description
Fixes issue with nix channel update when based on 25.11
<!--- Elaborate on your Wonderful Work! --->



<!--- Include links to any relevant issues! --->
<!--- Please explain anything that can be helpful to the reviewers since they didn't write the code themselves. --->

## Changelogs
updates gnome-photos to loupe
also updated the nixos installation guide to use 25.11 channels
<!--- Short descriptive change logs. Shouldn't be more than a line per change--->

## Steps to Test
`sudo nix-channel --update`
`sudo nixos-rebuild switch`
<!--- How does someone test your awesome work? Add as Much Detail as Possible --->



<!--- Is there a route on the gui to look at? --->
<!--- Should a certain launch file be used? --->

## Memes

<!-- Every PR should include a Meme that is to please the reviewers, doesn't matter if it's a One Line Change or an entire feature.-->
<!-- Feel Free to Describe anything you learnt from this PR -->
<!-- Absence of Memes and Experiences will be frowned upon-->
<img width="1250" height="716" alt="image" src="https://github.com/user-attachments/assets/c219ed61-6a68-47b2-ba71-ad66602bfe8c" />

<!-- TAGS START -->
Tags for Notion Integration:
tag:nixfiles
<!-- TAGS END -->
